### PR TITLE
feat(desktop): add multi-note tabs

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -192,7 +192,7 @@ async function triggerPreviousTabShortcut(window: Page) {
 }
 
 async function triggerCloseOtherTabsShortcut(window: Page) {
-  await window.keyboard.press(isMac ? "Meta+Alt+W" : "Control+Alt+W");
+  await window.keyboard.press(isMac ? "Meta+Shift+W" : "Control+Shift+W");
 }
 
 async function getTabState(window: Page, options?: { workspaceRoot?: string }) {

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -183,6 +183,10 @@ async function triggerTabSwitchShortcut(window: Page, tabNumber: number) {
   await window.keyboard.press(`${modKey}+${tabNumber}`);
 }
 
+async function triggerCloseOtherTabsShortcut(window: Page) {
+  await window.keyboard.press(isMac ? "Meta+Alt+W" : "Control+Alt+W");
+}
+
 async function getTabState(window: Page) {
   return await window.evaluate(() => {
     const tabs = Array.from(document.querySelectorAll('[role="tab"]')).map((tab) => ({
@@ -197,6 +201,28 @@ async function getTabState(window: Page) {
       editorText: editor?.textContent ?? null,
     };
   });
+}
+
+async function dragTabBefore(window: Page, sourceIndex: number, targetIndex: number) {
+  const sourceTab = window.getByRole("tab").nth(sourceIndex);
+  const targetTab = window.getByRole("tab").nth(targetIndex);
+
+  await expect(sourceTab).toBeVisible();
+  await expect(targetTab).toBeVisible();
+  await sourceTab.dragTo(targetTab, {
+    targetPosition: {
+      x: 8,
+      y: 12,
+    },
+  });
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getTabFileName(title: string | null) {
+  return title ? path.basename(title) : null;
 }
 
 async function expectTabSelectedByTitle(window: Page, title: string | null) {
@@ -586,13 +612,49 @@ test("opens notes in multiple tabs and switches between them with keyboard short
       glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
     ).toBeVisible();
     await expectTabSelectedByTitle(glyph.window, secondTab?.title ?? null);
+    await expect
+      .poll(async () => (await readPersistedSession(glyph.window))?.noteFilePath ?? null, {
+        timeout: 15_000,
+      })
+      .toBe(secondTab?.title ?? null);
+
+    await triggerCloseOtherTabsShortcut(glyph.window);
+    await expect
+      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
+        timeout: 15_000,
+      })
+      .toEqual(secondTab?.title ? [secondTab.title] : []);
+    await expect(
+      glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
+    ).toBeVisible();
+    await expectTabSelectedByTitle(glyph.window, secondTab?.title ?? null);
+
+    const reopenedTabFileName = getTabFileName(firstTab?.title ?? null);
+    expect(reopenedTabFileName).toBeTruthy();
+
+    await selectPaletteItem(
+      glyph.window,
+      reopenedTabFileName!.replace(/\.md$/i, ""),
+      new RegExp(escapeRegExp(reopenedTabFileName!), "i"),
+    );
+    await expect
+      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
+        timeout: 15_000,
+      })
+      .toEqual(
+        [secondTab?.title ?? null, firstTab?.title ?? null].filter((title): title is string =>
+          Boolean(title),
+        ),
+      );
 
     await selectPaletteItem(glyph.window, "close current tab", /close current tab/i);
+    await expect
+      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
+        timeout: 15_000,
+      })
+      .toEqual(secondTab?.title ? [secondTab.title] : []);
     await expect(
-      glyph.window.getByRole("tab", { name: new RegExp(secondTab?.label ?? "", "i") }),
-    ).toBeHidden();
-    await expect(
-      glyph.window.getByText(getExpectedBodyForTabTitle(firstTab?.title ?? null)),
+      glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
     ).toBeVisible();
   } finally {
     await glyph.stop(testInfo);
@@ -626,6 +688,37 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
 
     await selectPaletteItem(firstRun.window, "nested-note", /nested-note/i);
     await expect(firstRun.window.getByText("Nested note body.")).toBeVisible();
+    const tabStateBeforeReorder = await getTabState(firstRun.window);
+    const tabTitlesBeforeReorder = tabStateBeforeReorder.tabs
+      .map((tab) => tab.title)
+      .filter((title): title is string => Boolean(title));
+    expect(tabTitlesBeforeReorder).toHaveLength(2);
+
+    await dragTabBefore(firstRun.window, 1, 0);
+
+    const reorderedTabTitles = [...tabTitlesBeforeReorder].reverse();
+    const activeRestoredTitle =
+      tabStateBeforeReorder.tabs.find((tab) => tab.selected === "true")?.title ?? null;
+    expect(activeRestoredTitle).toBeTruthy();
+
+    await expect
+      .poll(async () => (await getTabState(firstRun.window)).tabs.map((tab) => tab.title), {
+        timeout: 15_000,
+      })
+      .toEqual(reorderedTabTitles);
+
+    await expect
+      .poll(async () => (await readPersistedSession(firstRun.window))?.noteFilePath ?? null, {
+        timeout: 15_000,
+      })
+      .toBe(activeRestoredTitle);
+
+    await triggerTabSwitchShortcut(firstRun.window, 1);
+    await expect(
+      firstRun.window.getByText(getExpectedBodyForTabTitle(reorderedTabTitles[0] ?? null)),
+    ).toBeVisible();
+    const activeTitleAfterShortcut = reorderedTabTitles[0] ?? null;
+
     const persistedTabPaths = (await getTabState(firstRun.window)).tabs
       .map((tab) => tab.title)
       .filter((title): title is string => Boolean(title));
@@ -635,7 +728,7 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
         timeout: 15_000,
       })
       .toMatchObject({
-        noteFilePath: path.join(sandbox.workspaceRoot, "notes", "nested-note.md"),
+        noteFilePath: activeTitleAfterShortcut,
         noteTabPaths: persistedTabPaths,
         noteWorkspacePath: sandbox.workspaceRoot,
       });
