### PR TITLE
Add quick open for workspace navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ typist/
 - browse files in a sidebar
 - edit markdown source
 - live preview rendered markdown
+- quick open with `Cmd/Ctrl+P`
 - global workspace search with `Cmd/Ctrl+Shift+F`
 - autosave
 - create new files and folders

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -113,6 +113,13 @@ async function createWindow() {
           click: () => {
             mainWindow?.webContents.send("app:command", "search" satisfies AppCommand);
           }
+        },
+        {
+          label: "Quick Open",
+          accelerator: "CmdOrCtrl+P",
+          click: () => {
+            mainWindow?.webContents.send("app:command", "quick-open" satisfies AppCommand);
+          }
         }
       ]
     },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,10 +1,36 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { EditorPane } from "./components/EditorPane";
 import { MarkdownPreview } from "./components/MarkdownPreview";
+import { QuickOpenPanel } from "./components/QuickOpenPanel";
 import { SearchPanel } from "./components/SearchPanel";
 import { Sidebar } from "./components/Sidebar";
-import type { SearchResult } from "./shared/workspace";
+import type { DirectoryNode, SearchResult } from "./shared/workspace";
 import { useWorkspaceStore } from "./store/workspace";
+
+type QuickOpenItem = {
+  path: string;
+  name: string;
+  relativePath: string;
+};
+
+function flattenFiles(nodes: DirectoryNode[], rootPath: string | null): QuickOpenItem[] {
+  const items: QuickOpenItem[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "file") {
+      items.push({
+        path: node.path,
+        name: node.name,
+        relativePath: rootPath ? node.path.replace(`${rootPath}/`, "") : node.name
+      });
+      continue;
+    }
+
+    items.push(...flattenFiles(node.children, rootPath));
+  }
+
+  return items;
+}
 
 export function App() {
   const typist = window.typist;
@@ -50,6 +76,24 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isQuickOpenOpen, setIsQuickOpenOpen] = useState(false);
+  const [quickOpenQuery, setQuickOpenQuery] = useState("");
+
+  const quickOpenItems = useMemo(() => {
+    const files = flattenFiles(tree, rootPath);
+    const needle = quickOpenQuery.trim().toLowerCase();
+
+    if (!needle) {
+      return files.slice(0, 30);
+    }
+
+    return files
+      .filter((item) => {
+        const candidate = `${item.name} ${item.relativePath}`.toLowerCase();
+        return candidate.includes(needle);
+      })
+      .slice(0, 30);
+  }, [quickOpenQuery, rootPath, tree]);
 
   useEffect(() => {
     return typist.onWorkspaceChanged(async ({ tree: nextTree, changedPath }) => {
@@ -129,6 +173,11 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
     return () => window.clearTimeout(timer);
   }, [activeFile?.path, draftContent, isDirty, isSaving]);
 
+  const closeTransientPanels = () => {
+    setIsSearchOpen(false);
+    setIsQuickOpenOpen(false);
+  };
+
   const handleOpenFolder = async () => {
     if (!confirmDiscardChanges()) {
       return;
@@ -138,9 +187,10 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
       const workspace = await typist.openFolder();
       if (workspace) {
         setWorkspace(workspace);
-        setIsSearchOpen(false);
         setSearchQuery("");
         setSearchResults([]);
+        setQuickOpenQuery("");
+        closeTransientPanels();
       }
     } catch (openError) {
       setError(openError instanceof Error ? openError.message : "Unable to open folder.");
@@ -160,7 +210,7 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
           tree: [],
           activeFile: file
         });
-        setIsSearchOpen(false);
+        closeTransientPanels();
       }
     } catch (openError) {
       setError(openError instanceof Error ? openError.message : "Unable to open file.");
@@ -179,6 +229,7 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
     try {
       const file = await typist.readFile(filePath);
       setActiveFile(file);
+      closeTransientPanels();
     } catch (openError) {
       setError(openError instanceof Error ? openError.message : "Unable to read file.");
     }
@@ -186,6 +237,10 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
 
   const handleOpenSearchResult = async (result: SearchResult) => {
     await handleFileOpen(result.path);
+  };
+
+  const handleOpenQuickItem = async (item: QuickOpenItem) => {
+    await handleFileOpen(item.path);
   };
 
   const resolveCurrentDirectory = () => {
@@ -273,7 +328,14 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
 
       if (event.key.toLowerCase() === "f" && event.shiftKey) {
         event.preventDefault();
+        setIsQuickOpenOpen(false);
         setIsSearchOpen(true);
+      }
+
+      if (event.key.toLowerCase() === "p") {
+        event.preventDefault();
+        setIsSearchOpen(false);
+        setIsQuickOpenOpen(true);
       }
     };
 
@@ -309,7 +371,14 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
       }
 
       if (command === "search") {
+        setIsQuickOpenOpen(false);
         setIsSearchOpen(true);
+        return;
+      }
+
+      if (command === "quick-open") {
+        setIsSearchOpen(false);
+        setIsQuickOpenOpen(true);
       }
     });
   }, [activeFile, draftContent, isDirty, rootPath, typist]);
