### PR TITLE
fix(desktop): keep downloaded updates staged until install

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -152,7 +152,11 @@ function wireAutoUpdater() {
   }
 
   autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = true;
+  // Keep the downloaded update staged until the user explicitly installs it.
+  // On macOS, enabling install-on-quit starts an extra native updater handoff
+  // immediately after download, which can emit an error and clear the install CTA
+  // before the user gets a chance to apply the update.
+  autoUpdater.autoInstallOnAppQuit = false;
 
   autoUpdater.on("checking-for-update", () => {
     if (shouldPreserveUpdateState(updateState.status)) {


### PR DESCRIPTION
Closes #116

## What is happening
The desktop updater was surfacing a downloaded update and then letting the install action disappear before the user could reliably apply it.

## Root cause
Glyph had `autoUpdater.autoInstallOnAppQuit` enabled. With `electron-updater`, that setting starts an extra native install-preparation handoff immediately after the download completes. On macOS that handoff can emit an updater error after the `update-downloaded` event has already fired, which clears our downloaded state and makes the install CTA disappear.

## Fix
Keep downloaded updates staged until the user explicitly chooses Install Update by setting `autoInstallOnAppQuit` to `false`.

That keeps the downloaded state stable, preserves the install button, and defers the native handoff until the user actually triggers installation.

## Validation
- `pnpm typecheck:desktop`
- `pnpm --filter @glyph/desktop lint`
- repository pre-commit checks during `git commit` (format, lint, full recursive typecheck)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the automatic update installation behavior. Updates now require explicit user action to install, providing greater control over when updates are applied to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->