@@ -652,11 +745,10 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
       .toEqual(persistedTabPaths);
     await expect(secondRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
     await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
-    await expect(secondRun.window.getByText("Nested note body.")).toBeVisible();
-    await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    await expect(
+      secondRun.window.getByText(getExpectedBodyForTabTitle(activeTitleAfterShortcut)),
+    ).toBeVisible();
+    await expectTabSelectedByTitle(secondRun.window, activeTitleAfterShortcut);
   } finally {
     if (firstRun) {
       await firstRun.stop(testInfo);

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -183,24 +183,37 @@ async function triggerTabSwitchShortcut(window: Page, tabNumber: number) {
   await window.keyboard.press(`${modKey}+${tabNumber}`);
 }
 
+async function triggerNextTabShortcut(window: Page) {
+  await window.keyboard.press(isMac ? "Meta+Shift+]" : "Control+Tab");
+}
+
+async function triggerPreviousTabShortcut(window: Page) {
+  await window.keyboard.press(isMac ? "Meta+Shift+[" : "Control+Shift+Tab");
+}
+
 async function triggerCloseOtherTabsShortcut(window: Page) {
   await window.keyboard.press(isMac ? "Meta+Alt+W" : "Control+Alt+W");
 }
 
-async function getTabState(window: Page) {
-  return await window.evaluate(() => {
-    const tabs = Array.from(document.querySelectorAll('[role="tab"]')).map((tab) => ({
-      label: tab.textContent?.trim() ?? null,
-      selected: tab.getAttribute("aria-selected"),
-      title: tab.getAttribute("title"),
-    }));
-    const editor = document.querySelector('[data-glyph-editor="true"]');
+async function getTabState(window: Page, options?: { workspaceRoot?: string }) {
+  return await window.evaluate(
+    ({ workspaceRoot }) => {
+      const tabs = Array.from(document.querySelectorAll('[role="tab"]'))
+        .map((tab) => ({
+          label: tab.textContent?.trim() ?? null,
+          selected: tab.getAttribute("aria-selected"),
+          title: tab.getAttribute("title"),
+        }))
+        .filter((tab) => !workspaceRoot || tab.title?.startsWith(workspaceRoot));
+      const editor = document.querySelector('[data-glyph-editor="true"]');
 
-    return {
-      tabs,
-      editorText: editor?.textContent ?? null,
-    };
-  });
+      return {
+        tabs,
+        editorText: editor?.textContent ?? null,
+      };
+    },
+    { workspaceRoot: options?.workspaceRoot ?? null },
+  );
 }
 
 async function dragTabBefore(window: Page, sourceIndex: number, targetIndex: number) {
@@ -241,6 +254,11 @@ function getExpectedBodyForTabTitle(title: string | null) {
 
   if (title?.endsWith("nested-note.md")) {
     return "Nested note body.";
+  }
+
+  const generatedTabMatch = title?.match(/tab-(\d+)\.md$/i);
+  if (generatedTabMatch) {
+    return `Body ${generatedTabMatch[1]}.`;
   }
 
   throw new Error(`Unexpected tab title: ${title ?? "null"}`);
@@ -332,7 +350,7 @@ test("toggles the current note pin action from the command palette", async ({}, 
   try {
     await expectAppShell(glyph.window);
     await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
-    await selectPaletteItem(glyph.window, "nested-note", /nested-note/i);
+    await selectPaletteItem(glyph.window, "nested", /nested-note/i);
     await expect(glyph.window.getByText("Nested note body.")).toBeVisible();
 
     await selectPaletteItem(glyph.window, "pin current note", /pin current note/i);
@@ -595,7 +613,9 @@ test("opens notes in multiple tabs and switches between them with keyboard short
     await expect(glyph.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
     await expect(glyph.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
 
-    const tabState = await getTabState(glyph.window);
+    const tabState = await getTabState(glyph.window, {
+      workspaceRoot: glyph.sandbox.workspaceRoot,
+    });
     expect(tabState.tabs).toHaveLength(2);
     const [firstTab, secondTab] = tabState.tabs;
     expect(firstTab).toBeDefined();
@@ -620,9 +640,17 @@ test("opens notes in multiple tabs and switches between them with keyboard short
 
     await triggerCloseOtherTabsShortcut(glyph.window);
     await expect
-      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
-        timeout: 15_000,
-      })
+      .poll(
+        async () =>
+          (
+            await getTabState(glyph.window, {
+              workspaceRoot: glyph.sandbox.workspaceRoot,
+            })
+          ).tabs.map((tab) => tab.title),
+        {
+          timeout: 15_000,
+        },
+      )
       .toEqual(secondTab?.title ? [secondTab.title] : []);
     await expect(
       glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
@@ -638,9 +666,17 @@ test("opens notes in multiple tabs and switches between them with keyboard short
       new RegExp(escapeRegExp(reopenedTabFileName!), "i"),
     );
     await expect
-      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
-        timeout: 15_000,
-      })
+      .poll(
+        async () =>
+          (
+            await getTabState(glyph.window, {
+              workspaceRoot: glyph.sandbox.workspaceRoot,
+            })
+          ).tabs.map((tab) => tab.title),
+        {
+          timeout: 15_000,
+        },
+      )
       .toEqual(
         [secondTab?.title ?? null, firstTab?.title ?? null].filter((title): title is string =>
           Boolean(title),
@@ -649,15 +685,92 @@ test("opens notes in multiple tabs and switches between them with keyboard short
 
     await selectPaletteItem(glyph.window, "close current tab", /close current tab/i);
     await expect
-      .poll(async () => (await getTabState(glyph.window)).tabs.map((tab) => tab.title), {
-        timeout: 15_000,
-      })
+      .poll(
+        async () =>
+          (
+            await getTabState(glyph.window, {
+              workspaceRoot: glyph.sandbox.workspaceRoot,
+            })
+          ).tabs.map((tab) => tab.title),
+        {
+          timeout: 15_000,
+        },
+      )
       .toEqual(secondTab?.title ? [secondTab.title] : []);
     await expect(
       glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
     ).toBeVisible();
   } finally {
     await glyph.stop(testInfo);
+  }
+});
+
+test("supports last-tab and adjacent tab keyboard shortcuts across long tab rails", async ({}, testInfo) => {
+  const sandbox = await createGlyphSandbox();
+  const generatedTabs = Array.from({ length: 8 }, (_, index) => {
+    const label = String(index + 1).padStart(2, "0");
+    return {
+      label,
+      fileName: `tab-${label}.md`,
+      query: `body ${label}`,
+      titlePattern: new RegExp(`tab-${label}\\.md`, "i"),
+    };
+  });
+
+  await Promise.all(
+    generatedTabs.map((tab) =>
+      fs.writeFile(
+        path.join(sandbox.workspaceRoot, tab.fileName),
+        [`# Tab ${tab.label}`, "", `Body ${tab.label}.`].join("\n"),
+      ),
+    ),
+  );
+
+  const glyph = await launchGlyph(sandbox);
+
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    await selectPaletteItem(glyph.window, "nested", /nested-note\.md/i);
+
+    for (const tab of generatedTabs) {
+      await selectPaletteItem(glyph.window, tab.query, tab.titlePattern);
+    }
+
+    const tabState = await getTabState(glyph.window, {
+      workspaceRoot: sandbox.workspaceRoot,
+    });
+    expect(tabState.tabs).toHaveLength(10);
+
+    const firstTabTitle = tabState.tabs[0]?.title ?? null;
+    const lastTabTitle = tabState.tabs.at(-1)?.title ?? null;
+    const previousToLastTabTitle = tabState.tabs.at(-2)?.title ?? null;
+    expect(firstTabTitle).toBeTruthy();
+    expect(lastTabTitle).toBeTruthy();
+    expect(previousToLastTabTitle).toBeTruthy();
+
+    await triggerTabSwitchShortcut(glyph.window, 9);
+    await expect(glyph.window.getByText(getExpectedBodyForTabTitle(lastTabTitle))).toBeVisible();
+    await expectTabSelectedByTitle(glyph.window, lastTabTitle);
+
+    await triggerNextTabShortcut(glyph.window);
+    await expect(glyph.window.getByText(getExpectedBodyForTabTitle(firstTabTitle))).toBeVisible();
+    await expectTabSelectedByTitle(glyph.window, firstTabTitle);
+
+    await triggerPreviousTabShortcut(glyph.window);
+    await expect(glyph.window.getByText(getExpectedBodyForTabTitle(lastTabTitle))).toBeVisible();
+    await expectTabSelectedByTitle(glyph.window, lastTabTitle);
+
+    await triggerPreviousTabShortcut(glyph.window);
+    await expect(
+      glyph.window.getByText(getExpectedBodyForTabTitle(previousToLastTabTitle)),
+    ).toBeVisible();
+    await expectTabSelectedByTitle(glyph.window, previousToLastTabTitle);
+  } finally {
+    await glyph.stop(testInfo);
+    await sandbox.cleanup();
   }
 });
 
@@ -686,9 +799,11 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     await firstRun.window.keyboard.press(`${modKey}+W`);
     await expect(firstRun.window.getByRole("tab", { name: /Untitled-/ })).toBeHidden();
 
-    await selectPaletteItem(firstRun.window, "nested-note", /nested-note/i);
+    await selectPaletteItem(firstRun.window, "nested", /nested-note/i);
     await expect(firstRun.window.getByText("Nested note body.")).toBeVisible();
-    const tabStateBeforeReorder = await getTabState(firstRun.window);
+    const tabStateBeforeReorder = await getTabState(firstRun.window, {
+      workspaceRoot: sandbox.workspaceRoot,
+    });
     const tabTitlesBeforeReorder = tabStateBeforeReorder.tabs
       .map((tab) => tab.title)
       .filter((title): title is string => Boolean(title));
@@ -702,9 +817,17 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     expect(activeRestoredTitle).toBeTruthy();
 
     await expect
-      .poll(async () => (await getTabState(firstRun.window)).tabs.map((tab) => tab.title), {
-        timeout: 15_000,
-      })
+      .poll(
+        async () =>
+          (
+            await getTabState(firstRun.window, {
+              workspaceRoot: sandbox.workspaceRoot,
+            })
+          ).tabs.map((tab) => tab.title),
+        {
+          timeout: 15_000,
+        },
+      )
       .toEqual(reorderedTabTitles);
 
     await expect
@@ -719,7 +842,11 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     ).toBeVisible();
     const activeTitleAfterShortcut = reorderedTabTitles[0] ?? null;
 
-    const persistedTabPaths = (await getTabState(firstRun.window)).tabs
+    const persistedTabPaths = (
+      await getTabState(firstRun.window, {
+        workspaceRoot: sandbox.workspaceRoot,
+      })
+    ).tabs
       .map((tab) => tab.title)
       .filter((title): title is string => Boolean(title));
 
@@ -739,9 +866,17 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     secondRun = await launchGlyph(sandbox);
     await expectAppShell(secondRun.window);
     await expect
-      .poll(async () => (await getTabState(secondRun.window)).tabs.map((tab) => tab.title), {
-        timeout: 15_000,
-      })
+      .poll(
+        async () =>
+          (
+            await getTabState(secondRun.window, {
+              workspaceRoot: sandbox.workspaceRoot,
+            })
+          ).tabs.map((tab) => tab.title),
+        {
+          timeout: 15_000,
+        },
+      )
       .toEqual(persistedTabPaths);
     await expect(secondRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
     await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -173,6 +173,53 @@ async function openWorkspace(window: Page, workspaceRoot: string) {
   expect(workspace?.rootPath).toBe(workspaceRoot);
 }
 
+async function triggerTabSwitchShortcut(window: Page, tabNumber: number) {
+  await window.evaluate(
+    ({ nextTabNumber, useMeta }) => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: String(nextTabNumber),
+          metaKey: useMeta,
+          ctrlKey: !useMeta,
+          bubbles: true,
+        }),
+      );
+    },
+    {
+      nextTabNumber: tabNumber,
+      useMeta: isMac,
+    },
+  );
+}
+
+async function getTabState(window: Page) {
+  return await window.evaluate(() => {
+    const tabs = Array.from(document.querySelectorAll('[role="tab"]')).map((tab) => ({
+      label: tab.textContent?.trim() ?? null,
+      selected: tab.getAttribute("aria-selected"),
+      title: tab.getAttribute("title"),
+    }));
+    const editor = document.querySelector('[data-glyph-editor="true"]');
+
+    return {
+      tabs,
+      editorText: editor?.textContent ?? null,
+    };
+  });
+}
+
+function getExpectedBodyForTabTitle(title: string | null) {
+  if (title?.endsWith("welcome.md")) {
+    return "Smoke test note content.";
+  }
+
+  if (title?.endsWith("nested-note.md")) {
+    return "Nested note body.";
+  }
+
+  throw new Error(`Unexpected tab title: ${title ?? "null"}`);
+}
+
 async function readJson<T>(targetPath: string): Promise<T | null> {
   try {
     const raw = await fs.readFile(targetPath, "utf8");
@@ -489,6 +536,108 @@ test("new note is editable and content persists after save", async ({}, testInfo
     await expect(glyph.window.getByText("My Test Content")).toBeVisible();
   } finally {
     await glyph.stop(testInfo);
+  }
+});
+
+test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    await expect(glyph.window.getByText("Smoke test note content.")).toBeVisible();
+    await expect(glyph.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+
+    await selectPaletteItem(glyph.window, "nested", /nested-note\.md/i);
+    await expect(glyph.window.getByText("Nested note body.")).toBeVisible();
+    await expect(glyph.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+    await expect(glyph.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
+
+    const tabState = await getTabState(glyph.window);
+    expect(tabState.tabs).toHaveLength(2);
+    const [firstTab, secondTab] = tabState.tabs;
+    expect(firstTab).toBeDefined();
+    expect(secondTab).toBeDefined();
+
+    await triggerTabSwitchShortcut(glyph.window, 1);
+    await expect(
+      glyph.window.getByText(getExpectedBodyForTabTitle(firstTab?.title ?? null)),
+    ).toBeVisible();
+    await expect(
+      glyph.window.getByRole("tab", { name: new RegExp(firstTab?.label ?? "", "i") }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    await triggerTabSwitchShortcut(glyph.window, 2);
+    await expect(
+      glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
+    ).toBeVisible();
+    await expect(
+      glyph.window.getByRole("tab", { name: new RegExp(secondTab?.label ?? "", "i") }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    await selectPaletteItem(glyph.window, "close current tab", /close current tab/i);
+    await expect(
+      glyph.window.getByRole("tab", { name: new RegExp(secondTab?.label ?? "", "i") }),
+    ).toBeHidden();
+    await expect(
+      glyph.window.getByText(getExpectedBodyForTabTitle(firstTab?.title ?? null)),
+    ).toBeVisible();
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("creates and closes tabs from shortcuts and restores tab sessions after relaunch", async ({}, testInfo) => {
+  const sandbox = await createGlyphSandbox();
+  let firstRun: GlyphHarness | null = null;
+  let secondRun: GlyphHarness | null = null;
+
+  try {
+    firstRun = await launchGlyph(sandbox);
+    await expectAppShell(firstRun.window);
+    await openWorkspace(firstRun.window, sandbox.workspaceRoot);
+    await selectPaletteItem(firstRun.window, "welcome", /welcome\.md/i);
+    await expect(firstRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+
+    await firstRun.window.keyboard.press(`${modKey}+T`);
+    await expect(firstRun.window.getByRole("tab", { name: /Untitled-/ })).toBeVisible();
+
+    const paletteInput = await openCommandPalette(firstRun.window);
+    await paletteInput.fill("close current tab");
+    await expect(
+      firstRun.window.getByRole("option", { name: /close current tab/i }).first(),
+    ).toBeVisible();
+    await firstRun.window.keyboard.press("Escape");
+
+    await firstRun.window.keyboard.press(`${modKey}+W`);
+    await expect(firstRun.window.getByRole("tab", { name: /Untitled-/ })).toBeHidden();
+
+    await selectPaletteItem(firstRun.window, "nested", /nested-note\.md/i);
+    await expect(firstRun.window.getByText("Nested note body.")).toBeVisible();
+
+    await firstRun.stop(testInfo);
+    firstRun = null;
+
+    secondRun = await launchGlyph(sandbox);
+    await expectAppShell(secondRun.window);
+    await expect(secondRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+    await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
+    await expect(secondRun.window.getByText("Nested note body.")).toBeVisible();
+    await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  } finally {
+    if (firstRun) {
+      await firstRun.stop(testInfo);
+    }
+
+    if (secondRun) {
+      await secondRun.stop(testInfo);
+    }
+
+    await sandbox.cleanup();
   }
 });
 

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -30,6 +30,12 @@ type GlyphHarness = {
   window: Page;
 };
 
+type PersistedSessionState = {
+  noteFilePath: string | null;
+  noteTabPaths: string[];
+  noteWorkspacePath: string | null;
+};
+
 async function createGlyphSandbox(): Promise<GlyphSandbox> {
   const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "glyph-e2e-"));
   const workspaceRoot = path.join(sandboxRoot, "workspace");
@@ -147,8 +153,8 @@ async function openCommandPalette(window: Page) {
 async function selectPaletteItem(window: Page, query: string, name: RegExp) {
   const paletteInput = await openCommandPalette(window);
   await paletteInput.fill(query);
-  const option = window.getByRole("option", { name }).first();
-  await expect(option).toBeVisible();
+  const option = window.locator('[role="option"]').filter({ hasText: name }).first();
+  await expect(option).toBeVisible({ timeout: 15_000 });
   await option.click();
   await expect(paletteInput).toBeHidden({ timeout: 15_000 });
 }
@@ -174,22 +180,7 @@ async function openWorkspace(window: Page, workspaceRoot: string) {
 }
 
 async function triggerTabSwitchShortcut(window: Page, tabNumber: number) {
-  await window.evaluate(
-    ({ nextTabNumber, useMeta }) => {
-      window.dispatchEvent(
-        new KeyboardEvent("keydown", {
-          key: String(nextTabNumber),
-          metaKey: useMeta,
-          ctrlKey: !useMeta,
-          bubbles: true,
-        }),
-      );
-    },
-    {
-      nextTabNumber: tabNumber,
-      useMeta: isMac,
-    },
-  );
+  await window.keyboard.press(`${modKey}+${tabNumber}`);
 }
 
 async function getTabState(window: Page) {
@@ -206,6 +197,15 @@ async function getTabState(window: Page) {
       editorText: editor?.textContent ?? null,
     };
   });
+}
+
+async function expectTabSelectedByTitle(window: Page, title: string | null) {
+  await expect
+    .poll(async () => {
+      const tabState = await getTabState(window);
+      return tabState.tabs.find((tab) => tab.title === title)?.selected ?? null;
+    })
+    .toBe("true");
 }
 
 function getExpectedBodyForTabTitle(title: string | null) {
@@ -229,6 +229,21 @@ async function readJson<T>(targetPath: string): Promise<T | null> {
   }
 }
 
+async function readPersistedSession(window: Page): Promise<PersistedSessionState | null> {
+  return await window.evaluate(() => {
+    const rawSession = window.localStorage.getItem("glyph.editor-session");
+    if (!rawSession) {
+      return null;
+    }
+
+    const parsedSession = JSON.parse(rawSession) as {
+      state?: PersistedSessionState;
+    };
+
+    return parsedSession.state ?? null;
+  });
+}
+
 test("launches Glyph and opens settings from the command palette", async ({}, testInfo) => {
   const glyph = await launchGlyph();
 
@@ -250,7 +265,7 @@ test("opens a seeded markdown note from the workspace", async ({}, testInfo) => 
   try {
     await expectAppShell(glyph.window);
     await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
-    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    await selectPaletteItem(glyph.window, "welcome", /welcome/i);
 
     await expect(glyph.window.getByText("Smoke test note content.")).toBeVisible();
     await expect(glyph.window.getByRole("heading", { name: "Welcome to Glyph" })).toBeVisible();
@@ -291,7 +306,7 @@ test("toggles the current note pin action from the command palette", async ({}, 
   try {
     await expectAppShell(glyph.window);
     await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
-    await selectPaletteItem(glyph.window, "nested", /nested-note\.md/i);
+    await selectPaletteItem(glyph.window, "nested-note", /nested-note/i);
     await expect(glyph.window.getByText("Nested note body.")).toBeVisible();
 
     await selectPaletteItem(glyph.window, "pin current note", /pin current note/i);
@@ -564,17 +579,13 @@ test("opens notes in multiple tabs and switches between them with keyboard short
     await expect(
       glyph.window.getByText(getExpectedBodyForTabTitle(firstTab?.title ?? null)),
     ).toBeVisible();
-    await expect(
-      glyph.window.getByRole("tab", { name: new RegExp(firstTab?.label ?? "", "i") }),
-    ).toHaveAttribute("aria-selected", "true");
+    await expectTabSelectedByTitle(glyph.window, firstTab?.title ?? null);
 
     await triggerTabSwitchShortcut(glyph.window, 2);
     await expect(
       glyph.window.getByText(getExpectedBodyForTabTitle(secondTab?.title ?? null)),
     ).toBeVisible();
-    await expect(
-      glyph.window.getByRole("tab", { name: new RegExp(secondTab?.label ?? "", "i") }),
-    ).toHaveAttribute("aria-selected", "true");
+    await expectTabSelectedByTitle(glyph.window, secondTab?.title ?? null);
 
     await selectPaletteItem(glyph.window, "close current tab", /close current tab/i);
     await expect(
@@ -597,10 +608,10 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     firstRun = await launchGlyph(sandbox);
     await expectAppShell(firstRun.window);
     await openWorkspace(firstRun.window, sandbox.workspaceRoot);
-    await selectPaletteItem(firstRun.window, "welcome", /welcome\.md/i);
+    await selectPaletteItem(firstRun.window, "welcome", /welcome/i);
     await expect(firstRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
 
-    await firstRun.window.keyboard.press(`${modKey}+T`);
+    await firstRun.window.keyboard.press(`${modKey}+N`);
     await expect(firstRun.window.getByRole("tab", { name: /Untitled-/ })).toBeVisible();
 
     const paletteInput = await openCommandPalette(firstRun.window);
@@ -613,14 +624,32 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     await firstRun.window.keyboard.press(`${modKey}+W`);
     await expect(firstRun.window.getByRole("tab", { name: /Untitled-/ })).toBeHidden();
 
-    await selectPaletteItem(firstRun.window, "nested", /nested-note\.md/i);
+    await selectPaletteItem(firstRun.window, "nested-note", /nested-note/i);
     await expect(firstRun.window.getByText("Nested note body.")).toBeVisible();
+    const persistedTabPaths = (await getTabState(firstRun.window)).tabs
+      .map((tab) => tab.title)
+      .filter((title): title is string => Boolean(title));
+
+    await expect
+      .poll(async () => readPersistedSession(firstRun.window), {
+        timeout: 15_000,
+      })
+      .toMatchObject({
+        noteFilePath: path.join(sandbox.workspaceRoot, "notes", "nested-note.md"),
+        noteTabPaths: persistedTabPaths,
+        noteWorkspacePath: sandbox.workspaceRoot,
+      });
 
     await firstRun.stop(testInfo);
     firstRun = null;
 
     secondRun = await launchGlyph(sandbox);
     await expectAppShell(secondRun.window);
+    await expect
+      .poll(async () => (await getTabState(secondRun.window)).tabs.map((tab) => tab.title), {
+        timeout: 15_000,
+      })
+      .toEqual(persistedTabPaths);
     await expect(secondRun.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
     await expect(secondRun.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
     await expect(secondRun.window.getByText("Nested note body.")).toBeVisible();

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -902,6 +902,9 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
     const keys = resolvedShortcuts.find((shortcut) => shortcut.id === id)?.keys;
     return keys ? toElectronAccelerator(keys) : undefined;
   };
+  const previousTabAccelerator =
+    process.platform === "darwin" ? "Command+Shift+[" : "Ctrl+Shift+Tab";
+  const nextTabAccelerator = process.platform === "darwin" ? "Command+Shift+]" : "Ctrl+Tab";
   const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {
     label: "Check for Updates",
     accelerator: getAccelerator("check-updates"),
@@ -955,6 +958,17 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
           accelerator: getAccelerator("close-tab"),
           click: () =>
             mainWindow?.webContents.send("app:command", "close-tab" satisfies AppCommand),
+        },
+        {
+          label: "Previous Tab",
+          accelerator: previousTabAccelerator,
+          click: () =>
+            mainWindow?.webContents.send("app:command", "previous-tab" satisfies AppCommand),
+        },
+        {
+          label: "Next Tab",
+          accelerator: nextTabAccelerator,
+          click: () => mainWindow?.webContents.send("app:command", "next-tab" satisfies AppCommand),
         },
         { type: "separator" },
         {
@@ -2017,7 +2031,7 @@ app
       return net.fetch(pathToFileURL(normalizedTarget).toString());
     });
 
-    if (process.platform !== "darwin") {
+    if (process.platform !== "darwin" && !isE2EDistMode) {
       const args = process.argv.slice(1);
       const target = args.find(
         (arg) => arg !== "." && !arg.startsWith("-") && !arg.includes("node_modules"),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -950,6 +950,12 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
           accelerator: getAccelerator("save"),
           click: () => mainWindow?.webContents.send("app:command", "save" satisfies AppCommand),
         },
+        {
+          label: "Close Tab",
+          accelerator: getAccelerator("close-tab"),
+          click: () =>
+            mainWindow?.webContents.send("app:command", "close-tab" satisfies AppCommand),
+        },
         { type: "separator" },
         {
           label: "Toggle Sidebar",

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1224,6 +1224,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                   void controller.activateNoteTab(path, { recordHistory: true })
                 }
                 onCloseTab={(path) => void controller.closeNoteTab(path)}
+                onMoveTab={(sourcePath, targetPath, position) =>
+                  controller.moveNoteTab(sourcePath, targetPath, position)
+                }
                 onToggleSidebar={handleToggleSidebar}
                 onCreateNote={() => void controller.createNote()}
                 onOpenSettings={handleOpenSettings}

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -745,7 +745,13 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   }, [controller.isPaletteOpen, controller.paletteQuery, skillsController.searchSkillIds]);
 
   const visibleNotePaletteItems = useMemo(() => {
-    const noteOnlyCommandIds = new Set(["new-note", "pin-note", "toggle-focus-mode"]);
+    const noteOnlyCommandIds = new Set([
+      "new-note",
+      "close-tab",
+      "close-other-tabs",
+      "pin-note",
+      "toggle-focus-mode",
+    ]);
 
     const filteredItems = controller.paletteItems.filter((item) => {
       if (viewerMode === "skill") {
@@ -1214,7 +1220,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 outlineJumpRequest={controller.outlineJumpRequest}
                 updateState={controller.updateState}
                 onContentChange={controller.updateDraftContent}
-                onCreateTab={() => void controller.createNote()}
                 onSelectTab={(path) =>
                   void controller.activateNoteTab(path, { recordHistory: true })
                 }

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -73,6 +73,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const selectedSkillCollectionId = useSessionStore((state) => state.selectedSkillCollectionId);
   const noteWorkspacePath = useSessionStore((state) => state.noteWorkspacePath);
   const noteFilePath = useSessionStore((state) => state.noteFilePath);
+  const noteTabPaths = useSessionStore((state) => state.noteTabPaths);
   const skillDocumentPath = useSessionStore((state) => state.skillDocumentPath);
   const getPreferredSkillDocumentKind = useSessionStore(
     (state) => state.getPreferredSkillDocumentKind,
@@ -88,9 +89,11 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const hasCapturedInitialSessionRef = useRef(false);
   const initialNoteSessionRef = useRef<{
     filePath: string | null;
+    tabPaths: string[];
     workspacePath: string | null;
   }>({
     filePath: null,
+    tabPaths: [],
     workspacePath: null,
   });
   const initialSkillSessionRef = useRef<{
@@ -106,6 +109,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   if (sessionHasHydrated && !hasCapturedInitialSessionRef.current) {
     initialNoteSessionRef.current = {
       filePath: noteFilePath,
+      tabPaths: noteTabPaths.length > 0 ? noteTabPaths : noteFilePath ? [noteFilePath] : [],
       workspacePath: noteWorkspacePath,
     };
     initialSkillSessionRef.current = {
@@ -118,6 +122,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
 
   const controller = useDesktopAppController(glyph, {
     initialFilePath: initialNoteSessionRef.current.filePath,
+    initialTabPaths: initialNoteSessionRef.current.tabPaths,
     initialWorkspacePath: initialNoteSessionRef.current.workspacePath,
     sessionReady: sessionHasHydrated,
   });
@@ -1195,6 +1200,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 wordCount={controller.wordCount}
                 readingTime={controller.readingTime}
                 isSidebarCollapsed={controller.isSidebarCollapsed}
+                activeTabId={controller.activeTabId}
+                noteTabs={controller.noteTabs}
                 shortcuts={controller.shortcuts}
                 canGoBack={controller.canGoBack}
                 canGoForward={controller.canGoForward}
@@ -1207,6 +1214,11 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 outlineJumpRequest={controller.outlineJumpRequest}
                 updateState={controller.updateState}
                 onContentChange={controller.updateDraftContent}
+                onCreateTab={() => void controller.createNote()}
+                onSelectTab={(path) =>
+                  void controller.activateNoteTab(path, { recordHistory: true })
+                }
+                onCloseTab={(path) => void controller.closeNoteTab(path)}
                 onToggleSidebar={handleToggleSidebar}
                 onCreateNote={() => void controller.createNote()}
                 onOpenSettings={handleOpenSettings}

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -749,6 +749,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       "new-note",
       "close-tab",
       "close-other-tabs",
+      "previous-tab",
+      "next-tab",
       "pin-note",
       "toggle-focus-mode",
     ]);

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -196,23 +196,6 @@ export function EditorToolbar({
             <TooltipContent side="bottom">{forwardTooltipLabel}</TooltipContent>
           </Tooltip>
         ) : null}
-        {onCreateNote ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="text-muted-foreground hover:text-foreground hover:bg-muted flex-shrink-0"
-                onClick={onCreateNote}
-                aria-label="New note"
-                type="button"
-              >
-                <PlusIcon size={16} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{`New Note${newNoteShortcut ? ` (${newNoteShortcut})` : ""}`}</TooltipContent>
-          </Tooltip>
-        ) : null}
         {fileName ? (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -288,6 +271,24 @@ export function EditorToolbar({
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">{updateButtonTooltip}</TooltipContent>
+          </Tooltip>
+        ) : null}
+        {onCreateNote ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 shrink-0 rounded-full px-3 text-xs font-semibold shadow-sm"
+                onClick={onCreateNote}
+                aria-label="New note"
+                type="button"
+              >
+                <PlusIcon size={14} />
+                <span>New Note</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{`New Note${newNoteShortcut ? ` (${newNoteShortcut})` : ""}`}</TooltipContent>
           </Tooltip>
         ) : null}
         {headerAccessory ? <div className="mr-1 flex items-center">{headerAccessory}</div> : null}

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -25,8 +25,6 @@ import {
 } from "@/components/icons";
 import { FileManagerLogo } from "./file-manager-logo";
 
-const MARKDOWN_FILE_SUFFIX_PATTERN = /\.(md|mdx|markdown)$/i;
-
 type EditorToolbarProps = {
   _isMacLike: boolean;
   isSidebarCollapsed: boolean | undefined;
@@ -196,14 +194,21 @@ export function EditorToolbar({
             <TooltipContent side="bottom">{forwardTooltipLabel}</TooltipContent>
           </Tooltip>
         ) : null}
-        {fileName ? (
+        {onCreateNote ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="max-w-[220px] truncate pl-1 text-sm font-medium text-foreground">
-                {fileName.replace(MARKDOWN_FILE_SUFFIX_PATTERN, "")}
-              </span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground hover:bg-muted flex-shrink-0"
+                onClick={onCreateNote}
+                aria-label="New note"
+                type="button"
+              >
+                <PlusIcon size={16} />
+              </Button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">{fileName}</TooltipContent>
+            <TooltipContent side="bottom">{`New Note${newNoteShortcut ? ` (${newNoteShortcut})` : ""}`}</TooltipContent>
           </Tooltip>
         ) : null}
       </div>
@@ -271,24 +276,6 @@ export function EditorToolbar({
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">{updateButtonTooltip}</TooltipContent>
-          </Tooltip>
-        ) : null}
-        {onCreateNote ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 shrink-0 rounded-full px-3 text-xs font-semibold shadow-sm"
-                onClick={onCreateNote}
-                aria-label="New note"
-                type="button"
-              >
-                <PlusIcon size={14} />
-                <span>New Note</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{`New Note${newNoteShortcut ? ` (${newNoteShortcut})` : ""}`}</TooltipContent>
           </Tooltip>
         ) : null}
         {headerAccessory ? <div className="mr-1 flex items-center">{headerAccessory}</div> : null}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -290,6 +290,7 @@ export const MarkdownEditor = ({
   onToggleSidebar,
   isSidebarCollapsed,
   headerAccessory,
+  subheaderContent,
   topContent,
   onCreateNote,
   toggleSidebarShortcut,
@@ -1138,6 +1139,9 @@ export const MarkdownEditor = ({
         onTogglePinnedFile={onTogglePinnedFile}
         isActiveFilePinned={isActiveFilePinned}
       />
+      {subheaderContent ? (
+        <div className="border-b border-border/30">{subheaderContent}</div>
+      ) : null}
       <div
         ref={scrollContainerRef}
         className={`flex-1 min-h-0 overflow-y-auto relative [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -134,8 +134,18 @@ type TableControlsState = {
   canDeleteTable: boolean;
 };
 
+type SelectionSnapshot = {
+  from: number;
+  to: number;
+};
+
 type EditorOutlineItem = OutlineItem & {
   pos: number;
+};
+
+const DEFAULT_SELECTION_SNAPSHOT: SelectionSnapshot = {
+  from: 1,
+  to: 1,
 };
 
 const extractLinkAttributes = (input: string) => {
@@ -325,6 +335,7 @@ export const MarkdownEditor = ({
   const onChangeRef = useRef(onChange);
   const onScrollPositionChangeRef = useRef(onScrollPositionChange);
   const filePathRef = useRef(filePath);
+  const scrollRestorationKeyRef = useRef(scrollRestorationKey);
   const onOpenLinkedFileRef = useRef(onOpenLinkedFile);
   const isAutoConvertingRef = useRef(false);
   const liveEditorRef = useRef<Editor | null>(null);
@@ -333,7 +344,8 @@ export const MarkdownEditor = ({
   const toastTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const hoveredLinkHideTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const scrollPositionTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
-  const selectionSnapshotRef = useRef({ from: 1, to: 1 });
+  const selectionSnapshotRef = useRef<SelectionSnapshot>(DEFAULT_SELECTION_SNAPSHOT);
+  const selectionSnapshotsByDocumentRef = useRef<Record<string, SelectionSnapshot>>({});
   const lastHandledFocusRequestRef = useRef<number | null>(null);
   const lastRestoredScrollStateRef = useRef<{
     key: string | null;
@@ -356,8 +368,9 @@ export const MarkdownEditor = ({
     onChangeRef.current = onChange;
     onScrollPositionChangeRef.current = onScrollPositionChange;
     filePathRef.current = filePath;
+    scrollRestorationKeyRef.current = scrollRestorationKey;
     onOpenLinkedFileRef.current = onOpenLinkedFile;
-  }, [onChange, onScrollPositionChange, filePath, onOpenLinkedFile]);
+  }, [filePath, onChange, onOpenLinkedFile, onScrollPositionChange, scrollRestorationKey]);
 
   const refreshOutline = useCallback((nextEditor: Editor) => {
     const items = collectEditorOutline(nextEditor);
@@ -373,8 +386,17 @@ export const MarkdownEditor = ({
     onScrollPositionChangeRef.current(scrollRestorationKey, scrollContainerRef.current.scrollTop);
   }, [scrollRestorationKey]);
 
+  const rememberSelectionSnapshot = useCallback((nextSelection: SelectionSnapshot) => {
+    selectionSnapshotRef.current = nextSelection;
+
+    const targetKey = scrollRestorationKeyRef.current ?? filePathRef.current;
+    if (targetKey) {
+      selectionSnapshotsByDocumentRef.current[targetKey] = nextSelection;
+    }
+  }, []);
+
   const focusEditorWithoutScroll = useCallback(
-    (selection: { from: number; to: number }, resetScrollTop: boolean) => {
+    (selection: SelectionSnapshot, resetScrollTop: boolean) => {
       const nextEditor = liveEditorRef.current;
       if (!nextEditor) {
         return;
@@ -386,7 +408,7 @@ export const MarkdownEditor = ({
         to: clamp(selection.to, 1, maxPosition),
       };
 
-      selectionSnapshotRef.current = nextSelection;
+      rememberSelectionSnapshot(nextSelection);
       nextEditor.view.dispatch(
         nextEditor.state.tr.setSelection(
           TextSelection.create(nextEditor.state.doc, nextSelection.from, nextSelection.to),
@@ -398,7 +420,7 @@ export const MarkdownEditor = ({
         scrollContainerRef.current.scrollTop = 0;
       }
     },
-    [],
+    [rememberSelectionSnapshot],
   );
 
   const effectiveUpdateState = devPreviewUpdateState ?? updateState ?? null;
@@ -779,10 +801,10 @@ export const MarkdownEditor = ({
           return;
         }
 
-        selectionSnapshotRef.current = {
+        rememberSelectionSnapshot({
           from: nextEditor.state.selection.from,
           to: nextEditor.state.selection.to,
-        };
+        });
         refreshTableControls(nextEditor);
         refreshImageControls(nextEditor);
         refreshOutline(nextEditor);
@@ -794,15 +816,15 @@ export const MarkdownEditor = ({
       },
       onSelectionUpdate: ({ editor: nextEditor }) => {
         liveEditorRef.current = nextEditor;
-        selectionSnapshotRef.current = {
+        rememberSelectionSnapshot({
           from: nextEditor.state.selection.from,
           to: nextEditor.state.selection.to,
-        };
+        });
         refreshTableControls(nextEditor);
         refreshImageControls(nextEditor);
       },
     },
-    [],
+    [rememberSelectionSnapshot],
   );
 
   useEffect(() => {
@@ -819,6 +841,14 @@ export const MarkdownEditor = ({
     refreshImageControls(editor);
     refreshOutline(editor);
   }, [content, editor, refreshOutline]);
+
+  useEffect(() => {
+    const targetKey = scrollRestorationKey ?? filePath;
+
+    selectionSnapshotRef.current = targetKey
+      ? (selectionSnapshotsByDocumentRef.current[targetKey] ?? DEFAULT_SELECTION_SNAPSHOT)
+      : DEFAULT_SELECTION_SNAPSHOT;
+  }, [filePath, scrollRestorationKey]);
 
   useEffect(() => {
     if (!editor || !scrollContainerRef.current || !scrollRestorationKey) {

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -1,31 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getDisplayFileName } from "@/lib/paths";
 import { cn } from "@/lib/utils";
-import type { NoteTab } from "@/shared/workspace";
 
-import { PlusIcon, XIcon } from "./icons";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { XIcon } from "./icons";
+
+export type NoteTabRailItem = {
+  id: string;
+  isDirty: boolean;
+  label: string;
+  path: string;
+  shortcutLabel?: string;
+};
 
 type NoteTabsBarProps = {
   activeTabId: string | null;
-  closeTabShortcut?: string;
-  newTabShortcut?: string;
   onCloseTab: (path: string) => void;
-  onCreateTab: () => void;
   onSelectTab: (path: string) => void;
-  tabs: NoteTab[];
+  tabs: NoteTabRailItem[];
 };
 
-export function NoteTabsBar({
-  activeTabId,
-  closeTabShortcut,
-  newTabShortcut,
-  onCloseTab,
-  onCreateTab,
-  onSelectTab,
-  tabs,
-}: NoteTabsBarProps) {
+export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: NoteTabsBarProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -74,23 +68,7 @@ export function NoteTabsBar({
   }, [activeTabId]);
 
   return (
-    <div className="relative flex h-11 items-center gap-2 bg-background px-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={onCreateTab}
-            aria-label="Create a new tab"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-background text-muted-foreground shadow-sm outline-none transition-[border-color,background-color,color,transform] duration-100 ease-out hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:scale-[0.97]"
-          >
-            <PlusIcon size={15} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {`New Tab${newTabShortcut ? ` (${newTabShortcut})` : ""}`}
-        </TooltipContent>
-      </Tooltip>
-
+    <div className="relative flex h-11 items-center bg-background px-2">
       <div className="relative min-w-0 flex-1">
         {canScrollLeft ? (
           <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
@@ -105,72 +83,64 @@ export function NoteTabsBar({
           aria-label="Open note tabs"
           className="scrollbar-hide flex min-w-0 items-center gap-1 overflow-x-auto py-1"
         >
-          {tabs.length === 0 ? (
-            <div className="inline-flex h-8 items-center rounded-lg border border-dashed border-border/70 px-3 text-xs text-muted-foreground">
-              No open tabs
-            </div>
-          ) : (
-            tabs.map((tab) => {
-              const isActive = tab.id === activeTabId;
-              const label = getDisplayFileName(tab.file.name);
+          {tabs.map((tab) => {
+            const isActive = tab.id === activeTabId;
+            const label = tab.label;
 
-              return (
-                <div key={tab.id} className="group relative shrink-0">
-                  <button
-                    ref={(element) => {
-                      tabRefs.current[tab.id] = element;
-                    }}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    title={tab.file.path}
-                    onClick={() => onSelectTab(tab.file.path)}
-                    className={cn(
-                      "flex h-8 min-w-[152px] max-w-[224px] items-center gap-2 rounded-lg border px-3 pr-9 text-left outline-none",
-                      isActive
-                        ? "border-border bg-card text-foreground shadow-sm"
-                        : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/60 hover:text-foreground",
-                    )}
-                  >
+            return (
+              <div key={tab.id} className="group relative shrink-0">
+                <button
+                  ref={(element) => {
+                    tabRefs.current[tab.id] = element;
+                  }}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  title={tab.path}
+                  onClick={() => onSelectTab(tab.path)}
+                  className={cn(
+                    "flex h-8 min-w-[152px] max-w-[224px] items-center gap-2 rounded-lg border px-3 pr-9 text-left outline-none",
+                    isActive
+                      ? "border-border bg-card text-foreground shadow-sm"
+                      : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/60 hover:text-foreground",
+                  )}
+                >
+                  {tab.shortcutLabel ? (
+                    <span className="shrink-0 text-[10px] font-semibold tracking-[0.12em] text-muted-foreground/80">
+                      {tab.shortcutLabel}
+                    </span>
+                  ) : null}
+                  <span className="truncate text-sm font-medium">{label}</span>
+                  {tab.isDirty ? (
                     <span
-                      aria-hidden="true"
-                      className={cn(
-                        "h-1.5 w-1.5 shrink-0 rounded-full",
-                        tab.isDirty ? "bg-primary/80" : "bg-border/60",
-                      )}
+                      aria-label="Unsaved changes"
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary/75"
                     />
-                    <span className="truncate text-sm font-medium">{label}</span>
-                  </button>
+                  ) : null}
+                </button>
 
-                  <button
-                    type="button"
-                    tabIndex={isActive ? 0 : -1}
-                    aria-label={`Close ${label}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onCloseTab(tab.file.path);
-                    }}
-                    className={cn(
-                      "absolute top-1/2 right-1.5 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground outline-none",
-                      isActive
-                        ? "opacity-100 hover:bg-muted hover:text-foreground"
-                        : "opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100",
-                    )}
-                  >
-                    <XIcon size={12} />
-                  </button>
-                </div>
-              );
-            })
-          )}
+                <button
+                  type="button"
+                  tabIndex={isActive ? 0 : -1}
+                  aria-label={`Close ${label}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onCloseTab(tab.path);
+                  }}
+                  className={cn(
+                    "absolute top-1/2 right-1.5 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground outline-none",
+                    isActive
+                      ? "pointer-events-auto opacity-100 hover:bg-muted hover:text-foreground"
+                      : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  <XIcon size={12} />
+                </button>
+              </div>
+            );
+          })}
         </div>
       </div>
-
-      {tabs.length > 0 && closeTabShortcut ? (
-        <div className="hidden shrink-0 rounded-full border border-border/60 px-2 py-1 text-[10px] font-medium tracking-[0.12em] text-muted-foreground lg:inline-flex">
-          {closeTabShortcut}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { DragEvent } from "react";
 
+import { isSamePath } from "@/lib/paths";
 import { cn } from "@/lib/utils";
+import type { TabMovePosition } from "@/shared/workspace";
 
 import { XIcon } from "./icons";
 
 export type NoteTabRailItem = {
   id: string;
-  isDirty: boolean;
   label: string;
   path: string;
   shortcutLabel?: string;
@@ -15,15 +17,29 @@ export type NoteTabRailItem = {
 type NoteTabsBarProps = {
   activeTabId: string | null;
   onCloseTab: (path: string) => void;
+  onMoveTab: (sourcePath: string, targetPath: string, position: TabMovePosition) => void;
   onSelectTab: (path: string) => void;
   tabs: NoteTabRailItem[];
 };
 
-export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: NoteTabsBarProps) {
+export function NoteTabsBar({
+  activeTabId,
+  onCloseTab,
+  onMoveTab,
+  onSelectTab,
+  tabs,
+}: NoteTabsBarProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const draggedTabPathRef = useRef<string | null>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+  const [draggedTabPath, setDraggedTabPath] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{
+    path: string;
+    position: TabMovePosition;
+  } | null>(null);
+  const tabOrderKey = useMemo(() => tabs.map((tab) => tab.id).join("|"), [tabs]);
 
   const updateScrollState = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -54,7 +70,7 @@ export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: Note
       scrollContainer.removeEventListener("scroll", updateScrollState);
       window.removeEventListener("resize", updateScrollState);
     };
-  }, [tabs.length, updateScrollState]);
+  }, [tabOrderKey, updateScrollState]);
 
   useEffect(() => {
     if (!activeTabId) {
@@ -65,7 +81,76 @@ export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: Note
       block: "nearest",
       inline: "nearest",
     });
-  }, [activeTabId]);
+  }, [activeTabId, tabOrderKey]);
+
+  const clearDragState = useCallback(() => {
+    draggedTabPathRef.current = null;
+    setDraggedTabPath(null);
+    setDropTarget(null);
+  }, []);
+
+  const handleTabDragOver = useCallback((event: DragEvent<HTMLElement>, tabPath: string) => {
+    const currentDraggedTabPath = draggedTabPathRef.current;
+    if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tabPath)) {
+      return;
+    }
+
+    event.preventDefault();
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const position: TabMovePosition =
+      event.clientX < bounds.left + bounds.width / 2 ? "before" : "after";
+    setDropTarget((current) =>
+      current?.path === tabPath && current.position === position
+        ? current
+        : { path: tabPath, position },
+    );
+  }, []);
+
+  const handleContainerDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!draggedTabPathRef.current) {
+      return;
+    }
+
+    event.preventDefault();
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    const bounds = scrollContainer.getBoundingClientRect();
+    const edgeThreshold = 56;
+    if (event.clientX <= bounds.left + edgeThreshold) {
+      scrollContainer.scrollBy({ left: -18 });
+    } else if (event.clientX >= bounds.right - edgeThreshold) {
+      scrollContainer.scrollBy({ left: 18 });
+    }
+  }, []);
+
+  const handleContainerDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      const currentDraggedTabPath = draggedTabPathRef.current;
+      if (!currentDraggedTabPath) {
+        return;
+      }
+
+      const dropElement =
+        event.target instanceof HTMLElement
+          ? event.target.closest<HTMLElement>("[data-note-tab-path]")
+          : null;
+      if (dropElement) {
+        return;
+      }
+
+      const lastTab = tabs.at(-1);
+      if (lastTab && !isSamePath(lastTab.path, currentDraggedTabPath)) {
+        event.preventDefault();
+        onMoveTab(currentDraggedTabPath, lastTab.path, "after");
+      }
+
+      clearDragState();
+    },
+    [clearDragState, onMoveTab, tabs],
+  );
 
   return (
     <div className="relative flex h-11 items-center bg-background px-2">
@@ -82,27 +167,78 @@ export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: Note
           role="tablist"
           aria-label="Open note tabs"
           className="scrollbar-hide flex min-w-0 items-center gap-1 overflow-x-auto py-1"
+          onDragOver={handleContainerDragOver}
+          onDrop={handleContainerDrop}
         >
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             const label = tab.label;
+            const showDropIndicator = dropTarget?.path === tab.path;
 
             return (
-              <div key={tab.id} className="group relative shrink-0">
+              <div
+                key={tab.id}
+                data-note-tab-path={tab.path}
+                className="group/tab relative shrink-0"
+              >
+                {showDropIndicator ? (
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "pointer-events-none absolute inset-y-1 z-20 w-0.5 rounded-full bg-primary/75",
+                      dropTarget.position === "before" ? "-left-0.5" : "-right-0.5",
+                    )}
+                  />
+                ) : null}
+
                 <button
                   ref={(element) => {
                     tabRefs.current[tab.id] = element;
                   }}
                   type="button"
                   role="tab"
+                  draggable={tabs.length > 1}
                   aria-selected={isActive}
                   title={tab.path}
+                  onDragEnd={clearDragState}
+                  onDragLeave={(event) => {
+                    if (
+                      event.currentTarget.contains(event.relatedTarget as Node | null) ||
+                      !dropTarget ||
+                      dropTarget.path !== tab.path
+                    ) {
+                      return;
+                    }
+
+                    setDropTarget(null);
+                  }}
+                  onDragStart={(event) => {
+                    event.dataTransfer.effectAllowed = "move";
+                    event.dataTransfer.setData("text/plain", tab.path);
+                    draggedTabPathRef.current = tab.path;
+                    setDraggedTabPath(tab.path);
+                  }}
+                  onDragOver={(event) => handleTabDragOver(event, tab.path)}
+                  onDrop={(event) => {
+                    const currentDraggedTabPath = draggedTabPathRef.current;
+                    if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tab.path)) {
+                      clearDragState();
+                      return;
+                    }
+
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const position = dropTarget?.path === tab.path ? dropTarget.position : "after";
+                    onMoveTab(currentDraggedTabPath, tab.path, position);
+                    clearDragState();
+                  }}
                   onClick={() => onSelectTab(tab.path)}
                   className={cn(
-                    "flex h-8 min-w-[152px] max-w-[224px] items-center gap-2 rounded-lg border px-3 pr-9 text-left outline-none",
+                    "flex h-8 min-w-[152px] max-w-[224px] cursor-grab items-center gap-2 rounded-lg border px-3 pr-9 text-left outline-none transition-[border-color,background-color,color,box-shadow] duration-150 ease-out active:cursor-grabbing focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                     isActive
                       ? "border-border bg-card text-foreground shadow-sm"
                       : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/60 hover:text-foreground",
+                    draggedTabPath && isSamePath(draggedTabPath, tab.path) ? "opacity-70" : "",
                   )}
                 >
                   {tab.shortcutLabel ? (
@@ -111,12 +247,6 @@ export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: Note
                     </span>
                   ) : null}
                   <span className="truncate text-sm font-medium">{label}</span>
-                  {tab.isDirty ? (
-                    <span
-                      aria-label="Unsaved changes"
-                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary/75"
-                    />
-                  ) : null}
                 </button>
 
                 <button
@@ -128,10 +258,10 @@ export function NoteTabsBar({ activeTabId, onCloseTab, onSelectTab, tabs }: Note
                     onCloseTab(tab.path);
                   }}
                   className={cn(
-                    "absolute top-1/2 right-1.5 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground outline-none",
+                    "absolute top-1/2 right-1.5 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground outline-none transition-[background-color,color,opacity,box-shadow] duration-150 ease-out focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                     isActive
                       ? "pointer-events-auto opacity-100 hover:bg-muted hover:text-foreground"
-                      : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted hover:text-foreground",
+                      : "pointer-events-none opacity-0 group-hover/tab:pointer-events-auto group-focus-within/tab:pointer-events-auto group-hover/tab:opacity-100 group-focus-within/tab:opacity-100 hover:bg-muted hover:text-foreground",
                   )}
                 >
                   <XIcon size={12} />

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getDisplayFileName } from "@/lib/paths";
+import { cn } from "@/lib/utils";
+import type { NoteTab } from "@/shared/workspace";
+
+import { PlusIcon, XIcon } from "./icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+type NoteTabsBarProps = {
+  activeTabId: string | null;
+  closeTabShortcut?: string;
+  newTabShortcut?: string;
+  onCloseTab: (path: string) => void;
+  onCreateTab: () => void;
+  onSelectTab: (path: string) => void;
+  tabs: NoteTab[];
+};
+
+export function NoteTabsBar({
+  activeTabId,
+  closeTabShortcut,
+  newTabShortcut,
+  onCloseTab,
+  onCreateTab,
+  onSelectTab,
+  tabs,
+}: NoteTabsBarProps) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      setCanScrollLeft(false);
+      setCanScrollRight(false);
+      return;
+    }
+
+    setCanScrollLeft(scrollContainer.scrollLeft > 4);
+    setCanScrollRight(
+      scrollContainer.scrollLeft + scrollContainer.clientWidth < scrollContainer.scrollWidth - 4,
+    );
+  }, []);
+
+  useEffect(() => {
+    updateScrollState();
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    scrollContainer.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+
+    return () => {
+      scrollContainer.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [tabs.length, updateScrollState]);
+
+  useEffect(() => {
+    if (!activeTabId) {
+      return;
+    }
+
+    tabRefs.current[activeTabId]?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeTabId]);
+
+  return (
+    <div className="relative flex h-11 items-center gap-2 bg-background px-2">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onCreateTab}
+            aria-label="Create a new tab"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-background text-muted-foreground shadow-sm outline-none transition-[border-color,background-color,color,transform] duration-100 ease-out hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:scale-[0.97]"
+          >
+            <PlusIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {`New Tab${newTabShortcut ? ` (${newTabShortcut})` : ""}`}
+        </TooltipContent>
+      </Tooltip>
+
+      <div className="relative min-w-0 flex-1">
+        {canScrollLeft ? (
+          <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
+        ) : null}
+        {canScrollRight ? (
+          <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent" />
+        ) : null}
+
+        <div
+          ref={scrollContainerRef}
+          role="tablist"
+          aria-label="Open note tabs"
+          className="scrollbar-hide flex min-w-0 items-center gap-1 overflow-x-auto py-1"
+        >
+          {tabs.length === 0 ? (
+            <div className="inline-flex h-8 items-center rounded-lg border border-dashed border-border/70 px-3 text-xs text-muted-foreground">
+              No open tabs
+            </div>
+          ) : (
+            tabs.map((tab) => {
+              const isActive = tab.id === activeTabId;
+              const label = getDisplayFileName(tab.file.name);
+
+              return (
+                <div key={tab.id} className="group relative shrink-0">
+                  <button
+                    ref={(element) => {
+                      tabRefs.current[tab.id] = element;
+                    }}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    title={tab.file.path}
+                    onClick={() => onSelectTab(tab.file.path)}
+                    className={cn(
+                      "flex h-8 min-w-[152px] max-w-[224px] items-center gap-2 rounded-lg border px-3 pr-9 text-left outline-none",
+                      isActive
+                        ? "border-border bg-card text-foreground shadow-sm"
+                        : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/60 hover:text-foreground",
+                    )}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "h-1.5 w-1.5 shrink-0 rounded-full",
+                        tab.isDirty ? "bg-primary/80" : "bg-border/60",
+                      )}
+                    />
+                    <span className="truncate text-sm font-medium">{label}</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    tabIndex={isActive ? 0 : -1}
+                    aria-label={`Close ${label}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onCloseTab(tab.file.path);
+                    }}
+                    className={cn(
+                      "absolute top-1/2 right-1.5 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground outline-none",
+                      isActive
+                        ? "opacity-100 hover:bg-muted hover:text-foreground"
+                        : "opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100",
+                    )}
+                  >
+                    <XIcon size={12} />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {tabs.length > 0 && closeTabShortcut ? (
+        <div className="hidden shrink-0 rounded-full border border-border/60 px-2 py-1 text-[10px] font-medium tracking-[0.12em] text-muted-foreground lg:inline-flex">
+          {closeTabShortcut}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 
 import { getShortcutDisplay } from "@/shared/shortcuts";
-import type { ShortcutSetting } from "@/shared/workspace";
+import type { NoteTab, ShortcutSetting } from "@/shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 import type { UpdateState } from "@/shared/workspace";
 import type { EditorFocusRequest } from "@/types/markdown-editor";
 
 import { MarkdownEditor } from "./markdown-editor";
+import { NoteTabsBar } from "./note-tabs-bar";
 
 type NoteViewProps = {
   content: string;
@@ -19,6 +20,8 @@ type NoteViewProps = {
   wordCount: number;
   readingTime: number;
   isSidebarCollapsed: boolean;
+  activeTabId: string | null;
+  noteTabs: NoteTab[];
   shortcuts: ShortcutSetting[];
   canGoBack: boolean;
   canGoForward: boolean;
@@ -31,6 +34,9 @@ type NoteViewProps = {
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;
   onContentChange: (value: string) => void;
+  onCreateTab: () => void;
+  onSelectTab: (path: string) => void;
+  onCloseTab: (path: string) => void;
   onToggleSidebar: () => void;
   onCreateNote: () => void;
   onOpenSettings: () => void;
@@ -58,6 +64,8 @@ export function NoteView({
   wordCount,
   readingTime,
   isSidebarCollapsed,
+  activeTabId,
+  noteTabs,
   shortcuts,
   canGoBack,
   canGoForward,
@@ -70,6 +78,9 @@ export function NoteView({
   outlineJumpRequest,
   updateState,
   onContentChange,
+  onCreateTab,
+  onSelectTab,
+  onCloseTab,
   onToggleSidebar,
   onCreateNote,
   onOpenSettings,
@@ -104,6 +115,17 @@ export function NoteView({
       footerMetaLabel={footerMetaLabel}
       wordCount={wordCount}
       readingTime={readingTime}
+      subheaderContent={
+        <NoteTabsBar
+          activeTabId={activeTabId}
+          tabs={noteTabs}
+          newTabShortcut={getShortcutDisplay(shortcuts, "new-tab")}
+          closeTabShortcut={getShortcutDisplay(shortcuts, "close-tab")}
+          onCreateTab={onCreateTab}
+          onSelectTab={onSelectTab}
+          onCloseTab={onCloseTab}
+        />
+      }
       onChange={onContentChange}
       onToggleSidebar={onToggleSidebar}
       isSidebarCollapsed={isSidebarCollapsed}

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -113,6 +113,7 @@ export function NoteView({
         path: tab.file.path,
         shortcutLabel: getDirectTabShortcutDisplay(
           index,
+          noteTabs.length,
           typeof navigator === "undefined" ? undefined : navigator.platform,
         ),
       })),

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { getDisplayFileName } from "@/lib/paths";
 import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
-import type { NoteTab, ShortcutSetting } from "@/shared/workspace";
+import type { NoteTab, ShortcutSetting, TabMovePosition } from "@/shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 import type { UpdateState } from "@/shared/workspace";
 import type { EditorFocusRequest } from "@/types/markdown-editor";
@@ -37,6 +37,7 @@ type NoteViewProps = {
   onContentChange: (value: string) => void;
   onSelectTab: (path: string) => void;
   onCloseTab: (path: string) => void;
+  onMoveTab: (sourcePath: string, targetPath: string, position: TabMovePosition) => void;
   onToggleSidebar: () => void;
   onCreateNote: () => void;
   onOpenSettings: () => void;
@@ -80,6 +81,7 @@ export function NoteView({
   onContentChange,
   onSelectTab,
   onCloseTab,
+  onMoveTab,
   onToggleSidebar,
   onCreateNote,
   onOpenSettings,
@@ -107,7 +109,6 @@ export function NoteView({
     () =>
       noteTabs.map((tab, index) => ({
         id: tab.id,
-        isDirty: tab.isDirty,
         label: getDisplayFileName(tab.file.name),
         path: tab.file.path,
         shortcutLabel: getDirectTabShortcutDisplay(
@@ -136,6 +137,7 @@ export function NoteView({
             tabs={noteTabItems}
             onSelectTab={onSelectTab}
             onCloseTab={onCloseTab}
+            onMoveTab={onMoveTab}
           />
         ) : null
       }

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
-import { getShortcutDisplay } from "@/shared/shortcuts";
+import { getDisplayFileName } from "@/lib/paths";
+import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
 import type { NoteTab, ShortcutSetting } from "@/shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 import type { UpdateState } from "@/shared/workspace";
@@ -34,7 +35,6 @@ type NoteViewProps = {
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;
   onContentChange: (value: string) => void;
-  onCreateTab: () => void;
   onSelectTab: (path: string) => void;
   onCloseTab: (path: string) => void;
   onToggleSidebar: () => void;
@@ -78,7 +78,6 @@ export function NoteView({
   outlineJumpRequest,
   updateState,
   onContentChange,
-  onCreateTab,
   onSelectTab,
   onCloseTab,
   onToggleSidebar,
@@ -104,6 +103,21 @@ export function NoteView({
     onOpenSettings();
   }, [onOpenSettings]);
 
+  const noteTabItems = useMemo(
+    () =>
+      noteTabs.map((tab, index) => ({
+        id: tab.id,
+        isDirty: tab.isDirty,
+        label: getDisplayFileName(tab.file.name),
+        path: tab.file.path,
+        shortcutLabel: getDirectTabShortcutDisplay(
+          index,
+          typeof navigator === "undefined" ? undefined : navigator.platform,
+        ),
+      })),
+    [noteTabs],
+  );
+
   return (
     <MarkdownEditor
       content={content}
@@ -116,15 +130,14 @@ export function NoteView({
       wordCount={wordCount}
       readingTime={readingTime}
       subheaderContent={
-        <NoteTabsBar
-          activeTabId={activeTabId}
-          tabs={noteTabs}
-          newTabShortcut={getShortcutDisplay(shortcuts, "new-tab")}
-          closeTabShortcut={getShortcutDisplay(shortcuts, "close-tab")}
-          onCreateTab={onCreateTab}
-          onSelectTab={onSelectTab}
-          onCloseTab={onCloseTab}
-        />
+        noteTabItems.length > 0 ? (
+          <NoteTabsBar
+            activeTabId={activeTabId}
+            tabs={noteTabItems}
+            onSelectTab={onSelectTab}
+            onCloseTab={onCloseTab}
+          />
+        ) : null
       }
       onChange={onContentChange}
       onToggleSidebar={onToggleSidebar}

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { BreadcrumbItem, OutlineItem } from "@/types/navigation";
 
-import { getShortcutDisplay } from "@/shared/shortcuts";
+import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
 import type { DirectoryNode, FileDocument } from "@/shared/workspace";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
@@ -42,10 +42,18 @@ const NOTE_NAME_SAFE_CHAR_PATTERN = /[^a-zA-Z0-9-_\s]/g;
 const TITLE_PREFIX_PATTERN = /^#+\s*/;
 const NOTE_NAME_MAX_LENGTH = 50;
 const APP_CHANGELOG_URL = "https://github.com/FALAK097/glyph/blob/main/CHANGELOG.md";
-const MAX_DIRECT_NOTE_TAB_SHORTCUTS = 9;
 
-const getTabSwitchShortcutLabel = (index: number) =>
-  index < MAX_DIRECT_NOTE_TAB_SHORTCUTS ? `⌘${index + 1}` : undefined;
+const getRenamedFolderFilePath = (
+  oldFolderPath: string,
+  newFolderPath: string,
+  filePath: string,
+) => {
+  const normalizedOldFolderPath = normalizePath(oldFolderPath).replace(/\/+$/, "");
+  const normalizedNewFolderPath = normalizePath(newFolderPath).replace(/\/+$/, "");
+  const suffix = normalizePath(filePath).slice(normalizedOldFolderPath.length);
+
+  return `${normalizedNewFolderPath}${suffix}`;
+};
 
 const getDraftTitleLine = (content: string) =>
   content.split(/\r?\n/, 1)[0]?.replace(TITLE_PREFIX_PATTERN, "").trim() ?? "";
@@ -113,6 +121,7 @@ export const useDesktopAppController = (
     setSaving,
     setTabSaving,
     setError,
+    navigationHistory,
     activateTab,
     closeTab,
     closeOtherTabs,
@@ -765,11 +774,11 @@ export const useDesktopAppController = (
       try {
         await glyph.deleteFolder(folderPath);
         setSidebarNodes((prev) => removeSidebarPath(prev, folderPath));
-        noteTabs
-          .filter((tab) => isFileInsideWorkspace(tab.file.path, folderPath))
-          .forEach((tab) => {
-            removeHistoryPath(tab.file.path);
-          });
+        Array.from(
+          new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, folderPath))),
+        ).forEach((entry) => {
+          removeHistoryPath(entry);
+        });
         removeTabsInFolder(folderPath);
 
         if (rootPath && isSamePath(rootPath, folderPath)) {
@@ -780,7 +789,15 @@ export const useDesktopAppController = (
         setError(err instanceof Error ? err.message : "Failed to delete folder");
       }
     },
-    [glyph, noteTabs, removeHistoryPath, removeTabsInFolder, rootPath, setError, setWorkspace],
+    [
+      glyph,
+      navigationHistory,
+      removeHistoryPath,
+      removeTabsInFolder,
+      rootPath,
+      setError,
+      setWorkspace,
+    ],
   );
 
   const handleRemoveFileFromGlyph = useCallback(
@@ -879,13 +896,10 @@ export const useDesktopAppController = (
       try {
         const { oldPath, newPath } = await glyph.renameFolder(folderPath, newName);
         setSidebarNodes((prev) => renameSidebarFolder(prev, oldPath, newPath, newName));
-        const remappedTabs = noteTabs.filter((tab) =>
-          isFileInsideWorkspace(tab.file.path, oldPath),
-        );
-        remappedTabs.forEach((tab) => {
-          const nextFilePath =
-            newPath + normalizePath(tab.file.path).slice(normalizePath(oldPath).length);
-          replaceHistoryPath(tab.file.path, nextFilePath);
+        Array.from(
+          new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, oldPath))),
+        ).forEach((entry) => {
+          replaceHistoryPath(entry, getRenamedFolderFilePath(oldPath, newPath, entry));
         });
         remapTabsForFolderRename(oldPath, newPath);
 
@@ -902,7 +916,7 @@ export const useDesktopAppController = (
     },
     [
       glyph,
-      noteTabs,
+      navigationHistory,
       replaceHistoryPath,
       remapTabsForFolderRename,
       rootPath,
@@ -1128,15 +1142,6 @@ export const useDesktopAppController = (
         onSelect: () => void createNote(),
       },
       {
-        id: "new-tab",
-        title: "New tab",
-        subtitle: "Create a new note in its own tab",
-        shortcut: getShortcutDisplay(shortcuts, "new-tab"),
-        section: "Tabs",
-        kind: "command",
-        onSelect: () => void createNote(),
-      },
-      {
         id: "new-folder",
         title: "New folder",
         subtitle: "Create a new folder in the current directory",
@@ -1250,6 +1255,7 @@ export const useDesktopAppController = (
               id: "close-other-tabs",
               title: "Close Other Tabs",
               subtitle: "Keep only the current note open",
+              shortcut: getShortcutDisplay(shortcuts, "close-other-tabs"),
               section: "Tabs",
               kind: "command" as const,
               onSelect: () => {
@@ -1338,7 +1344,7 @@ export const useDesktopAppController = (
           ? `${tab.file.name} (current)`
           : tab.file.name,
         subtitle: getRelativePath(tab.file.path, rootPath),
-        shortcut: getTabSwitchShortcutLabel(index),
+        shortcut: getDirectTabShortcutDisplay(index, appInfo?.platform),
         section: "Open Tabs",
         kind: "command" as const,
         onSelect: () => {
@@ -1349,6 +1355,7 @@ export const useDesktopAppController = (
     [
       activeFile,
       activateNoteTab,
+      appInfo?.platform,
       closeNoteTab,
       closeOtherNoteTabs,
       createNote,
@@ -1414,7 +1421,6 @@ export const useDesktopAppController = (
       );
     },
     createNote,
-    createTab: createNote,
     createFolder,
     closeActiveTab: async () => {
       if (!activeFile) {
@@ -1422,6 +1428,13 @@ export const useDesktopAppController = (
       }
 
       await closeNoteTab(activeFile.path);
+    },
+    closeOtherTabs: async () => {
+      if (!activeFile) {
+        return;
+      }
+
+      await closeOtherNoteTabs(activeFile.path);
     },
     activateTabByIndex,
     syncOpenedFile,
@@ -1565,12 +1578,8 @@ export const useDesktopAppController = (
         }
 
         if (restoredTabPaths.length > 0) {
-          const orderedRestorePaths = restoredActivePath
-            ? [
-                restoredActivePath,
-                ...restoredTabPaths.filter((path) => !isSamePath(path, restoredActivePath)),
-              ]
-            : restoredTabPaths;
+          const orderedRestorePaths = restoredTabPaths;
+          let firstRestoredFile: FileDocument | null = null;
           let restoredActiveFile: FileDocument | null = null;
 
           for (const restorePath of orderedRestorePaths) {
@@ -1579,25 +1588,30 @@ export const useDesktopAppController = (
               continue;
             }
 
+            if (!firstRestoredFile) {
+              firstRestoredFile = restoredFile;
+            }
+
             setActiveFile(restoredFile);
             setIsWorkspaceMode(
               Boolean(workspace && isFileInsideWorkspace(restoredFile.path, workspace.rootPath)),
             );
             nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, restoredFile);
 
-            if (!restoredActiveFile || isSamePath(restoredFile.path, restoredActivePath)) {
+            if (restoredActivePath && isSamePath(restoredFile.path, restoredActivePath)) {
               restoredActiveFile = restoredFile;
             }
           }
 
-          if (restoredActiveFile) {
-            setActiveFile(restoredActiveFile);
+          const nextActiveRestoredFile = restoredActiveFile ?? firstRestoredFile;
+          if (nextActiveRestoredFile) {
+            setActiveFile(nextActiveRestoredFile);
             setIsWorkspaceMode(
               Boolean(
-                workspace && isFileInsideWorkspace(restoredActiveFile.path, workspace.rootPath),
+                workspace && isFileInsideWorkspace(nextActiveRestoredFile.path, workspace.rootPath),
               ),
             );
-            pushHistory(restoredActiveFile.path);
+            pushHistory(nextActiveRestoredFile.path);
             bootFocusMode = "preserve";
           }
         }
@@ -1696,12 +1710,12 @@ export const useDesktopAppController = (
       return;
     }
 
-    const activeTab = getActiveTab();
-    if (!activeTab) {
-      return;
-    }
-
     const timer = window.setTimeout(async () => {
+      const activeTab = getActiveTab();
+      if (!activeTab || !activeTab.isDirty || activeTab.isSaving) {
+        return;
+      }
+
       await persistNoteDraft(
         {
           draftContent: activeTab.draftContent,
@@ -1716,10 +1730,10 @@ export const useDesktopAppController = (
     }, 800);
 
     return () => window.clearTimeout(timer);
-  }, [activeFile?.path, getActiveTab, isDirty, isSaving, persistNoteDraft]);
+  }, [activeFile?.path, draftContent, getActiveTab, isDirty, isSaving, persistNoteDraft]);
 
   // Session sync
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!sessionReady || !hasBooted) {
       return;
     }
@@ -1811,6 +1825,11 @@ export const useDesktopAppController = (
         return;
       }
 
+      if (command === "close-tab" && activeFile) {
+        await closeNoteTab(activeFile.path);
+        return;
+      }
+
       if (command === "open-file") {
         const file = await glyph.openDocument();
         if (file) {
@@ -1849,6 +1868,7 @@ export const useDesktopAppController = (
     });
   }, [
     activeFile,
+    closeNoteTab,
     createNote,
     draftContent,
     getActiveTab,

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { BreadcrumbItem, OutlineItem } from "@/types/navigation";
 
 import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
-import type { DirectoryNode, FileDocument } from "@/shared/workspace";
+import type { DirectoryNode, FileDocument, TabMovePosition } from "@/shared/workspace";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
 import { applyTheme } from "@/theme/themes";
@@ -125,6 +125,7 @@ export const useDesktopAppController = (
     activateTab,
     closeTab,
     closeOtherTabs,
+    moveTab,
     removeTabsInFolder,
     replaceTabPath,
     remapTabsForFolderRename,
@@ -473,7 +474,9 @@ export const useDesktopAppController = (
 
   const closeOtherNoteTabs = useCallback(
     async (filePath: string) => {
-      const otherTabs = noteTabs.filter((tab) => !isSamePath(tab.file.path, filePath));
+      const otherTabs = useWorkspaceStore
+        .getState()
+        .noteTabs.filter((tab) => !isSamePath(tab.file.path, filePath));
       for (const tab of otherTabs) {
         if (!tab.isDirty) {
           continue;
@@ -494,10 +497,16 @@ export const useDesktopAppController = (
           return;
         }
       }
-
       closeOtherTabs(filePath);
     },
-    [activeFile?.path, closeOtherTabs, noteTabs, persistNoteDraft],
+    [activeFile?.path, closeOtherTabs, persistNoteDraft],
+  );
+
+  const moveNoteTab = useCallback(
+    (sourcePath: string, targetPath: string, position: TabMovePosition) => {
+      moveTab(sourcePath, targetPath, position);
+    },
+    [moveTab],
   );
 
   const activateTabByIndex = useCallback(
@@ -1243,7 +1252,10 @@ export const useDesktopAppController = (
               section: "Tabs",
               kind: "command" as const,
               onSelect: () => {
-                void closeNoteTab(activeFile.path);
+                const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
+                if (currentActiveTab) {
+                  void closeNoteTab(currentActiveTab.file.path);
+                }
                 setIsPaletteOpen(false);
               },
             },
@@ -1259,7 +1271,10 @@ export const useDesktopAppController = (
               section: "Tabs",
               kind: "command" as const,
               onSelect: () => {
-                void closeOtherNoteTabs(activeFile.path);
+                const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
+                if (currentActiveTab) {
+                  void closeOtherNoteTabs(currentActiveTab.file.path);
+                }
                 setIsPaletteOpen(false);
               },
             },
@@ -1423,18 +1438,20 @@ export const useDesktopAppController = (
     createNote,
     createFolder,
     closeActiveTab: async () => {
-      if (!activeFile) {
+      const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
+      if (!currentActiveTab) {
         return;
       }
 
-      await closeNoteTab(activeFile.path);
+      await closeNoteTab(currentActiveTab.file.path);
     },
     closeOtherTabs: async () => {
-      if (!activeFile) {
+      const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
+      if (!currentActiveTab) {
         return;
       }
 
-      await closeOtherNoteTabs(activeFile.path);
+      await closeOtherNoteTabs(currentActiveTab.file.path);
     },
     activateTabByIndex,
     syncOpenedFile,
@@ -1613,6 +1630,14 @@ export const useDesktopAppController = (
             );
             pushHistory(nextActiveRestoredFile.path);
             bootFocusMode = "preserve";
+          } else if (workspace?.activeFile) {
+            setActiveFile(workspace.activeFile);
+            setIsWorkspaceMode(
+              isFileInsideWorkspace(workspace.activeFile.path, workspace.rootPath),
+            );
+            nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, workspace.activeFile);
+            pushHistory(workspace.activeFile.path);
+            bootFocusMode = "end";
           }
         }
       }
@@ -1825,8 +1850,13 @@ export const useDesktopAppController = (
         return;
       }
 
-      if (command === "close-tab" && activeFile) {
-        await closeNoteTab(activeFile.path);
+      if (command === "close-tab") {
+        const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
+        if (!currentActiveTab) {
+          return;
+        }
+
+        await closeNoteTab(currentActiveTab.file.path);
         return;
       }
 
@@ -1918,6 +1948,7 @@ export const useDesktopAppController = (
     isSettingsOpen,
     isSidebarCollapsed,
     markSaved,
+    moveNoteTab,
     noteTabs,
     navigateBack,
     navigateForward,

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -10,7 +10,13 @@ import { applyTheme } from "@/theme/themes";
 
 import { getErrorMessage } from "@/lib/errors";
 import { buildBreadcrumbs, extractMarkdownOutline } from "@/lib/note-navigation";
-import { getDirName, isFileInsideWorkspace, isSamePath, normalizePath } from "@/lib/paths";
+import {
+  getDirName,
+  getRelativePath,
+  isFileInsideWorkspace,
+  isSamePath,
+  normalizePath,
+} from "@/lib/paths";
 import { getFolderRevealLabel } from "@/lib/platform";
 import {
   orderSidebarNodes,
@@ -36,6 +42,10 @@ const NOTE_NAME_SAFE_CHAR_PATTERN = /[^a-zA-Z0-9-_\s]/g;
 const TITLE_PREFIX_PATTERN = /^#+\s*/;
 const NOTE_NAME_MAX_LENGTH = 50;
 const APP_CHANGELOG_URL = "https://github.com/FALAK097/glyph/blob/main/CHANGELOG.md";
+const MAX_DIRECT_NOTE_TAB_SHORTCUTS = 9;
+
+const getTabSwitchShortcutLabel = (index: number) =>
+  index < MAX_DIRECT_NOTE_TAB_SHORTCUTS ? `⌘${index + 1}` : undefined;
 
 const getDraftTitleLine = (content: string) =>
   content.split(/\r?\n/, 1)[0]?.replace(TITLE_PREFIX_PATTERN, "").trim() ?? "";
@@ -67,6 +77,7 @@ const getCommittedDraftFileName = (content: string) => {
 
 type UseDesktopAppControllerOptions = {
   initialFilePath?: string | null;
+  initialTabPaths?: string[];
   initialWorkspacePath?: string | null;
   sessionReady?: boolean;
 };
@@ -75,6 +86,7 @@ export const useDesktopAppController = (
   glyph: NonNullable<Window["glyph"]>,
   {
     initialFilePath = null,
+    initialTabPaths = [],
     initialWorkspacePath = null,
     sessionReady = true,
   }: UseDesktopAppControllerOptions = {},
@@ -82,6 +94,8 @@ export const useDesktopAppController = (
   const {
     rootPath,
     tree,
+    noteTabs,
+    activeTabId,
     activeFile,
     draftContent,
     isDirty,
@@ -95,8 +109,18 @@ export const useDesktopAppController = (
     updateActiveFile,
     updateDraftContent,
     markSaved,
+    markTabSaved,
     setSaving,
+    setTabSaving,
     setError,
+    activateTab,
+    closeTab,
+    closeOtherTabs,
+    removeTabsInFolder,
+    replaceTabPath,
+    remapTabsForFolderRename,
+    getActiveTab,
+    getTabByPath,
     pushHistory,
     replaceHistoryPath,
     removeHistoryPath,
@@ -246,8 +270,99 @@ export const useDesktopAppController = (
     [saveSettings, settings?.hiddenFiles],
   );
 
+  const persistNoteDraft = useCallback(
+    async (
+      target: {
+        draftContent: string;
+        file: FileDocument;
+        isDirty: boolean;
+      },
+      options?: {
+        isActive?: boolean;
+        restoreFocus?: boolean;
+      },
+    ) => {
+      if (!target.isDirty) {
+        return target.file.path;
+      }
+
+      let currentPath = target.file.path;
+      setTabSaving(currentPath, true);
+      if (options?.isActive) {
+        setSaving(true);
+      }
+
+      try {
+        let nextFile = target.file;
+        const committedFileName = getCommittedDraftFileName(target.draftContent);
+
+        if (target.file.name.startsWith("Untitled-") && committedFileName) {
+          const previousPath = currentPath;
+          nextFile = await glyph.renameFile(currentPath, committedFileName);
+          setSidebarNodes((prev) =>
+            upsertSidebarFile(renameSidebarFile(prev, currentPath, nextFile), nextFile),
+          );
+          replaceTabPath(previousPath, nextFile);
+          replaceHistoryPath(previousPath, nextFile.path);
+          await syncTrackedPaths(previousPath, nextFile.path);
+          currentPath = nextFile.path;
+
+          if (options?.restoreFocus) {
+            requestEditorFocus("preserve");
+          }
+        }
+
+        const savedFile = await glyph.saveFile(currentPath, target.draftContent);
+        if (
+          options?.isActive &&
+          isSamePath(useWorkspaceStore.getState().activeFile?.path, currentPath)
+        ) {
+          markSaved(savedFile);
+        } else {
+          markTabSaved(currentPath, savedFile);
+        }
+
+        return currentPath;
+      } catch (saveError) {
+        setError(saveError instanceof Error ? saveError.message : "Unable to save file.");
+        return null;
+      } finally {
+        setTabSaving(currentPath, false);
+        if (options?.isActive) {
+          setSaving(false);
+        }
+      }
+    },
+    [
+      glyph,
+      markSaved,
+      markTabSaved,
+      replaceHistoryPath,
+      replaceTabPath,
+      requestEditorFocus,
+      setError,
+      setSaving,
+      setTabSaving,
+      syncTrackedPaths,
+    ],
+  );
+
   const syncOpenedFile = useCallback(
     async (file: FileDocument, options?: { recordHistory?: boolean }) => {
+      const currentActiveTab = getActiveTab();
+      if (currentActiveTab && !isSamePath(currentActiveTab.file.path, file.path)) {
+        void persistNoteDraft(
+          {
+            draftContent: currentActiveTab.draftContent,
+            file: currentActiveTab.file,
+            isDirty: currentActiveTab.isDirty,
+          },
+          {
+            isActive: true,
+          },
+        );
+      }
+
       await ensureFileVisible(file.path);
       const currentRootPath = useWorkspaceStore.getState().rootPath;
       const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(file.path);
@@ -262,15 +377,144 @@ export const useDesktopAppController = (
       // Clear the last-created folder so the next note goes next to the opened file
       lastCreatedFolderPathRef.current = null;
     },
-    [ensureFileVisible, pushHistory, requestEditorFocus, setActiveFile],
+    [
+      ensureFileVisible,
+      getActiveTab,
+      persistNoteDraft,
+      pushHistory,
+      requestEditorFocus,
+      setActiveFile,
+    ],
+  );
+
+  const activateNoteTab = useCallback(
+    async (filePath: string, options?: { recordHistory?: boolean }) => {
+      const targetTab = getTabByPath(filePath);
+      if (!targetTab) {
+        return;
+      }
+
+      const currentActiveTab = getActiveTab();
+      if (currentActiveTab && !isSamePath(currentActiveTab.file.path, filePath)) {
+        void persistNoteDraft(
+          {
+            draftContent: currentActiveTab.draftContent,
+            file: currentActiveTab.file,
+            isDirty: currentActiveTab.isDirty,
+          },
+          {
+            isActive: true,
+          },
+        );
+      }
+
+      const currentRootPath = useWorkspaceStore.getState().rootPath;
+      const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(filePath);
+      activateTab(filePath);
+      setIsWorkspaceMode(isFileInsideWorkspace(filePath, currentRootPath));
+      if (options?.recordHistory) {
+        pushHistory(filePath);
+      }
+      requestEditorFocus(shouldPreserveFocus ? "preserve" : "end");
+      setIsPaletteOpen(false);
+      lastCreatedFolderPathRef.current = null;
+    },
+    [activateTab, getActiveTab, getTabByPath, persistNoteDraft, pushHistory, requestEditorFocus],
+  );
+
+  const closeNoteTab = useCallback(
+    async (filePath: string) => {
+      const targetTab = getTabByPath(filePath);
+      if (!targetTab) {
+        return;
+      }
+
+      const isClosingActiveTab = isSamePath(activeFile?.path, filePath);
+      let targetPath = filePath;
+      if (targetTab.isDirty) {
+        const savedPath = await persistNoteDraft(
+          {
+            draftContent: targetTab.draftContent,
+            file: targetTab.file,
+            isDirty: targetTab.isDirty,
+          },
+          {
+            isActive: isClosingActiveTab,
+            restoreFocus: isClosingActiveTab,
+          },
+        );
+
+        if (!savedPath) {
+          return;
+        }
+
+        targetPath = savedPath;
+      }
+
+      const nextActivePath = closeTab(targetPath);
+      if (nextActivePath) {
+        const currentRootPath = useWorkspaceStore.getState().rootPath;
+        const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(nextActivePath);
+        setIsWorkspaceMode(isFileInsideWorkspace(nextActivePath, currentRootPath));
+        requestEditorFocus(shouldPreserveFocus ? "preserve" : "end");
+      }
+    },
+    [activeFile?.path, closeTab, getTabByPath, persistNoteDraft, requestEditorFocus],
+  );
+
+  const closeOtherNoteTabs = useCallback(
+    async (filePath: string) => {
+      const otherTabs = noteTabs.filter((tab) => !isSamePath(tab.file.path, filePath));
+      for (const tab of otherTabs) {
+        if (!tab.isDirty) {
+          continue;
+        }
+
+        const savedPath = await persistNoteDraft(
+          {
+            draftContent: tab.draftContent,
+            file: tab.file,
+            isDirty: tab.isDirty,
+          },
+          {
+            isActive: isSamePath(activeFile?.path, tab.file.path),
+          },
+        );
+
+        if (!savedPath) {
+          return;
+        }
+      }
+
+      closeOtherTabs(filePath);
+    },
+    [activeFile?.path, closeOtherTabs, noteTabs, persistNoteDraft],
+  );
+
+  const activateTabByIndex = useCallback(
+    async (index: number) => {
+      const targetTab = noteTabs[index];
+      if (!targetTab) {
+        return;
+      }
+
+      await activateNoteTab(targetTab.file.path, { recordHistory: true });
+    },
+    [activateNoteTab, noteTabs],
   );
 
   const openFile = useCallback(
     async (filePath: string) => {
+      const existingTab = getTabByPath(filePath);
+      if (existingTab) {
+        await activateNoteTab(existingTab.file.path, { recordHistory: true });
+        return;
+      }
+
       const file = await glyph.readFile(filePath);
       await syncOpenedFile(file, { recordHistory: true });
     },
-    [syncOpenedFile, glyph],
+    [activateNoteTab, getTabByPath, syncOpenedFile, glyph],
   );
 
   const createNote = useCallback(async () => {
@@ -293,6 +537,20 @@ export const useDesktopAppController = (
 
     if (!baseDir) {
       return;
+    }
+
+    const currentActiveTab = getActiveTab();
+    if (currentActiveTab) {
+      void persistNoteDraft(
+        {
+          draftContent: currentActiveTab.draftContent,
+          file: currentActiveTab.file,
+          isDirty: currentActiveTab.isDirty,
+        },
+        {
+          isActive: true,
+        },
+      );
     }
 
     setIsPaletteOpen(false);
@@ -326,8 +584,10 @@ export const useDesktopAppController = (
     requestEditorFocus("start");
   }, [
     activeFile,
+    getActiveTab,
     glyph,
     isWorkspaceMode,
+    persistNoteDraft,
     pushHistory,
     requestEditorFocus,
     rootPath,
@@ -485,15 +745,19 @@ export const useDesktopAppController = (
         setSidebarNodes((prev) => removeSidebarPath(prev, filePath));
         removeHistoryPath(filePath);
         await syncTrackedPaths(filePath);
-
-        if (activeFile?.path === filePath) {
-          setActiveFile(null);
+        const nextActivePath = closeTab(filePath);
+        if (nextActivePath) {
+          const currentRootPath = useWorkspaceStore.getState().rootPath;
+          setIsWorkspaceMode(isFileInsideWorkspace(nextActivePath, currentRootPath));
+          requestEditorFocus(
+            useSessionStore.getState().hasDocumentScroll(nextActivePath) ? "preserve" : "end",
+          );
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to delete file");
       }
     },
-    [activeFile?.path, glyph, removeHistoryPath, setActiveFile, setError, syncTrackedPaths],
+    [closeTab, glyph, removeHistoryPath, requestEditorFocus, setError, syncTrackedPaths],
   );
 
   const handleDeleteFolder = useCallback(
@@ -501,11 +765,12 @@ export const useDesktopAppController = (
       try {
         await glyph.deleteFolder(folderPath);
         setSidebarNodes((prev) => removeSidebarPath(prev, folderPath));
-
-        if (activeFile && isFileInsideWorkspace(activeFile.path, folderPath)) {
-          setActiveFile(null);
-          removeHistoryPath(activeFile.path);
-        }
+        noteTabs
+          .filter((tab) => isFileInsideWorkspace(tab.file.path, folderPath))
+          .forEach((tab) => {
+            removeHistoryPath(tab.file.path);
+          });
+        removeTabsInFolder(folderPath);
 
         if (rootPath && isSamePath(rootPath, folderPath)) {
           setWorkspace({ rootPath: "", tree: [], activeFile: null });
@@ -515,33 +780,54 @@ export const useDesktopAppController = (
         setError(err instanceof Error ? err.message : "Failed to delete folder");
       }
     },
-    [activeFile, glyph, removeHistoryPath, rootPath, setActiveFile, setError, setWorkspace],
+    [glyph, noteTabs, removeHistoryPath, removeTabsInFolder, rootPath, setError, setWorkspace],
   );
 
   const handleRemoveFileFromGlyph = useCallback(
     async (filePath: string) => {
       try {
-        if (activeFile?.path && isSamePath(activeFile.path, filePath) && isDirty) {
-          const savedFile = await glyph.saveFile(filePath, draftContent);
-          markSaved(savedFile);
+        const targetTab = getTabByPath(filePath);
+        let targetPath = filePath;
+        if (targetTab?.isDirty) {
+          const savedPath = await persistNoteDraft(
+            {
+              draftContent: targetTab.draftContent,
+              file: targetTab.file,
+              isDirty: targetTab.isDirty,
+            },
+            {
+              isActive: isSamePath(activeFile?.path, filePath),
+              restoreFocus: isSamePath(activeFile?.path, filePath),
+            },
+          );
+
+          if (!savedPath) {
+            return;
+          }
+
+          targetPath = savedPath;
         }
 
         const nextHiddenFiles = [
-          filePath,
-          ...(settings?.hiddenFiles ?? []).filter((entry) => !isSamePath(entry, filePath)),
+          targetPath,
+          ...(settings?.hiddenFiles ?? []).filter((entry) => !isSamePath(entry, targetPath)),
         ];
         const nextPinnedFiles = (settings?.pinnedFiles ?? []).filter(
-          (entry) => !isSamePath(entry, filePath),
+          (entry) => !isSamePath(entry, targetPath),
         );
 
         await saveSettings({
           hiddenFiles: nextHiddenFiles,
           pinnedFiles: nextPinnedFiles,
         });
-        removeHistoryPath(filePath);
-
-        if (activeFile?.path && isSamePath(activeFile.path, filePath)) {
-          setActiveFile(null);
+        removeHistoryPath(targetPath);
+        const nextActivePath = closeTab(targetPath);
+        if (nextActivePath) {
+          const currentRootPath = useWorkspaceStore.getState().rootPath;
+          setIsWorkspaceMode(isFileInsideWorkspace(nextActivePath, currentRootPath));
+          requestEditorFocus(
+            useSessionStore.getState().hasDocumentScroll(nextActivePath) ? "preserve" : "end",
+          );
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to remove note from Glyph");
@@ -549,13 +835,12 @@ export const useDesktopAppController = (
     },
     [
       activeFile?.path,
-      draftContent,
-      glyph,
-      isDirty,
-      markSaved,
+      closeTab,
+      getTabByPath,
+      persistNoteDraft,
       removeHistoryPath,
+      requestEditorFocus,
       saveSettings,
-      setActiveFile,
       setError,
       settings?.hiddenFiles,
       settings?.pinnedFiles,
@@ -575,14 +860,14 @@ export const useDesktopAppController = (
         );
         replaceHistoryPath(filePath, renamedFile.path);
         await syncTrackedPaths(filePath, renamedFile.path);
-        if (activeFile?.path === filePath) {
-          setActiveFile(renamedFile);
+        if (getTabByPath(filePath)) {
+          replaceTabPath(filePath, renamedFile);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to rename file");
       }
     },
-    [activeFile?.path, glyph, replaceHistoryPath, setActiveFile, setError, syncTrackedPaths],
+    [getTabByPath, glyph, replaceHistoryPath, replaceTabPath, setError, syncTrackedPaths],
   );
 
   const handleRenameFolder = useCallback(
@@ -594,21 +879,15 @@ export const useDesktopAppController = (
       try {
         const { oldPath, newPath } = await glyph.renameFolder(folderPath, newName);
         setSidebarNodes((prev) => renameSidebarFolder(prev, oldPath, newPath, newName));
-
-        // Remap active file path if it was inside the renamed folder
-        if (activeFile && isFileInsideWorkspace(activeFile.path, oldPath)) {
-          const newFilePath =
-            newPath + normalizePath(activeFile.path).slice(normalizePath(oldPath).length);
-          try {
-            const refreshedFile = await glyph.readFile(newFilePath);
-            setActiveFile(refreshedFile);
-            replaceHistoryPath(activeFile.path, newFilePath);
-          } catch {
-            // File may be temporarily inaccessible — clear active file
-            setActiveFile(null);
-            removeHistoryPath(activeFile.path);
-          }
-        }
+        const remappedTabs = noteTabs.filter((tab) =>
+          isFileInsideWorkspace(tab.file.path, oldPath),
+        );
+        remappedTabs.forEach((tab) => {
+          const nextFilePath =
+            newPath + normalizePath(tab.file.path).slice(normalizePath(oldPath).length);
+          replaceHistoryPath(tab.file.path, nextFilePath);
+        });
+        remapTabsForFolderRename(oldPath, newPath);
 
         // If the renamed folder was the workspace root, reopen to restart the watcher
         if (rootPath && isSamePath(rootPath, oldPath)) {
@@ -622,12 +901,11 @@ export const useDesktopAppController = (
       }
     },
     [
-      activeFile,
       glyph,
-      removeHistoryPath,
+      noteTabs,
       replaceHistoryPath,
+      remapTabsForFolderRename,
       rootPath,
-      setActiveFile,
       setError,
       syncWorkspace,
     ],
@@ -850,6 +1128,15 @@ export const useDesktopAppController = (
         onSelect: () => void createNote(),
       },
       {
+        id: "new-tab",
+        title: "New tab",
+        subtitle: "Create a new note in its own tab",
+        shortcut: getShortcutDisplay(shortcuts, "new-tab"),
+        section: "Tabs",
+        kind: "command",
+        onSelect: () => void createNote(),
+      },
+      {
         id: "new-folder",
         title: "New folder",
         subtitle: "Create a new folder in the current directory",
@@ -941,6 +1228,37 @@ export const useDesktopAppController = (
           setIsPaletteOpen(false);
         },
       },
+      ...(activeFile
+        ? [
+            {
+              id: "close-tab",
+              title: "Close Current Tab",
+              subtitle: "Close the current note tab",
+              shortcut: getShortcutDisplay(shortcuts, "close-tab"),
+              section: "Tabs",
+              kind: "command" as const,
+              onSelect: () => {
+                void closeNoteTab(activeFile.path);
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
+      ...(activeFile && noteTabs.length > 1
+        ? [
+            {
+              id: "close-other-tabs",
+              title: "Close Other Tabs",
+              subtitle: "Keep only the current note open",
+              section: "Tabs",
+              kind: "command" as const,
+              onSelect: () => {
+                void closeOtherNoteTabs(activeFile.path);
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
       {
         id: "toggle-focus-mode",
         title: isFocusMode ? "Exit Focus Mode" : "Enter Focus Mode",
@@ -1014,9 +1332,25 @@ export const useDesktopAppController = (
           setIsPaletteOpen(false);
         },
       },
+      ...noteTabs.map((tab, index) => ({
+        id: `open-tab-${tab.id}`,
+        title: isSamePath(tab.file.path, activeFile?.path)
+          ? `${tab.file.name} (current)`
+          : tab.file.name,
+        subtitle: getRelativePath(tab.file.path, rootPath),
+        shortcut: getTabSwitchShortcutLabel(index),
+        section: "Open Tabs",
+        kind: "command" as const,
+        onSelect: () => {
+          void activateNoteTab(tab.file.path, { recordHistory: true });
+        },
+      })),
     ],
     [
       activeFile,
+      activateNoteTab,
+      closeNoteTab,
+      closeOtherNoteTabs,
       createNote,
       createFolder,
       glyph,
@@ -1024,6 +1358,8 @@ export const useDesktopAppController = (
       isFocusMode,
       navigateBack,
       navigateForward,
+      noteTabs,
+      rootPath,
       saveSettings,
       shortcuts,
       showOutline,
@@ -1059,12 +1395,35 @@ export const useDesktopAppController = (
     glyph,
     shortcuts,
     activeFile,
-    draftContent,
-    markSaved,
-    setError,
-    setSaving,
+    saveActiveNote: async () => {
+      const activeTab = getActiveTab();
+      if (!activeTab) {
+        return;
+      }
+
+      await persistNoteDraft(
+        {
+          draftContent: activeTab.draftContent,
+          file: activeTab.file,
+          isDirty: activeTab.isDirty,
+        },
+        {
+          isActive: true,
+          restoreFocus: true,
+        },
+      );
+    },
     createNote,
+    createTab: createNote,
     createFolder,
+    closeActiveTab: async () => {
+      if (!activeFile) {
+        return;
+      }
+
+      await closeNoteTab(activeFile.path);
+    },
+    activateTabByIndex,
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,
@@ -1134,6 +1493,17 @@ export const useDesktopAppController = (
           return null;
         }
       };
+      const restoredTabPaths = Array.from(
+        new Set(
+          (initialTabPaths.length > 0
+            ? initialTabPaths
+            : initialFilePath
+              ? [initialFilePath]
+              : []
+          ).map((path) => normalizePath(path)),
+        ),
+      );
+      const restoredActivePath = initialFilePath ? normalizePath(initialFilePath) : null;
 
       const target = await glyph.getPendingExternalPath();
       if (target) {
@@ -1152,7 +1522,11 @@ export const useDesktopAppController = (
         } else {
           const workspace = await tryOpenWorkspace(null);
           if (workspace) {
-            setWorkspace(workspace);
+            setWorkspace({
+              rootPath: workspace.rootPath,
+              tree: workspace.tree,
+              activeFile: null,
+            });
             nextSidebarNodes = upsertSidebarFolder(nextSidebarNodes, workspace);
             nextExpandedFolders.add(workspace.rootPath);
           }
@@ -1175,24 +1549,57 @@ export const useDesktopAppController = (
       } else {
         const workspace = await tryOpenWorkspace(initialWorkspacePath);
         if (workspace) {
-          setWorkspace(workspace);
+          setWorkspace({
+            rootPath: workspace.rootPath,
+            tree: workspace.tree,
+            activeFile: restoredTabPaths.length > 0 ? null : workspace.activeFile,
+          });
           setIsWorkspaceMode(true);
           nextSidebarNodes = upsertSidebarFolder(nextSidebarNodes, workspace);
-          if (workspace.activeFile) {
+          if (restoredTabPaths.length === 0 && workspace.activeFile) {
             nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, workspace.activeFile);
+            pushHistory(workspace.activeFile.path);
             bootFocusMode = "end";
           }
           nextExpandedFolders.add(workspace.rootPath);
         }
 
-        const restoredFile = await tryReadPersistedFile(initialFilePath);
-        if (restoredFile) {
-          setActiveFile(restoredFile);
-          setIsWorkspaceMode(
-            Boolean(workspace && isFileInsideWorkspace(restoredFile.path, workspace.rootPath)),
-          );
-          nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, restoredFile);
-          bootFocusMode = "preserve";
+        if (restoredTabPaths.length > 0) {
+          const orderedRestorePaths = restoredActivePath
+            ? [
+                restoredActivePath,
+                ...restoredTabPaths.filter((path) => !isSamePath(path, restoredActivePath)),
+              ]
+            : restoredTabPaths;
+          let restoredActiveFile: FileDocument | null = null;
+
+          for (const restorePath of orderedRestorePaths) {
+            const restoredFile = await tryReadPersistedFile(restorePath);
+            if (!restoredFile) {
+              continue;
+            }
+
+            setActiveFile(restoredFile);
+            setIsWorkspaceMode(
+              Boolean(workspace && isFileInsideWorkspace(restoredFile.path, workspace.rootPath)),
+            );
+            nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, restoredFile);
+
+            if (!restoredActiveFile || isSamePath(restoredFile.path, restoredActivePath)) {
+              restoredActiveFile = restoredFile;
+            }
+          }
+
+          if (restoredActiveFile) {
+            setActiveFile(restoredActiveFile);
+            setIsWorkspaceMode(
+              Boolean(
+                workspace && isFileInsideWorkspace(restoredActiveFile.path, workspace.rootPath),
+              ),
+            );
+            pushHistory(restoredActiveFile.path);
+            bootFocusMode = "preserve";
+          }
         }
       }
 
@@ -1262,17 +1669,26 @@ export const useDesktopAppController = (
           }),
         );
 
-        if (activeFile && changedPaths.includes(activeFile.path) && !isDirty) {
-          try {
-            const refreshedFile = await glyph.readFile(activeFile.path);
-            updateActiveFile(refreshedFile);
-          } catch {
-            // Ignore transient external FS races (file renamed/deleted).
-          }
-        }
+        const changedOpenTabs = noteTabs.filter((tab) =>
+          changedPaths.some((changedPath) => isSamePath(changedPath, tab.file.path)),
+        );
+        await Promise.all(
+          changedOpenTabs.map(async (tab) => {
+            if (tab.isDirty) {
+              return;
+            }
+
+            try {
+              const refreshedFile = await glyph.readFile(tab.file.path);
+              updateActiveFile(refreshedFile);
+            } catch {
+              // Ignore transient external FS races (file renamed/deleted).
+            }
+          }),
+        );
       },
     );
-  }, [activeFile?.path, isDirty, updateActiveFile, setTree, glyph]);
+  }, [glyph, noteTabs, updateActiveFile, setTree]);
 
   // Auto-save draft content
   useEffect(() => {
@@ -1280,50 +1696,27 @@ export const useDesktopAppController = (
       return;
     }
 
+    const activeTab = getActiveTab();
+    if (!activeTab) {
+      return;
+    }
+
     const timer = window.setTimeout(async () => {
-      setSaving(true);
-      try {
-        let currentPath = activeFile.path;
-        let finalFile = activeFile;
-        const isUntitled = activeFile.name.startsWith("Untitled-");
-        const committedFileName = getCommittedDraftFileName(draftContent);
-
-        if (isUntitled && committedFileName) {
-          const previousPath = currentPath;
-          finalFile = await glyph.renameFile(currentPath, committedFileName);
-          setSidebarNodes((prev) =>
-            upsertSidebarFile(renameSidebarFile(prev, currentPath, finalFile), finalFile),
-          );
-          currentPath = finalFile.path;
-          updateActiveFile(finalFile);
-          replaceHistoryPath(previousPath, finalFile.path);
-          await syncTrackedPaths(previousPath, finalFile.path);
-          requestEditorFocus("preserve");
-        }
-
-        const savedFile = await glyph.saveFile(currentPath, draftContent);
-        markSaved(savedFile);
-      } catch (saveError) {
-        setError(saveError instanceof Error ? saveError.message : "Unable to save file.");
-      } finally {
-        setSaving(false);
-      }
+      await persistNoteDraft(
+        {
+          draftContent: activeTab.draftContent,
+          file: activeTab.file,
+          isDirty: activeTab.isDirty,
+        },
+        {
+          isActive: true,
+          restoreFocus: true,
+        },
+      );
     }, 800);
 
     return () => window.clearTimeout(timer);
-  }, [
-    activeFile?.path,
-    draftContent,
-    glyph,
-    isDirty,
-    isSaving,
-    markSaved,
-    replaceHistoryPath,
-    requestEditorFocus,
-    setError,
-    setSaving,
-    syncTrackedPaths,
-  ]);
+  }, [activeFile?.path, getActiveTab, isDirty, isSaving, persistNoteDraft]);
 
   // Session sync
   useEffect(() => {
@@ -1331,8 +1724,12 @@ export const useDesktopAppController = (
       return;
     }
 
-    setNoteSession(rootPath || null, activeFile?.path ?? null);
-  }, [activeFile?.path, hasBooted, rootPath, sessionReady, setNoteSession]);
+    setNoteSession(
+      rootPath || null,
+      noteTabs.map((tab) => tab.file.path),
+      activeFile?.path ?? null,
+    );
+  }, [activeFile?.path, hasBooted, noteTabs, rootPath, sessionReady, setNoteSession]);
 
   const requestOutlineJump = useCallback((id: string) => {
     setOutlineJumpRequest({
@@ -1432,25 +1829,31 @@ export const useDesktopAppController = (
       }
 
       if (command === "save" && activeFile) {
-        setSaving(true);
-        try {
-          const savedFile = await glyph.saveFile(activeFile.path, draftContent);
-          markSaved(savedFile);
-        } catch (saveError) {
-          console.error("Menu save failed:", saveError);
-          setError(getErrorMessage(saveError));
-        } finally {
-          setSaving(false);
+        const activeTab = getActiveTab();
+        if (!activeTab) {
+          return;
         }
+
+        await persistNoteDraft(
+          {
+            draftContent: activeTab.draftContent,
+            file: activeTab.file,
+            isDirty: activeTab.isDirty,
+          },
+          {
+            isActive: true,
+            restoreFocus: true,
+          },
+        );
       }
     });
   }, [
     activeFile,
     createNote,
     draftContent,
-    markSaved,
+    getActiveTab,
+    persistNoteDraft,
     setError,
-    setSaving,
     syncOpenedFile,
     syncWorkspace,
     glyph,
@@ -1463,6 +1866,7 @@ export const useDesktopAppController = (
   return {
     activeFile,
     appInfo,
+    activeTabId,
     breadcrumbs,
     canGoBack,
     canGoForward,
@@ -1470,6 +1874,8 @@ export const useDesktopAppController = (
     changeThemeMode,
     chooseFolderAndUpdateWorkspace,
     clearOutlineJumpRequest,
+    closeNoteTab,
+    closeOtherNoteTabs,
     createNote,
     createFolder,
     draftContent,
@@ -1492,8 +1898,11 @@ export const useDesktopAppController = (
     isSettingsOpen,
     isSidebarCollapsed,
     markSaved,
+    noteTabs,
     navigateBack,
     navigateForward,
+    activateNoteTab,
+    activateTabByIndex,
     openFile,
     outlineItems,
     outlineJumpRequest,

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import type { BreadcrumbItem, OutlineItem } from "@/types/navigation";
 
-import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
+import {
+  getAdjacentTabShortcutDisplay,
+  getDirectTabShortcutDisplay,
+  getDirectTabTargetIndex,
+  getShortcutDisplay,
+} from "@/shared/shortcuts";
 import type { DirectoryNode, FileDocument, TabMovePosition } from "@/shared/workspace";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
@@ -511,7 +516,12 @@ export const useDesktopAppController = (
 
   const activateTabByIndex = useCallback(
     async (index: number) => {
-      const targetTab = noteTabs[index];
+      const targetIndex = getDirectTabTargetIndex(index, noteTabs.length);
+      if (targetIndex === null) {
+        return;
+      }
+
+      const targetTab = noteTabs[targetIndex];
       if (!targetTab) {
         return;
       }
@@ -519,6 +529,28 @@ export const useDesktopAppController = (
       await activateNoteTab(targetTab.file.path, { recordHistory: true });
     },
     [activateNoteTab, noteTabs],
+  );
+
+  const activateAdjacentNoteTab = useCallback(
+    async (direction: -1 | 1) => {
+      if (noteTabs.length <= 1 || !activeTabId) {
+        return;
+      }
+
+      const currentIndex = noteTabs.findIndex((tab) => tab.id === activeTabId);
+      if (currentIndex < 0) {
+        return;
+      }
+
+      const targetIndex = (currentIndex + direction + noteTabs.length) % noteTabs.length;
+      const targetTab = noteTabs[targetIndex];
+      if (!targetTab) {
+        return;
+      }
+
+      await activateNoteTab(targetTab.file.path, { recordHistory: true });
+    },
+    [activateNoteTab, activeTabId, noteTabs],
   );
 
   const openFile = useCallback(
@@ -1242,6 +1274,34 @@ export const useDesktopAppController = (
           setIsPaletteOpen(false);
         },
       },
+      ...(noteTabs.length > 1
+        ? [
+            {
+              id: "previous-tab",
+              title: "Previous Tab",
+              subtitle: "Move to the previous open note tab",
+              shortcut: getAdjacentTabShortcutDisplay("previous", appInfo?.platform),
+              section: "Tabs",
+              kind: "command" as const,
+              onSelect: () => {
+                void activateAdjacentNoteTab(-1);
+                setIsPaletteOpen(false);
+              },
+            },
+            {
+              id: "next-tab",
+              title: "Next Tab",
+              subtitle: "Move to the next open note tab",
+              shortcut: getAdjacentTabShortcutDisplay("next", appInfo?.platform),
+              section: "Tabs",
+              kind: "command" as const,
+              onSelect: () => {
+                void activateAdjacentNoteTab(1);
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
       ...(activeFile
         ? [
             {
@@ -1359,7 +1419,7 @@ export const useDesktopAppController = (
           ? `${tab.file.name} (current)`
           : tab.file.name,
         subtitle: getRelativePath(tab.file.path, rootPath),
-        shortcut: getDirectTabShortcutDisplay(index, appInfo?.platform),
+        shortcut: getDirectTabShortcutDisplay(index, noteTabs.length, appInfo?.platform),
         section: "Open Tabs",
         kind: "command" as const,
         onSelect: () => {
@@ -1369,6 +1429,7 @@ export const useDesktopAppController = (
     ],
     [
       activeFile,
+      activateAdjacentNoteTab,
       activateNoteTab,
       appInfo?.platform,
       closeNoteTab,
@@ -1454,6 +1515,12 @@ export const useDesktopAppController = (
       await closeOtherNoteTabs(currentActiveTab.file.path);
     },
     activateTabByIndex,
+    activateNextTab: async () => {
+      await activateAdjacentNoteTab(1);
+    },
+    activatePreviousTab: async () => {
+      await activateAdjacentNoteTab(-1);
+    },
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,
@@ -1860,6 +1927,16 @@ export const useDesktopAppController = (
         return;
       }
 
+      if (command === "next-tab") {
+        await activateAdjacentNoteTab(1);
+        return;
+      }
+
+      if (command === "previous-tab") {
+        await activateAdjacentNoteTab(-1);
+        return;
+      }
+
       if (command === "open-file") {
         const file = await glyph.openDocument();
         if (file) {
@@ -1899,6 +1976,7 @@ export const useDesktopAppController = (
   }, [
     activeFile,
     closeNoteTab,
+    activateAdjacentNoteTab,
     createNote,
     draftContent,
     getActiveTab,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -9,9 +9,9 @@ type UseKeyboardShortcutsOptions = {
   activeFile: FileDocument | null;
   saveActiveNote: () => Promise<void>;
   createNote: () => Promise<void>;
-  createTab: () => Promise<void>;
   createFolder: () => Promise<void>;
   closeActiveTab: () => Promise<void>;
+  closeOtherTabs: () => Promise<void>;
   activateTabByIndex: (index: number) => Promise<void>;
   syncOpenedFile: (file: FileDocument, options?: { recordHistory?: boolean }) => Promise<void>;
   syncWorkspace: (workspace: WorkspaceSnapshot) => void;
@@ -33,9 +33,9 @@ export function useKeyboardShortcuts({
   activeFile,
   saveActiveNote,
   createNote,
-  createTab,
   createFolder,
   closeActiveTab,
+  closeOtherTabs,
   activateTabByIndex,
   syncOpenedFile,
   syncWorkspace,
@@ -95,9 +95,9 @@ export function useKeyboardShortcuts({
         "focus-mode",
         "check-updates",
         "new-note",
-        "new-tab",
         "new-folder",
         "close-tab",
+        "close-other-tabs",
       ]);
       const globalShortcut = shortcuts.find(
         (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys),
@@ -129,14 +129,14 @@ export function useKeyboardShortcuts({
           case "new-note":
             void createNote();
             break;
-          case "new-tab":
-            void createTab();
-            break;
           case "new-folder":
             void createFolder();
             break;
           case "close-tab":
             void closeActiveTab();
+            break;
+          case "close-other-tabs":
+            void closeOtherTabs();
             break;
         }
         return;
@@ -204,9 +204,9 @@ export function useKeyboardShortcuts({
     saveActiveNote,
     glyph,
     createNote,
-    createTab,
     createFolder,
     closeActiveTab,
+    closeOtherTabs,
     activateTabByIndex,
     syncOpenedFile,
     syncWorkspace,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { matchAdjacentTabShortcut, matchShortcut } from "@/shared/shortcuts";
+import { matchShortcut } from "@/shared/shortcuts";
 import type { FileDocument, ShortcutSetting, WorkspaceSnapshot } from "@/shared/workspace";
 
 type UseKeyboardShortcutsOptions = {
@@ -94,22 +94,34 @@ export function useKeyboardShortcuts({
         return;
       }
 
-      const currentPlatform = typeof navigator === "undefined" ? undefined : navigator.platform;
-      if (
+      const isPreviousBracketShortcut =
+        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ [");
+      const isNextBracketShortcut =
+        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ ]");
+      const isPreviousCtrlTabShortcut =
         !hasConfiguredShortcutMatch &&
+        event.ctrlKey &&
+        !event.metaKey &&
         !event.altKey &&
-        matchAdjacentTabShortcut(event, "previous", currentPlatform)
-      ) {
+        event.shiftKey &&
+        !event.repeat &&
+        event.key === "Tab";
+      const isNextCtrlTabShortcut =
+        !hasConfiguredShortcutMatch &&
+        event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        !event.repeat &&
+        event.key === "Tab";
+
+      if (!hasConfiguredShortcutMatch && (isPreviousBracketShortcut || isPreviousCtrlTabShortcut)) {
         event.preventDefault();
         void activatePreviousTab();
         return;
       }
 
-      if (
-        !hasConfiguredShortcutMatch &&
-        !event.altKey &&
-        matchAdjacentTabShortcut(event, "next", currentPlatform)
-      ) {
+      if (!hasConfiguredShortcutMatch && (isNextBracketShortcut || isNextCtrlTabShortcut)) {
         event.preventDefault();
         void activateNextTab();
         return;

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { matchShortcut } from "@/shared/shortcuts";
+import { matchAdjacentTabShortcut, matchShortcut } from "@/shared/shortcuts";
 import type { FileDocument, ShortcutSetting, WorkspaceSnapshot } from "@/shared/workspace";
 
 type UseKeyboardShortcutsOptions = {
@@ -13,6 +13,8 @@ type UseKeyboardShortcutsOptions = {
   closeActiveTab: () => Promise<void>;
   closeOtherTabs: () => Promise<void>;
   activateTabByIndex: (index: number) => Promise<void>;
+  activateNextTab: () => Promise<void>;
+  activatePreviousTab: () => Promise<void>;
   syncOpenedFile: (file: FileDocument, options?: { recordHistory?: boolean }) => Promise<void>;
   syncWorkspace: (workspace: WorkspaceSnapshot) => void;
   setIsWorkspaceMode: React.Dispatch<React.SetStateAction<boolean>>;
@@ -37,6 +39,8 @@ export function useKeyboardShortcuts({
   closeActiveTab,
   closeOtherTabs,
   activateTabByIndex,
+  activateNextTab,
+  activatePreviousTab,
   syncOpenedFile,
   syncWorkspace,
   setIsWorkspaceMode,
@@ -87,6 +91,27 @@ export function useKeyboardShortcuts({
       ) {
         event.preventDefault();
         void activateTabByIndex(Number(event.key) - 1);
+        return;
+      }
+
+      const currentPlatform = typeof navigator === "undefined" ? undefined : navigator.platform;
+      if (
+        !hasConfiguredShortcutMatch &&
+        !event.altKey &&
+        matchAdjacentTabShortcut(event, "previous", currentPlatform)
+      ) {
+        event.preventDefault();
+        void activatePreviousTab();
+        return;
+      }
+
+      if (
+        !hasConfiguredShortcutMatch &&
+        !event.altKey &&
+        matchAdjacentTabShortcut(event, "next", currentPlatform)
+      ) {
+        event.preventDefault();
+        void activateNextTab();
         return;
       }
 
@@ -212,6 +237,8 @@ export function useKeyboardShortcuts({
     closeActiveTab,
     closeOtherTabs,
     activateTabByIndex,
+    activateNextTab,
+    activatePreviousTab,
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -73,8 +73,12 @@ export function useKeyboardShortcuts({
         }
       }
 
+      const hasConfiguredShortcutMatch = shortcuts.some((entry) =>
+        matchShortcut(event, entry.keys),
+      );
       const primaryPressed = event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
       if (
+        !hasConfiguredShortcutMatch &&
         primaryPressed &&
         !event.altKey &&
         !event.shiftKey &&

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -3,18 +3,16 @@ import { useEffect } from "react";
 import { matchShortcut } from "@/shared/shortcuts";
 import type { FileDocument, ShortcutSetting, WorkspaceSnapshot } from "@/shared/workspace";
 
-import { getErrorMessage } from "@/lib/errors";
-
 type UseKeyboardShortcutsOptions = {
   glyph: NonNullable<Window["glyph"]>;
   shortcuts: ShortcutSetting[];
   activeFile: FileDocument | null;
-  draftContent: string;
-  markSaved: (file: FileDocument) => void;
-  setError: (message: string | null) => void;
-  setSaving: (isSaving: boolean) => void;
+  saveActiveNote: () => Promise<void>;
   createNote: () => Promise<void>;
+  createTab: () => Promise<void>;
   createFolder: () => Promise<void>;
+  closeActiveTab: () => Promise<void>;
+  activateTabByIndex: (index: number) => Promise<void>;
   syncOpenedFile: (file: FileDocument, options?: { recordHistory?: boolean }) => Promise<void>;
   syncWorkspace: (workspace: WorkspaceSnapshot) => void;
   setIsWorkspaceMode: React.Dispatch<React.SetStateAction<boolean>>;
@@ -33,12 +31,12 @@ export function useKeyboardShortcuts({
   glyph,
   shortcuts,
   activeFile,
-  draftContent,
-  markSaved,
-  setError,
-  setSaving,
+  saveActiveNote,
   createNote,
+  createTab,
   createFolder,
+  closeActiveTab,
+  activateTabByIndex,
   syncOpenedFile,
   syncWorkspace,
   setIsWorkspaceMode,
@@ -75,6 +73,19 @@ export function useKeyboardShortcuts({
         }
       }
 
+      const primaryPressed = event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
+      if (
+        primaryPressed &&
+        !event.altKey &&
+        !event.shiftKey &&
+        !event.repeat &&
+        /^[1-9]$/.test(event.key)
+      ) {
+        event.preventDefault();
+        void activateTabByIndex(Number(event.key) - 1);
+        return;
+      }
+
       const globalShortcutIds = new Set([
         "toggle-sidebar",
         "command-palette",
@@ -84,7 +95,9 @@ export function useKeyboardShortcuts({
         "focus-mode",
         "check-updates",
         "new-note",
+        "new-tab",
         "new-folder",
+        "close-tab",
       ]);
       const globalShortcut = shortcuts.find(
         (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys),
@@ -116,8 +129,14 @@ export function useKeyboardShortcuts({
           case "new-note":
             void createNote();
             break;
+          case "new-tab":
+            void createTab();
+            break;
           case "new-folder":
             void createFolder();
+            break;
+          case "close-tab":
+            void closeActiveTab();
             break;
         }
         return;
@@ -131,16 +150,7 @@ export function useKeyboardShortcuts({
 
         if (saveShortcut && activeFile) {
           event.preventDefault();
-          setSaving(true);
-          try {
-            const savedFile = await glyph.saveFile(activeFile.path, draftContent);
-            markSaved(savedFile);
-          } catch (saveError) {
-            console.error("Manual save failed:", saveError);
-            setError(getErrorMessage(saveError));
-          } finally {
-            setSaving(false);
-          }
+          await saveActiveNote();
           return;
         }
       }
@@ -177,16 +187,7 @@ export function useKeyboardShortcuts({
             }
             case "save":
               if (activeFile) {
-                setSaving(true);
-                try {
-                  const savedFile = await glyph.saveFile(activeFile.path, draftContent);
-                  markSaved(savedFile);
-                } catch (saveError) {
-                  console.error("Manual save failed:", saveError);
-                  setError(getErrorMessage(saveError));
-                } finally {
-                  setSaving(false);
-                }
+                await saveActiveNote();
               }
               break;
           }
@@ -200,13 +201,13 @@ export function useKeyboardShortcuts({
   }, [
     shortcuts,
     activeFile,
-    draftContent,
-    markSaved,
-    setError,
-    setSaving,
+    saveActiveNote,
     glyph,
     createNote,
+    createTab,
     createFolder,
+    closeActiveTab,
+    activateTabByIndex,
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -70,12 +70,80 @@ export function getPrimaryShortcutPrefix(platform?: string): string {
     : MODIFIER_TOKENS.ctrl;
 }
 
-export function getDirectTabShortcutDisplay(index: number, platform?: string): string | undefined {
-  if (index < 0 || index > 8) {
+export const MAX_DIRECT_NOTE_TAB_SHORTCUTS = 9;
+
+export function getDirectTabShortcutDisplay(
+  index: number,
+  totalTabs: number,
+  platform?: string,
+): string | undefined {
+  if (index < 0 || totalTabs <= 0) {
     return undefined;
   }
 
-  return `${getPrimaryShortcutPrefix(platform)}${index + 1}`;
+  if (totalTabs <= MAX_DIRECT_NOTE_TAB_SHORTCUTS) {
+    if (index >= totalTabs) {
+      return undefined;
+    }
+
+    return `${getPrimaryShortcutPrefix(platform)}${index + 1}`;
+  }
+
+  if (index < MAX_DIRECT_NOTE_TAB_SHORTCUTS - 1) {
+    return `${getPrimaryShortcutPrefix(platform)}${index + 1}`;
+  }
+
+  if (index === totalTabs - 1) {
+    return `${getPrimaryShortcutPrefix(platform)}${MAX_DIRECT_NOTE_TAB_SHORTCUTS}`;
+  }
+
+  return undefined;
+}
+
+export function getDirectTabTargetIndex(requestedIndex: number, totalTabs: number): number | null {
+  if (requestedIndex < 0 || totalTabs <= 0) {
+    return null;
+  }
+
+  if (totalTabs <= MAX_DIRECT_NOTE_TAB_SHORTCUTS) {
+    return requestedIndex < totalTabs ? requestedIndex : null;
+  }
+
+  if (requestedIndex < MAX_DIRECT_NOTE_TAB_SHORTCUTS - 1) {
+    return requestedIndex;
+  }
+
+  return requestedIndex === MAX_DIRECT_NOTE_TAB_SHORTCUTS - 1 ? totalTabs - 1 : null;
+}
+
+export function getAdjacentTabShortcutDisplay(
+  direction: "next" | "previous",
+  platform?: string,
+): string {
+  const normalizedPlatform = platform?.toLowerCase() ?? "";
+  const isMacPlatform = normalizedPlatform.includes("mac") || normalizedPlatform === "darwin";
+
+  if (isMacPlatform) {
+    return direction === "next" ? "⇧⌘]" : "⇧⌘[";
+  }
+
+  return direction === "next" ? "Ctrl+Tab" : "Ctrl+Shift+Tab";
+}
+
+export function matchAdjacentTabShortcut(
+  event: ShortcutEventLike,
+  direction: "next" | "previous",
+  platform?: string,
+): boolean {
+  const normalizedPlatform = platform?.toLowerCase() ?? "";
+  const isMacPlatform = normalizedPlatform.includes("mac") || normalizedPlatform === "darwin";
+
+  return matchShortcut(
+    event,
+    isMacPlatform
+      ? `⇧ ⌘ ${direction === "next" ? "]" : "["}`
+      : `${direction === "next" ? "⌘ Tab" : "⇧ ⌘ Tab"}`,
+  );
 }
 
 const MODIFIER_TOKENS_SET = new Set(Object.values(MODIFIER_TOKENS));

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -3,9 +3,9 @@ import type { ShortcutSetting } from "./workspace.js";
 export type ShortcutId =
   | "command-palette"
   | "new-note"
-  | "new-tab"
   | "new-folder"
   | "close-tab"
+  | "close-other-tabs"
   | "open-file"
   | "open-folder"
   | "check-updates"
@@ -41,9 +41,9 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   // App shortcuts (fire globally, even from inside the editor)
   { id: "command-palette", label: "Command Palette", keys: "⌘ P" },
   { id: "new-note", label: "New Note", keys: "⌘ N" },
-  { id: "new-tab", label: "New Tab", keys: "⌘ T" },
   { id: "new-folder", label: "New Folder", keys: "⇧ ⌘ N" },
   { id: "close-tab", label: "Close Tab", keys: "⌘ W" },
+  { id: "close-other-tabs", label: "Close Other Tabs", keys: "⌥ ⌘ W" },
   { id: "open-file", label: "Open File", keys: "⌘ O" },
   { id: "open-folder", label: "Open Folder", keys: "⇧ ⌘ O" },
   { id: "check-updates", label: "Update Action", keys: "⇧ ⌘ U" },
@@ -60,6 +60,22 @@ export const MODIFIER_TOKENS = {
   alt: "⌥",
   shift: "⇧",
 } as const;
+
+export function getPrimaryShortcutPrefix(platform?: string): string {
+  const normalizedPlatform = platform?.toLowerCase() ?? "";
+
+  return normalizedPlatform.includes("mac") || normalizedPlatform === "darwin"
+    ? MODIFIER_TOKENS.cmdOrCtrl
+    : "Ctrl+";
+}
+
+export function getDirectTabShortcutDisplay(index: number, platform?: string): string | undefined {
+  if (index < 0 || index > 8) {
+    return undefined;
+  }
+
+  return `${getPrimaryShortcutPrefix(platform)}${index + 1}`;
+}
 
 const MODIFIER_TOKENS_SET = new Set(Object.values(MODIFIER_TOKENS));
 

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -3,7 +3,9 @@ import type { ShortcutSetting } from "./workspace.js";
 export type ShortcutId =
   | "command-palette"
   | "new-note"
+  | "new-tab"
   | "new-folder"
+  | "close-tab"
   | "open-file"
   | "open-folder"
   | "check-updates"
@@ -39,7 +41,9 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   // App shortcuts (fire globally, even from inside the editor)
   { id: "command-palette", label: "Command Palette", keys: "⌘ P" },
   { id: "new-note", label: "New Note", keys: "⌘ N" },
+  { id: "new-tab", label: "New Tab", keys: "⌘ T" },
   { id: "new-folder", label: "New Folder", keys: "⇧ ⌘ N" },
+  { id: "close-tab", label: "Close Tab", keys: "⌘ W" },
   { id: "open-file", label: "Open File", keys: "⌘ O" },
   { id: "open-folder", label: "Open Folder", keys: "⇧ ⌘ O" },
   { id: "check-updates", label: "Update Action", keys: "⇧ ⌘ U" },

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -43,7 +43,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "new-note", label: "New Note", keys: "⌘ N" },
   { id: "new-folder", label: "New Folder", keys: "⇧ ⌘ N" },
   { id: "close-tab", label: "Close Tab", keys: "⌘ W" },
-  { id: "close-other-tabs", label: "Close Other Tabs", keys: "⌥ ⌘ W" },
+  { id: "close-other-tabs", label: "Close Other Tabs", keys: "⇧ ⌘ W" },
   { id: "open-file", label: "Open File", keys: "⌘ O" },
   { id: "open-folder", label: "Open Folder", keys: "⇧ ⌘ O" },
   { id: "check-updates", label: "Update Action", keys: "⇧ ⌘ U" },
@@ -226,6 +226,10 @@ const SHIFTED_SYMBOL_ALIASES: Record<string, string> = {
   "~": "`",
 };
 
+const LEGACY_SHORTCUT_MIGRATIONS: Partial<Record<ShortcutId, string[]>> = {
+  "close-other-tabs": ["⌥ ⌘ W"],
+};
+
 function normalizeShortcutKeyToken(token: string): string | null {
   const trimmed = token.trim();
 
@@ -308,10 +312,18 @@ export function mergeShortcutSettings(shortcuts?: ShortcutSetting[] | null): Sho
         (shortcut): shortcut is ShortcutSetting =>
           typeof shortcut?.id === "string" && typeof shortcut?.keys === "string",
       )
-      .map((shortcut) => [
-        shortcut.id,
-        canonicalizeShortcut(shortcut.keys) ?? shortcut.keys.trim(),
-      ]),
+      .map((shortcut) => {
+        const normalizedKeys = canonicalizeShortcut(shortcut.keys) ?? shortcut.keys.trim();
+        const shortcutId = shortcut.id as ShortcutId;
+        const legacyKeys = LEGACY_SHORTCUT_MIGRATIONS[shortcutId];
+
+        if (legacyKeys?.some((legacyKey) => canonicalizeShortcut(legacyKey) === normalizedKeys)) {
+          const migratedDefault = DEFAULT_SHORTCUTS.find((entry) => entry.id === shortcutId)?.keys;
+          return [shortcut.id, migratedDefault ?? normalizedKeys];
+        }
+
+        return [shortcut.id, normalizedKeys];
+      }),
   );
 
   return DEFAULT_SHORTCUTS.map((shortcut) => ({

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -57,6 +57,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
 
 export const MODIFIER_TOKENS = {
   cmdOrCtrl: "⌘",
+  ctrl: "Ctrl+",
   alt: "⌥",
   shift: "⇧",
 } as const;
@@ -66,7 +67,7 @@ export function getPrimaryShortcutPrefix(platform?: string): string {
 
   return normalizedPlatform.includes("mac") || normalizedPlatform === "darwin"
     ? MODIFIER_TOKENS.cmdOrCtrl
-    : "Ctrl+";
+    : MODIFIER_TOKENS.ctrl;
 }
 
 export function getDirectTabShortcutDisplay(index: number, platform?: string): string | undefined {

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -13,6 +13,8 @@ export type NoteTab = {
   lastSavedAt: number | null;
 };
 
+export type TabMovePosition = "before" | "after";
+
 export type FileNode = {
   type: "file";
   name: string;

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -138,6 +138,7 @@ export type AppCommand =
   | "save"
   | "new-file"
   | "new-folder"
+  | "close-tab"
   | "search"
   | "quick-open"
   | "toggle-sidebar"

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -141,6 +141,8 @@ export type AppCommand =
   | "new-file"
   | "new-folder"
   | "close-tab"
+  | "next-tab"
+  | "previous-tab"
   | "search"
   | "quick-open"
   | "toggle-sidebar"

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -4,6 +4,15 @@ export type FileDocument = {
   content: string;
 };
 
+export type NoteTab = {
+  id: string;
+  file: FileDocument;
+  draftContent: string;
+  isDirty: boolean;
+  isSaving: boolean;
+  lastSavedAt: number | null;
+};
+
 export type FileNode = {
   type: "file";
   name: string;

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -66,6 +66,9 @@ const normalizeUniquePaths = (paths: string[]) => {
   return normalizedPaths;
 };
 
+const arePathArraysEqual = (left: string[], right: string[]) =>
+  left.length === right.length && left.every((entry, index) => entry === right[index]);
+
 const trimScrollPositions = (positions: Record<string, ScrollEntry>) => {
   const entries = Object.entries(positions);
   if (entries.length <= MAX_SCROLL_ENTRIES) {
@@ -110,11 +113,21 @@ export const useSessionStore = create<SessionState>()(
         set({ selectedSkillCollectionId });
       },
       setNoteSession: (noteWorkspacePath, tabPaths, activeFilePath) => {
+        const normalizedWorkspacePath = noteWorkspacePath ? normalizePath(noteWorkspacePath) : null;
         const normalizedTabPaths = normalizeUniquePaths(tabPaths);
         const normalizedActivePath = activeFilePath ? normalizePath(activeFilePath) : null;
+        const currentState = get();
+
+        if (
+          currentState.noteWorkspacePath === normalizedWorkspacePath &&
+          currentState.noteFilePath === normalizedActivePath &&
+          arePathArraysEqual(currentState.noteTabPaths, normalizedTabPaths)
+        ) {
+          return;
+        }
 
         set({
-          noteWorkspacePath: noteWorkspacePath ? normalizePath(noteWorkspacePath) : null,
+          noteWorkspacePath: normalizedWorkspacePath,
           noteFilePath: normalizedActivePath,
           noteTabPaths: normalizedTabPaths,
         });

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -22,6 +22,7 @@ type SessionState = {
   selectedSkillCollectionId: string | null;
   noteWorkspacePath: string | null;
   noteFilePath: string | null;
+  noteTabPaths: string[];
   skillDocumentPath: string | null;
   skillDocumentKind: SkillDocumentKind;
   skillDocumentKindsById: Record<string, SkillDocumentKind>;
@@ -31,7 +32,11 @@ type SessionState = {
   setNotesExpanded: (value: boolean) => void;
   setSkillsExpanded: (value: boolean) => void;
   setSelectedSkillCollectionId: (value: string | null) => void;
-  setNoteSession: (workspacePath: string | null, filePath: string | null) => void;
+  setNoteSession: (
+    workspacePath: string | null,
+    tabPaths: string[],
+    activeFilePath: string | null,
+  ) => void;
   setSkillSession: (documentPath: string | null, documentKind: SkillDocumentKind) => void;
   setPreferredSkillDocumentKind: (skillId: string | null, documentKind: SkillDocumentKind) => void;
   getPreferredSkillDocumentKind: (skillId: string | null | undefined) => SkillDocumentKind | null;
@@ -42,6 +47,24 @@ type SessionState = {
 };
 
 const toScrollKey = (targetPath: string) => normalizePath(targetPath).toLowerCase();
+
+const normalizeUniquePaths = (paths: string[]) => {
+  const seenKeys = new Set<string>();
+  const normalizedPaths: string[] = [];
+
+  paths.forEach((path) => {
+    const normalizedPath = normalizePath(path);
+    const key = normalizedPath.toLowerCase();
+    if (seenKeys.has(key)) {
+      return;
+    }
+
+    seenKeys.add(key);
+    normalizedPaths.push(normalizedPath);
+  });
+
+  return normalizedPaths;
+};
 
 const trimScrollPositions = (positions: Record<string, ScrollEntry>) => {
   const entries = Object.entries(positions);
@@ -66,6 +89,7 @@ export const useSessionStore = create<SessionState>()(
       selectedSkillCollectionId: null,
       noteWorkspacePath: null,
       noteFilePath: null,
+      noteTabPaths: [],
       skillDocumentPath: null,
       skillDocumentKind: "skill",
       skillDocumentKindsById: {},
@@ -85,10 +109,14 @@ export const useSessionStore = create<SessionState>()(
       setSelectedSkillCollectionId: (selectedSkillCollectionId) => {
         set({ selectedSkillCollectionId });
       },
-      setNoteSession: (noteWorkspacePath, noteFilePath) => {
+      setNoteSession: (noteWorkspacePath, tabPaths, activeFilePath) => {
+        const normalizedTabPaths = normalizeUniquePaths(tabPaths);
+        const normalizedActivePath = activeFilePath ? normalizePath(activeFilePath) : null;
+
         set({
           noteWorkspacePath: noteWorkspacePath ? normalizePath(noteWorkspacePath) : null,
-          noteFilePath: noteFilePath ? normalizePath(noteFilePath) : null,
+          noteFilePath: normalizedActivePath,
+          noteTabPaths: normalizedTabPaths,
         });
       },
       setSkillSession: (skillDocumentPath, skillDocumentKind) => {
@@ -165,6 +193,7 @@ export const useSessionStore = create<SessionState>()(
         selectedSkillCollectionId: state.selectedSkillCollectionId,
         noteWorkspacePath: state.noteWorkspacePath,
         noteFilePath: state.noteFilePath,
+        noteTabPaths: state.noteTabPaths,
         skillDocumentPath: state.skillDocumentPath,
         skillDocumentKind: state.skillDocumentKind,
         skillDocumentKindsById: state.skillDocumentKindsById,

--- a/apps/desktop/src/store/workspace.ts
+++ b/apps/desktop/src/store/workspace.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 
-import { isSamePath } from "@/lib/paths";
+import { getBaseName, isPathInside, isSamePath, normalizePath } from "@/lib/paths";
 
-import type { DirectoryNode, FileDocument } from "../shared/workspace";
+import type { DirectoryNode, FileDocument, NoteTab } from "../shared/workspace";
 
 const getClosestHistoryIndex = (history: string[], currentIndex: number, filePath: string) => {
   let closestIndex = -1;
@@ -23,16 +23,73 @@ const getClosestHistoryIndex = (history: string[], currentIndex: number, filePat
   return closestIndex;
 };
 
+const toTabId = (path: string) => normalizePath(path).toLowerCase();
+
+type ActiveSurfaceSnapshot = {
+  activeFile: FileDocument | null;
+  draftContent: string;
+  isDirty: boolean;
+  isSaving: boolean;
+  lastSavedAt: number | null;
+};
+
+const EMPTY_ACTIVE_SURFACE: ActiveSurfaceSnapshot = {
+  activeFile: null,
+  draftContent: "",
+  isDirty: false,
+  isSaving: false,
+  lastSavedAt: null,
+};
+
+const createNoteTab = (
+  file: FileDocument,
+  overrides?: Partial<Omit<NoteTab, "file" | "id">>,
+): NoteTab => ({
+  id: toTabId(file.path),
+  file,
+  draftContent: overrides?.draftContent ?? file.content,
+  isDirty: overrides?.isDirty ?? false,
+  isSaving: overrides?.isSaving ?? false,
+  lastSavedAt: overrides?.lastSavedAt ?? Date.now(),
+});
+
+const getNoteTabIndex = (noteTabs: NoteTab[], filePath: string) =>
+  noteTabs.findIndex((tab) => tab.id === toTabId(filePath));
+
+const getActiveSurface = (
+  noteTabs: NoteTab[],
+  activeTabId: string | null,
+  fallback: ActiveSurfaceSnapshot,
+): ActiveSurfaceSnapshot => {
+  if (!activeTabId) {
+    return fallback;
+  }
+
+  const activeTab = noteTabs.find((tab) => tab.id === activeTabId);
+  if (!activeTab) {
+    return fallback;
+  }
+
+  return {
+    activeFile: activeTab.file,
+    draftContent: activeTab.draftContent,
+    isDirty: activeTab.isDirty,
+    isSaving: activeTab.isSaving,
+    lastSavedAt: activeTab.lastSavedAt,
+  };
+};
+
 type WorkspaceState = {
   rootPath: string | null;
   tree: DirectoryNode[];
+  noteTabs: NoteTab[];
+  activeTabId: string | null;
   activeFile: FileDocument | null;
   draftContent: string;
   isDirty: boolean;
   isSaving: boolean;
   lastSavedAt: number | null;
   error: string | null;
-  // Navigation history
   navigationHistory: string[];
   navigationIndex: number;
   setWorkspace: (payload: {
@@ -46,9 +103,19 @@ type WorkspaceState = {
   updateActiveFile: (file: FileDocument) => void;
   updateDraftContent: (content: string) => void;
   markSaved: (file: FileDocument) => void;
+  markTabSaved: (filePath: string, file: FileDocument) => void;
   setSaving: (isSaving: boolean) => void;
+  setTabSaving: (filePath: string, isSaving: boolean) => void;
   setError: (message: string | null) => void;
-  // Navigation history methods
+  activateTab: (filePath: string) => void;
+  closeTab: (filePath: string) => string | null;
+  closeOtherTabs: (filePath: string) => void;
+  removeTab: (filePath: string) => void;
+  removeTabsInFolder: (folderPath: string) => void;
+  replaceTabPath: (oldPath: string, file: FileDocument) => void;
+  remapTabsForFolderRename: (oldFolderPath: string, newFolderPath: string) => void;
+  getActiveTab: () => NoteTab | null;
+  getTabByPath: (filePath: string) => NoteTab | null;
   pushHistory: (filePath: string) => void;
   replaceHistoryPath: (oldPath: string, newPath: string) => void;
   removeHistoryPath: (targetPath: string) => void;
@@ -61,6 +128,8 @@ type WorkspaceState = {
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   rootPath: null,
   tree: [],
+  noteTabs: [],
+  activeTabId: null,
   activeFile: null,
   draftContent: "",
   isDirty: false,
@@ -70,46 +139,443 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   navigationHistory: [],
   navigationIndex: -1,
   setWorkspace: ({ rootPath, tree, activeFile }) =>
-    set({
-      rootPath,
-      tree,
-      activeFile,
-      draftContent: activeFile?.content ?? "",
-      isDirty: false,
-      lastSavedAt: activeFile ? Date.now() : null,
-      error: null,
-      navigationHistory: activeFile ? [activeFile.path] : [],
-      navigationIndex: activeFile ? 0 : -1,
+    set((state) => {
+      if (!activeFile) {
+        return {
+          rootPath,
+          tree,
+          error: null,
+        };
+      }
+
+      const existingIndex = getNoteTabIndex(state.noteTabs, activeFile.path);
+      const noteTabs =
+        existingIndex >= 0
+          ? state.noteTabs.map((tab, index) => {
+              if (index !== existingIndex) {
+                return tab;
+              }
+
+              return {
+                ...tab,
+                file: activeFile,
+                draftContent: tab.isDirty ? tab.draftContent : activeFile.content,
+              };
+            })
+          : [...state.noteTabs, createNoteTab(activeFile)];
+      const activeTabId = toTabId(activeFile.path);
+
+      return {
+        rootPath,
+        tree,
+        error: null,
+        noteTabs,
+        activeTabId,
+        ...getActiveSurface(noteTabs, activeTabId, EMPTY_ACTIVE_SURFACE),
+      };
     }),
   setTree: (tree) => set({ tree }),
   setActiveFile: (activeFile) =>
-    set({
-      activeFile,
-      draftContent: activeFile?.content ?? "",
-      isDirty: false,
-      lastSavedAt: activeFile ? Date.now() : null,
+    set((state) => {
+      if (!activeFile) {
+        return {
+          activeTabId: null,
+          ...EMPTY_ACTIVE_SURFACE,
+        };
+      }
+
+      const existingIndex = getNoteTabIndex(state.noteTabs, activeFile.path);
+      const noteTabs =
+        existingIndex >= 0
+          ? state.noteTabs.map((tab, index) => {
+              if (index !== existingIndex) {
+                return tab;
+              }
+
+              return {
+                ...tab,
+                file: activeFile,
+                draftContent: tab.isDirty ? tab.draftContent : activeFile.content,
+              };
+            })
+          : [...state.noteTabs, createNoteTab(activeFile)];
+      const activeTabId = toTabId(activeFile.path);
+
+      return {
+        noteTabs,
+        activeTabId,
+        ...getActiveSurface(noteTabs, activeTabId, EMPTY_ACTIVE_SURFACE),
+      };
     }),
   attachActiveFile: (activeFile) =>
-    set((state) => ({
-      activeFile,
-      draftContent: state.draftContent,
-      isDirty: state.isDirty,
-      lastSavedAt: state.lastSavedAt,
-    })),
-  updateActiveFile: (activeFile) => set({ activeFile }),
-  updateDraftContent: (draftContent) => set({ draftContent, isDirty: true }),
+    set((state) => {
+      const activeDraftContent = state.activeTabId ? activeFile.content : state.draftContent;
+      const activeIsDirty = state.activeTabId ? false : state.isDirty;
+      const activeIsSaving = state.activeTabId ? false : state.isSaving;
+      const activeLastSavedAt = state.activeTabId ? Date.now() : state.lastSavedAt;
+      const existingIndex = getNoteTabIndex(state.noteTabs, activeFile.path);
+      const nextTab = createNoteTab(activeFile, {
+        draftContent: activeDraftContent,
+        isDirty: activeIsDirty,
+        isSaving: activeIsSaving,
+        lastSavedAt: activeLastSavedAt,
+      });
+      const noteTabs =
+        existingIndex >= 0
+          ? state.noteTabs.map((tab, index) => (index === existingIndex ? nextTab : tab))
+          : [...state.noteTabs, nextTab];
+
+      return {
+        noteTabs,
+        activeTabId: nextTab.id,
+        activeFile,
+        draftContent: nextTab.draftContent,
+        isDirty: nextTab.isDirty,
+        isSaving: nextTab.isSaving,
+        lastSavedAt: nextTab.lastSavedAt,
+      };
+    }),
+  updateActiveFile: (activeFile) =>
+    set((state) => {
+      const tabIndex = getNoteTabIndex(state.noteTabs, activeFile.path);
+      const noteTabs =
+        tabIndex >= 0
+          ? state.noteTabs.map((tab, index) => {
+              if (index !== tabIndex) {
+                return tab;
+              }
+
+              return {
+                ...tab,
+                file: activeFile,
+                draftContent: tab.isDirty ? tab.draftContent : activeFile.content,
+              };
+            })
+          : state.noteTabs;
+      const activeTabId = state.activeTabId;
+
+      return {
+        noteTabs,
+        ...getActiveSurface(noteTabs, activeTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
+      };
+    }),
+  updateDraftContent: (draftContent) =>
+    set((state) => {
+      if (!state.activeTabId) {
+        return { draftContent, isDirty: true };
+      }
+
+      const noteTabs = state.noteTabs.map((tab) =>
+        tab.id === state.activeTabId
+          ? {
+              ...tab,
+              draftContent,
+              isDirty: true,
+            }
+          : tab,
+      );
+
+      return {
+        noteTabs,
+        draftContent,
+        isDirty: true,
+      };
+    }),
   markSaved: (activeFile) =>
-    set((state) => ({
-      activeFile,
-      // Only update draft content if it's not currently dirty.
-      // This prevents the editor from resetting the cursor if the user is typing while it saves.
-      draftContent: state.isDirty ? state.draftContent : activeFile.content,
-      isDirty: false,
-      isSaving: false,
-      lastSavedAt: Date.now(),
-    })),
-  setSaving: (isSaving) => set({ isSaving }),
+    set((state) => {
+      const currentActiveTab = state.activeTabId
+        ? (state.noteTabs.find((tab) => tab.id === state.activeTabId) ?? null)
+        : null;
+      const shouldRemainDirty =
+        (currentActiveTab?.draftContent ?? state.draftContent) !== activeFile.content;
+
+      if (!state.activeTabId) {
+        return {
+          activeFile,
+          draftContent: shouldRemainDirty ? state.draftContent : activeFile.content,
+          isDirty: shouldRemainDirty,
+          isSaving: false,
+          lastSavedAt: Date.now(),
+        };
+      }
+
+      const noteTabs = state.noteTabs.map((tab) =>
+        tab.id === state.activeTabId
+          ? {
+              ...tab,
+              file: activeFile,
+              draftContent: shouldRemainDirty ? tab.draftContent : activeFile.content,
+              isDirty: shouldRemainDirty,
+              isSaving: false,
+              lastSavedAt: Date.now(),
+            }
+          : tab,
+      );
+
+      return {
+        noteTabs,
+        activeFile,
+        draftContent: shouldRemainDirty ? state.draftContent : activeFile.content,
+        isDirty: shouldRemainDirty,
+        isSaving: false,
+        lastSavedAt: Date.now(),
+      };
+    }),
+  markTabSaved: (filePath, file) =>
+    set((state) => {
+      const tabIndex = getNoteTabIndex(state.noteTabs, filePath);
+      if (tabIndex < 0) {
+        return state;
+      }
+
+      const noteTabs = state.noteTabs.map((tab, index) =>
+        index === tabIndex
+          ? {
+              ...tab,
+              id: toTabId(file.path),
+              file,
+              draftContent: file.content,
+              isDirty: false,
+              isSaving: false,
+              lastSavedAt: Date.now(),
+            }
+          : tab,
+      );
+      const nextActiveTabId =
+        state.activeTabId === toTabId(filePath) ? toTabId(file.path) : state.activeTabId;
+
+      return {
+        noteTabs,
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(noteTabs, nextActiveTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
+      };
+    }),
+  setSaving: (isSaving) =>
+    set((state) => {
+      if (!state.activeTabId) {
+        return { isSaving };
+      }
+
+      return {
+        noteTabs: state.noteTabs.map((tab) =>
+          tab.id === state.activeTabId
+            ? {
+                ...tab,
+                isSaving,
+              }
+            : tab,
+        ),
+        isSaving,
+      };
+    }),
+  setTabSaving: (filePath, isSaving) =>
+    set((state) => {
+      const tabIndex = getNoteTabIndex(state.noteTabs, filePath);
+      if (tabIndex < 0) {
+        return state;
+      }
+
+      const noteTabs = state.noteTabs.map((tab, index) =>
+        index === tabIndex
+          ? {
+              ...tab,
+              isSaving,
+            }
+          : tab,
+      );
+
+      return {
+        noteTabs,
+        ...getActiveSurface(noteTabs, state.activeTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
+      };
+    }),
   setError: (error) => set({ error }),
+  activateTab: (filePath) =>
+    set((state) => {
+      const nextActiveTabId = toTabId(filePath);
+      if (state.activeTabId === nextActiveTabId) {
+        return state;
+      }
+
+      const tab = state.noteTabs.find((entry) => entry.id === nextActiveTabId);
+      if (!tab) {
+        return state;
+      }
+
+      return {
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(state.noteTabs, nextActiveTabId, EMPTY_ACTIVE_SURFACE),
+      };
+    }),
+  closeTab: (filePath) => {
+    const state = get();
+    const tabIndex = getNoteTabIndex(state.noteTabs, filePath);
+    if (tabIndex < 0) {
+      return state.activeFile?.path ?? null;
+    }
+
+    const targetTabId = state.noteTabs[tabIndex]?.id ?? null;
+    const noteTabs = state.noteTabs.filter((tab) => tab.id !== targetTabId);
+    let nextActiveTabId = state.activeTabId;
+
+    if (targetTabId && state.activeTabId === targetTabId) {
+      const previousTab = state.noteTabs[tabIndex - 1] ?? null;
+      const nextTab = state.noteTabs[tabIndex + 1] ?? null;
+      nextActiveTabId = previousTab?.id ?? nextTab?.id ?? null;
+    }
+
+    set({
+      noteTabs,
+      activeTabId: nextActiveTabId,
+      ...getActiveSurface(noteTabs, nextActiveTabId, EMPTY_ACTIVE_SURFACE),
+    });
+
+    const nextActiveTab = noteTabs.find((tab) => tab.id === nextActiveTabId) ?? null;
+    return nextActiveTab?.file.path ?? null;
+  },
+  closeOtherTabs: (filePath) =>
+    set((state) => {
+      const tabIndex = getNoteTabIndex(state.noteTabs, filePath);
+      if (tabIndex < 0) {
+        return state;
+      }
+
+      const nextTab = state.noteTabs[tabIndex]!;
+      const noteTabs = [nextTab];
+
+      return {
+        noteTabs,
+        activeTabId: nextTab.id,
+        ...getActiveSurface(noteTabs, nextTab.id, EMPTY_ACTIVE_SURFACE),
+      };
+    }),
+  removeTab: (filePath) =>
+    set((state) => {
+      const nextTabs = state.noteTabs.filter((tab) => !isSamePath(tab.file.path, filePath));
+      const nextActiveTabId =
+        state.activeTabId && isSamePath(filePath, state.activeFile?.path)
+          ? (nextTabs.at(-1)?.id ?? null)
+          : state.activeTabId;
+
+      return {
+        noteTabs: nextTabs,
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(nextTabs, nextActiveTabId, EMPTY_ACTIVE_SURFACE),
+      };
+    }),
+  removeTabsInFolder: (folderPath) =>
+    set((state) => {
+      const nextTabs = state.noteTabs.filter((tab) => !isPathInside(tab.file.path, folderPath));
+      const nextActiveTabId =
+        state.activeTabId && isPathInside(state.activeFile?.path ?? "", folderPath)
+          ? (nextTabs.at(-1)?.id ?? null)
+          : state.activeTabId;
+
+      return {
+        noteTabs: nextTabs,
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(nextTabs, nextActiveTabId, EMPTY_ACTIVE_SURFACE),
+      };
+    }),
+  replaceTabPath: (oldPath, file) =>
+    set((state) => {
+      const tabIndex = getNoteTabIndex(state.noteTabs, oldPath);
+      if (tabIndex < 0) {
+        return state;
+      }
+
+      const previousTab = state.noteTabs[tabIndex]!;
+      const nextTab: NoteTab = {
+        ...previousTab,
+        id: toTabId(file.path),
+        file,
+      };
+      const noteTabs = state.noteTabs.map((tab, index) => (index === tabIndex ? nextTab : tab));
+      const nextActiveTabId = state.activeTabId === previousTab.id ? nextTab.id : state.activeTabId;
+
+      return {
+        noteTabs,
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(noteTabs, nextActiveTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
+      };
+    }),
+  remapTabsForFolderRename: (oldFolderPath, newFolderPath) =>
+    set((state) => {
+      let nextActiveTabId = state.activeTabId;
+      const noteTabs = state.noteTabs.map((tab) => {
+        if (!isPathInside(tab.file.path, oldFolderPath)) {
+          return tab;
+        }
+
+        const normalizedOldFolderPath = normalizePath(oldFolderPath).replace(/\/+$/, "");
+        const normalizedNewFolderPath = normalizePath(newFolderPath).replace(/\/+$/, "");
+        const suffix = normalizePath(tab.file.path).slice(normalizedOldFolderPath.length);
+        const nextPath = `${normalizedNewFolderPath}${suffix}`;
+        const nextTab: NoteTab = {
+          ...tab,
+          id: toTabId(nextPath),
+          file: {
+            ...tab.file,
+            path: nextPath,
+            name: getBaseName(nextPath),
+          },
+        };
+
+        if (state.activeTabId === tab.id) {
+          nextActiveTabId = nextTab.id;
+        }
+
+        return nextTab;
+      });
+
+      return {
+        noteTabs,
+        activeTabId: nextActiveTabId,
+        ...getActiveSurface(noteTabs, nextActiveTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
+      };
+    }),
+  getActiveTab: () => {
+    const state = get();
+    if (!state.activeTabId) {
+      return null;
+    }
+
+    return state.noteTabs.find((tab) => tab.id === state.activeTabId) ?? null;
+  },
+  getTabByPath: (filePath) => {
+    const state = get();
+    return state.noteTabs.find((tab) => isSamePath(tab.file.path, filePath)) ?? null;
+  },
   pushHistory: (filePath) => {
     set((state) => {
       const currentPath =
@@ -133,17 +599,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         };
       }
 
-      // If we're not at the end of history, remove forward entries
       const newHistory = state.navigationHistory.slice(0, state.navigationIndex + 1);
-
-      // Don't add duplicate consecutive entries
       if (isSamePath(newHistory[newHistory.length - 1], filePath)) {
         return state;
       }
 
       newHistory.push(filePath);
 
-      // Limit history to 50 entries
       if (newHistory.length > 50) {
         newHistory.shift();
       }

--- a/apps/desktop/src/store/workspace.ts
+++ b/apps/desktop/src/store/workspace.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 import { getBaseName, isPathInside, isSamePath, normalizePath } from "@/lib/paths";
 
-import type { DirectoryNode, FileDocument, NoteTab } from "../shared/workspace";
+import type { DirectoryNode, FileDocument, NoteTab, TabMovePosition } from "../shared/workspace";
 
 const getClosestHistoryIndex = (history: string[], currentIndex: number, filePath: string) => {
   let closestIndex = -1;
@@ -110,6 +110,7 @@ type WorkspaceState = {
   activateTab: (filePath: string) => void;
   closeTab: (filePath: string) => string | null;
   closeOtherTabs: (filePath: string) => void;
+  moveTab: (sourcePath: string, targetPath: string, position: TabMovePosition) => void;
   removeTab: (filePath: string) => void;
   removeTabsInFolder: (folderPath: string) => void;
   replaceTabPath: (oldPath: string, file: FileDocument) => void;
@@ -465,6 +466,45 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         noteTabs,
         activeTabId: nextTab.id,
         ...getActiveSurface(noteTabs, nextTab.id, EMPTY_ACTIVE_SURFACE),
+      };
+    }),
+  moveTab: (sourcePath, targetPath, position) =>
+    set((state) => {
+      const sourceIndex = getNoteTabIndex(state.noteTabs, sourcePath);
+      const targetIndex = getNoteTabIndex(state.noteTabs, targetPath);
+
+      if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+        return state;
+      }
+
+      const sourceTab = state.noteTabs[sourceIndex];
+      const targetTab = state.noteTabs[targetIndex];
+      if (!sourceTab || !targetTab) {
+        return state;
+      }
+
+      const remainingTabs = state.noteTabs.filter((tab) => tab.id !== sourceTab.id);
+      const nextTargetIndex = remainingTabs.findIndex((tab) => tab.id === targetTab.id);
+      if (nextTargetIndex < 0) {
+        return state;
+      }
+
+      const insertionIndex = position === "before" ? nextTargetIndex : nextTargetIndex + 1;
+      const noteTabs = [
+        ...remainingTabs.slice(0, insertionIndex),
+        sourceTab,
+        ...remainingTabs.slice(insertionIndex),
+      ];
+
+      return {
+        noteTabs,
+        ...getActiveSurface(noteTabs, state.activeTabId, {
+          activeFile: state.activeFile,
+          draftContent: state.draftContent,
+          isDirty: state.isDirty,
+          isSaving: state.isSaving,
+          lastSavedAt: state.lastSavedAt,
+        }),
       };
     }),
   removeTab: (filePath) =>

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -25,6 +25,7 @@ export type MarkdownEditorProps = {
   onToggleSidebar?: () => void;
   isSidebarCollapsed?: boolean;
   headerAccessory?: ReactNode;
+  subheaderContent?: ReactNode;
   topContent?: ReactNode;
   onCreateNote?: () => void;
   toggleSidebarShortcut?: string;


### PR DESCRIPTION
## Summary
- add a persisted multi-note tab model in the desktop workspace store, including restore-on-startup, tab-aware autosave, close/close-others flows, and path remapping for renames/deletes
- add a polished horizontal note tab rail with overflow scrolling, dirty state, instant switching, and new/close tab actions wired into the editor shell
- add keyboard and command-palette support for new tab, close tab, close other tabs, and direct `Cmd/Ctrl+1..9` switching, plus end-to-end coverage for switching, restore, and close shortcuts

## Notes
- this ships as notes-only for v1; the tab rail is reusable, but skills keep their existing lighter document toggle for now to avoid mixing two navigation models into the same shortcut space
- tab switching follows the visible left-to-right tab order, which keeps `Cmd/Ctrl+1..9` aligned with what the user sees in the rail

## Testing
- `pnpm typecheck:desktop`
- `pnpm lint:desktop`
- `pnpm test:e2e:desktop`
- `pnpm dlx react-doctor@latest`

Closes #147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tab note support with per-tab drafts, open/activate/close/move (including drag-and-drop) and tab-aware save/restore.

* **Keyboard Shortcuts**
  * Direct tab switching (primary+1–9), Close Tab, Close Other Tabs, and next/previous tab shortcuts; command-palette and menu entries for tab actions.

* **User Interface**
  * Horizontal tab strip with close controls in editor subheader; toolbar filename display removed.

* **Persistence**
  * Open tabs, order and selected tab persist and restore across launches.

* **Tests**
  * New end-to-end tests covering tab workflows, shortcuts, reordering and session restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->