@@ -350,12 +419,21 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
             <p className="hero-eyebrow">Minimal Markdown Workspace</p>
             <h1>Typist</h1>
             <p className="hero-copy">
-              The desktop app now supports workspace browsing, markdown editing, live preview, autosave, and global
-              search while the richer inline editor is still in progress.
+              The desktop app now supports workspace browsing, quick open, markdown editing, live preview, autosave,
+              and global search while the richer inline editor is still in progress.
             </p>
           </div>
           <div className="hero-actions">
-            <button className="secondary-button" onClick={() => setIsSearchOpen(true)} type="button">
+            <button className="secondary-button" onClick={() => {
+              setIsSearchOpen(false);
+              setIsQuickOpenOpen(true);
+            }} type="button">
+              Quick Open
+            </button>
+            <button className="secondary-button" onClick={() => {
+              setIsQuickOpenOpen(false);
+              setIsSearchOpen(true);
+            }} type="button">
               Search
             </button>
             <button className="secondary-button" onClick={handleCreateFile} type="button">
@@ -373,6 +451,14 @@ function DesktopApp({ typist }: { typist: NonNullable<Window["typist"]> }) {
           </div>
         </header>
         {error ? <div className="error-banner">{error}</div> : null}
+        <QuickOpenPanel
+          query={quickOpenQuery}
+          items={quickOpenItems}
+          isOpen={isQuickOpenOpen}
+          onChangeQuery={setQuickOpenQuery}
+          onClose={() => setIsQuickOpenOpen(false)}
+          onOpenItem={handleOpenQuickItem}
+        />
         <SearchPanel
           query={searchQuery}
           results={searchResults}

--- a/apps/desktop/src/components/QuickOpenPanel.tsx
+++ b/apps/desktop/src/components/QuickOpenPanel.tsx
@@ -1,0 +1,59 @@
+type QuickOpenItem = {
+  path: string;
+  name: string;
+  relativePath: string;
+};
+
+type QuickOpenPanelProps = {
+  query: string;
+  items: QuickOpenItem[];
+  isOpen: boolean;
+  onChangeQuery: (value: string) => void;
+  onClose: () => void;
+  onOpenItem: (item: QuickOpenItem) => void;
+};
+
+export function QuickOpenPanel({
+  query,
+  items,
+  isOpen,
+  onChangeQuery,
+  onClose,
+  onOpenItem
+}: QuickOpenPanelProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <section className="search-panel">
+      <div className="search-header">
+        <div>
+          <p className="panel-label">Quick Open</p>
+          <h2>Jump to a file</h2>
+        </div>
+        <button className="secondary-button" type="button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <input
+        className="search-input"
+        placeholder="Type a file name..."
+        value={query}
+        onChange={(event) => onChangeQuery(event.target.value)}
+      />
+      <div className="search-results">
+        {!query.trim() ? <p className="search-empty">Type to filter files in the current workspace.</p> : null}
+        {query.trim() && items.length === 0 ? <p className="search-empty">No files match “{query}”.</p> : null}
+        {items.map((item) => (
+          <button key={item.path} className="search-result" type="button" onClick={() => onOpenItem(item)}>
+            <div className="search-result-top">
+              <strong>{item.name}</strong>
+            </div>
+            <p>{item.relativePath}</p>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/components/SearchPanel.tsx
+++ b/apps/desktop/src/components/SearchPanel.tsx
@@ -35,7 +35,6 @@ export function SearchPanel({
         </button>
       </div>
       <input
-        autoFocus
         className="search-input"
         placeholder="Search markdown files..."
         value={query}

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -43,4 +43,4 @@ export type SearchResult = {
   snippet: string;
 };
 
-export type AppCommand = "open-file" | "open-folder" | "save" | "new-file" | "new-folder" | "search";
+export type AppCommand = "open-file" | "open-folder" | "save" | "new-file" | "new-folder" | "search" | "quick-open";

--- a/prd.md
+++ b/prd.md
@@ -92,6 +92,7 @@ Shipped now:
 - new file / new folder flows
 - basic markdown formatting toolbar
 - global workspace search with result snippets
+- quick open with `Cmd/Ctrl+P`
 - desktop dev startup hardened with renderer retry + preload failure fallback
 - standalone web landing page
 - placeholder download buttons
@@ -156,7 +157,7 @@ Not started:
 
 - [X] Global search
 - [ ] Themes
-- [ ] Quick open
+- [X] Quick open
 - [ ] Command palette
 - [ ] Export markdown
 - [ ] Export PDF
@@ -180,6 +181,6 @@ Not started:
 ## Next Up
 
 1. Replace the textarea editor with a markdown-aware editing layer.
-2. Add quick open and command-palette style navigation.
+2. Add a fuller command palette on top of quick open and search.
 3. Improve creation flows with real dialogs instead of prompts.
 4. Add packaging so the web app can ship real downloads.


### PR DESCRIPTION
## Summary
- add a quick-open panel for workspace files with Cmd/Ctrl+P
- wire the new quick-open command through the Electron menu
- update README and PRD to track the new desktop capability

## Verification
- pnpm typecheck
- pnpm build
- pnpm dlx react-doctor@latest apps/desktop --verbose --diff