### PR TITLE
feat(desktop): add in-note find and note link previews

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -631,15 +631,15 @@ test("find in note highlights matches and cycles through them from the keyboard"
     await expect(findInput).toBeVisible();
     await findInput.fill("needle");
 
-    await expect(findResults).toHaveText("1 of 3");
+    await expect(findResults).toHaveText("1/3");
     await expect(glyph.window.locator(".glyph-find-match")).toHaveCount(3);
     await expect(glyph.window.locator(".glyph-find-match-active")).toHaveCount(1);
 
     await glyph.window.keyboard.press("Enter");
-    await expect(findResults).toHaveText("2 of 3");
+    await expect(findResults).toHaveText("2/3");
 
     await glyph.window.keyboard.press("Shift+Enter");
-    await expect(findResults).toHaveText("1 of 3");
+    await expect(findResults).toHaveText("1/3");
 
     await glyph.window.keyboard.press("Escape");
     await expect(findInput).toBeHidden();

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -41,6 +41,7 @@ async function createGlyphSandbox(): Promise<GlyphSandbox> {
   const workspaceRoot = path.join(sandboxRoot, "workspace");
   const userDataRoot = path.join(sandboxRoot, "user-data");
   const welcomeNotePath = path.join(workspaceRoot, "welcome.md");
+  const findSamplePath = path.join(workspaceRoot, "find-sample.md");
   const nestedNotePath = path.join(workspaceRoot, "notes", "nested-note.md");
 
   await fs.mkdir(path.join(workspaceRoot, "notes"), { recursive: true });
@@ -48,7 +49,23 @@ async function createGlyphSandbox(): Promise<GlyphSandbox> {
 
   await fs.writeFile(
     welcomeNotePath,
-    ["# Welcome to Glyph", "", "Smoke test note content."].join("\n"),
+    [
+      "# Welcome to Glyph",
+      "",
+      "Smoke test note content.",
+      "",
+      "Preview the [Nested Note](notes/nested-note.md).",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    findSamplePath,
+    [
+      "# Find Sample",
+      "",
+      "Needle line one.",
+      "Needle line two.",
+      "Another needle appears here.",
+    ].join("\n"),
   );
   await fs.writeFile(nestedNotePath, ["# Nested Note", "", "Nested note body."].join("\n"));
 
@@ -593,6 +610,71 @@ test("new note is editable and content persists after save", async ({}, testInfo
 
     // The note should remain open and content should still be visible
     await expect(glyph.window.getByText("My Test Content")).toBeVisible();
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("find in note highlights matches and cycles through them from the keyboard", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "find sample", /find-sample\.md/i);
+    await expect(glyph.window.getByText("Needle line one.")).toBeVisible();
+
+    await glyph.window.keyboard.press(`${modKey}+F`);
+    const findInput = glyph.window.getByLabel("Find in current note");
+    const findResults = glyph.window.getByLabel("Find results");
+
+    await expect(findInput).toBeVisible();
+    await findInput.fill("needle");
+
+    await expect(findResults).toHaveText("1 of 3");
+    await expect(glyph.window.locator(".glyph-find-match")).toHaveCount(3);
+    await expect(glyph.window.locator(".glyph-find-match-active")).toHaveCount(1);
+
+    await glyph.window.keyboard.press("Enter");
+    await expect(findResults).toHaveText("2 of 3");
+
+    await glyph.window.keyboard.press("Shift+Enter");
+    await expect(findResults).toHaveText("1 of 3");
+
+    await glyph.window.keyboard.press("Escape");
+    await expect(findInput).toBeHidden();
+    await expect
+      .poll(async () =>
+        glyph.window.evaluate(() => {
+          const activeElement = document.activeElement;
+          return Boolean(activeElement?.closest('[data-glyph-editor="true"]'));
+        }),
+      )
+      .toBe(true);
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("hovering a markdown note link shows a local note preview", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    const nestedLink = glyph.window
+      .locator('[data-glyph-editor="true"] a')
+      .filter({ hasText: "Nested Note" })
+      .first();
+    await expect(nestedLink).toBeVisible();
+
+    await nestedLink.hover();
+
+    const previewCard = glyph.window.getByLabel("Note link preview");
+    await expect(previewCard).toBeVisible();
+    await expect(previewCard.getByText("Nested Note", { exact: true })).toBeVisible();
+    await expect(previewCard.getByText("Nested note body.")).toBeVisible();
   } finally {
     await glyph.stop(testInfo);
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -24,6 +24,7 @@ import type {
   DialogKind,
   DirectoryNode,
   FileOpenResult,
+  NoteLinkPreview,
   ResolvedLinkTarget,
   SearchResult,
   UpdateState,
@@ -55,6 +56,8 @@ const STARTUP_LIGHT_BACKGROUND = "#f8f7fb";
 const STARTUP_DARK_BACKGROUND = "#1f1b26";
 const GITHUB_RELEASES_URL = "https://github.com/FALAK097/glyph/releases";
 const GITHUB_LATEST_RELEASE_API_URL = "https://api.github.com/repos/FALAK097/glyph/releases/latest";
+const MARKDOWN_PREVIEW_SUFFIX_PATTERN = /\.(md|mdx|markdown)$/i;
+const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s+(.*)$/;
 
 type PersistedUpdateState = {
   stagedVersion: string | null;
@@ -810,6 +813,113 @@ async function resolveLinkTarget(
   };
 }
 
+function stripMarkdownPreviewSyntax(value: string) {
+  return value
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\[\[([^[\]|]+)(?:\|([^[\]]+))?\]\]/g, (_match, target: string, label?: string) =>
+      (label ?? target).trim(),
+    )
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/^\s*[-*+]\s+\[[xX ]\]\s+/, "")
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/^\s*\d+\.\s+/, "")
+    .replace(/`{1,3}([^`]+)`{1,3}/g, "$1")
+    .trim();
+}
+
+function deriveWorkspaceRootForPath(targetPath: string): string | null {
+  // Use the active workspace root if the target is inside it.
+  if (activeWorkspaceRoot) {
+    const rel = path.relative(activeWorkspaceRoot, targetPath);
+    if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+      return activeWorkspaceRoot;
+    }
+  }
+
+  return null;
+}
+
+function buildNoteLinkPreview(
+  document: {
+    content: string;
+    name: string;
+    path: string;
+  },
+  workspaceRoot?: string | null,
+): NoteLinkPreview {
+  const lines = document.content.split("\n");
+  const fallbackTitle = document.name.replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "");
+  let title = fallbackTitle;
+  let inCodeFence = false;
+  const excerptLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (/^(```|~~~)/.test(trimmed)) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+
+    if (inCodeFence) {
+      continue;
+    }
+
+    const headingMatch = trimmed.match(MARKDOWN_HEADING_PATTERN);
+    if (headingMatch && title === fallbackTitle) {
+      const headingTitle = stripMarkdownPreviewSyntax(headingMatch[1] ?? "");
+      if (headingTitle) {
+        title = headingTitle;
+        continue;
+      }
+    }
+
+    const previewLine = stripMarkdownPreviewSyntax(trimmed);
+    if (!previewLine) {
+      continue;
+    }
+
+    excerptLines.push(previewLine);
+    if (excerptLines.length >= 3) {
+      break;
+    }
+  }
+
+  const effectiveRoot = workspaceRoot ?? deriveWorkspaceRootForPath(document.path);
+  const relativePath = effectiveRoot ? path.relative(effectiveRoot, document.path) : null;
+  const displayPath =
+    relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
+      ? relativePath.replace(/\\/g, "/")
+      : document.name;
+
+  return {
+    targetPath: document.path,
+    title,
+    excerpt: excerptLines.join(" ").slice(0, 220),
+    displayPath: displayPath || document.name,
+  };
+}
+
+async function getLinkPreview(
+  currentFilePath: string | null,
+  href: string,
+): Promise<NoteLinkPreview | null> {
+  const resolved = await resolveLinkTarget(currentFilePath, href);
+  if (!resolved || resolved.kind !== "markdown-file") {
+    return null;
+  }
+
+  const workspaceRoot = currentFilePath
+    ? deriveWorkspaceRootForPath(currentFilePath)
+    : activeWorkspaceRoot;
+  const document = await readMarkdownFile(resolved.target);
+  return buildNoteLinkPreview(document, workspaceRoot);
+}
+
 function getDefaultSettings(): AppSettings {
   return {
     defaultWorkspacePath: getDefaultWorkspacePath(),
@@ -996,6 +1106,13 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
         { role: "copy" },
         { role: "paste" },
         { role: "selectAll" },
+        { type: "separator" },
+        {
+          label: "Find in Note",
+          accelerator: getAccelerator("find-in-note"),
+          click: () =>
+            mainWindow?.webContents.send("app:command", "find-in-note" satisfies AppCommand),
+        },
       ],
     },
     {
@@ -1639,6 +1756,20 @@ ipcMain.handle(
   async (_event, currentFilePath: string | null, href: string) =>
     resolveLinkTarget(currentFilePath, href),
 );
+
+ipcMain.handle("app:getLinkPreview", async (_event, currentFilePath: unknown, href: unknown) => {
+  const normalizedFilePath =
+    typeof currentFilePath === "string" && currentFilePath.trim().length > 0
+      ? path.normalize(currentFilePath)
+      : null;
+  const normalizedHref = typeof href === "string" ? href.trim() : "";
+
+  if (!normalizedHref) {
+    return null;
+  }
+
+  return getLinkPreview(normalizedFilePath, normalizedHref);
+});
 
 ipcMain.handle("workspace:openFolder", async (_event, dirPath?: string) => {
   let resolvedPath = dirPath;

--- a/apps/desktop/electron/preload.cts
+++ b/apps/desktop/electron/preload.cts
@@ -9,6 +9,7 @@ import type {
   UpdateState,
   FileDocument,
   FileOpenResult,
+  NoteLinkPreview,
   ResolvedLinkTarget,
   SearchResult,
   WorkspaceChangeEvent,
@@ -58,6 +59,13 @@ const api = {
       currentFilePath,
       href,
     ) as Promise<ResolvedLinkTarget | null>;
+  },
+  getLinkPreview(currentFilePath: string | null, href: string) {
+    return ipcRenderer.invoke(
+      "app:getLinkPreview",
+      currentFilePath,
+      href,
+    ) as Promise<NoteLinkPreview | null>;
   },
   openFolder(dirPath?: string) {
     return invokeWithRetry<WorkspaceSnapshot | null>("workspace:openFolder", dirPath);

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -797,6 +797,17 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     const query = paletteFilterQuery;
     const items: CommandPaletteItem[] = [
       {
+        id: "find-in-current-note",
+        title: "Find in Current Note",
+        subtitle: "Search the active note without leaving the editor",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          controller.requestFindInNote();
+          closePalette();
+        },
+      },
+      {
         id: "rename-current-note",
         title: "Rename Current Note",
         subtitle: "Change the file name from the command palette",
@@ -866,6 +877,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   }, [
     controller.activeFile,
     controller.folderRevealLabel,
+    controller.requestFindInNote,
     handleCopyCurrentNoteMarkdown,
     handleCopyCurrentNotePath,
     handleExportCurrentNote,
@@ -1202,6 +1214,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 fileName={controller.activeFile?.name ?? null}
                 filePath={controller.activeFile?.path ?? null}
                 editorFocusRequest={controller.editorFocusRequest}
+                findRequest={controller.findRequest}
                 initialScrollTop={noteInitialScrollTop}
                 saveStateLabel={controller.saveStateLabel}
                 footerMetaLabel={noteFileSizeLabel}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { MutableRefObject } from "react";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
@@ -19,6 +19,12 @@ import { createHeadingId } from "@/lib/note-navigation";
 import { getFolderRevealLabel } from "@/lib/platform";
 
 import { CustomCodeBlockLowlight } from "./tiptap-extension/code-block-lowlight";
+import {
+  FindHighlightExtension,
+  getFindHighlightState,
+  setActiveFindHighlightMatch,
+  setFindHighlightQuery,
+} from "./tiptap-extension/find-highlight";
 import { MarkdownShortcuts } from "./tiptap-extension/markdown-shortcuts";
 
 import { Button } from "@/components/ui/button";
@@ -29,14 +35,15 @@ import { EditorDialogs } from "./editor-dialogs";
 import { useUpdateStateFlags } from "./update-notification";
 import { SlashCommand } from "./slash-command";
 import { TableOfContents } from "./table-of-contents";
-import { ArrowUpIcon, TrashIcon, OutlineIcon } from "./icons";
+import { ArrowDownIcon, ArrowUpIcon, OutlineIcon, SearchIcon, TrashIcon, XIcon } from "./icons";
 
 import type { MarkdownEditorProps, MarkdownEditorToast } from "../types/markdown-editor";
 import type { OutlineItem } from "@/types/navigation";
-import type { UpdateState } from "../shared/workspace";
+import type { NoteLinkPreview, UpdateState } from "../shared/workspace";
 
 const LINK_IMAGE_PATTERN = /(!?)\[([^\]]+)\]\(([^)]+)\)$/;
 const MARKDOWN_FILE_SUFFIX_PATTERN = /\.(md|mdx|markdown)$/i;
+const WINDOWS_DRIVE_PATH_PATTERN = /^[a-z]:[\\/]/i;
 type EditorActionType = "insert-table" | "insert-link" | "insert-image";
 
 type EditorActionDetail = {
@@ -123,6 +130,10 @@ const getDevPreviewUpdateState = (): UpdateState | null => {
 };
 
 type HoveredLinkState = {
+  href: string;
+  placement: "above" | "below";
+  preview: NoteLinkPreview | null;
+  status: "hint" | "loading" | "preview";
   tooltipLeft: number;
   tooltipTop: number;
 };
@@ -139,6 +150,11 @@ type SelectionSnapshot = {
   to: number;
 };
 
+type FindPanelState = {
+  activeIndex: number;
+  matchCount: number;
+};
+
 type EditorOutlineItem = OutlineItem & {
   pos: number;
 };
@@ -146,6 +162,11 @@ type EditorOutlineItem = OutlineItem & {
 const DEFAULT_SELECTION_SNAPSHOT: SelectionSnapshot = {
   from: 1,
   to: 1,
+};
+
+const EMPTY_FIND_PANEL_STATE: FindPanelState = {
+  activeIndex: -1,
+  matchCount: 0,
 };
 
 const extractLinkAttributes = (input: string) => {
@@ -176,6 +197,37 @@ const normalizeLinkTarget = (value: string) => {
   }
 
   return trimmed;
+};
+
+const isSafeLocalLinkTarget = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.startsWith("#")) {
+    return true;
+  }
+
+  if (WINDOWS_DRIVE_PATH_PATTERN.test(trimmed)) {
+    return true;
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    return false;
+  }
+
+  const [pathPart] = trimmed.split(/[?#]/, 1);
+  if (!pathPart || pathPart.startsWith("//")) {
+    return false;
+  }
+
+  return pathPart.includes("/") || pathPart.startsWith(".");
+};
+
+const isExternalLink = (href: string) => {
+  const trimmed = href.trim();
+  return /^https?:\/\//i.test(trimmed) || /^mailto:/i.test(trimmed);
 };
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
@@ -216,6 +268,15 @@ function collectEditorOutline(editor: Editor): EditorOutlineItem[] {
   });
 
   return items;
+}
+
+function getSelectedEditorText(editor: Editor) {
+  const { from, to } = editor.state.selection;
+  if (from === to) {
+    return "";
+  }
+
+  return editor.state.doc.textBetween(from, to, " ", " ").trim();
 }
 
 const INACTIVE_TABLE_CONTROLS: TableControlsState = {
@@ -292,6 +353,7 @@ export const MarkdownEditor = ({
   initialScrollTop = 0,
   scrollRestorationKey = null,
   editorFocusRequest,
+  findRequest,
   saveStateLabel,
   footerMetaLabel,
   wordCount,
@@ -340,13 +402,17 @@ export const MarkdownEditor = ({
   const isAutoConvertingRef = useRef(false);
   const liveEditorRef = useRef<Editor | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const findInputRef = useRef<HTMLInputElement | null>(null);
   const tableControlsRef = useRef<TableControlsState>(INACTIVE_TABLE_CONTROLS);
   const toastTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const hoveredLinkHideTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  const hoveredLinkRequestNonceRef = useRef(0);
   const scrollPositionTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const selectionSnapshotRef = useRef<SelectionSnapshot>(DEFAULT_SELECTION_SNAPSHOT);
   const selectionSnapshotsByDocumentRef = useRef<Record<string, SelectionSnapshot>>({});
   const lastHandledFocusRequestRef = useRef<number | null>(null);
+  const lastHandledFindRequestRef = useRef<number | null>(null);
+  const isFindOpenRef = useRef(false);
   const lastRestoredScrollStateRef = useRef<{
     key: string | null;
     top: number;
@@ -362,6 +428,10 @@ export const MarkdownEditor = ({
   const [devPreviewUpdateState] = useState<UpdateState | null>(() => getDevPreviewUpdateState());
   const [outlineItems, setOutlineItems] = useState<EditorOutlineItem[]>([]);
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
+  const [isFindOpen, setIsFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const deferredFindQuery = useDeferredValue(findQuery);
+  const [findPanelState, setFindPanelState] = useState<FindPanelState>(EMPTY_FIND_PANEL_STATE);
   const outlineItemsRef = useRef<EditorOutlineItem[]>([]);
 
   useEffect(() => {
@@ -371,6 +441,10 @@ export const MarkdownEditor = ({
     scrollRestorationKeyRef.current = scrollRestorationKey;
     onOpenLinkedFileRef.current = onOpenLinkedFile;
   }, [filePath, onChange, onOpenLinkedFile, onScrollPositionChange, scrollRestorationKey]);
+
+  useEffect(() => {
+    isFindOpenRef.current = isFindOpen;
+  }, [isFindOpen]);
 
   const refreshOutline = useCallback((nextEditor: Editor) => {
     const items = collectEditorOutline(nextEditor);
@@ -421,6 +495,106 @@ export const MarkdownEditor = ({
       }
     },
     [rememberSelectionSnapshot],
+  );
+
+  const scrollToFindMatch = useCallback(
+    (nextEditor: Editor, match: { from: number; to: number }) => {
+      const container = scrollContainerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const startCoords = nextEditor.view.coordsAtPos(match.from);
+      const endCoords = nextEditor.view.coordsAtPos(Math.max(match.from, match.to - 1));
+      const containerRect = container.getBoundingClientRect();
+      const matchTop = Math.min(startCoords.top, endCoords.top);
+      const matchBottom = Math.max(startCoords.bottom, endCoords.bottom);
+      const visibleTop = containerRect.top + 92;
+      const visibleBottom = containerRect.bottom - 48;
+
+      if (matchTop >= visibleTop && matchBottom <= visibleBottom) {
+        return;
+      }
+
+      const targetScrollTop = container.scrollTop + (matchTop - containerRect.top) - 88;
+      container.scrollTo({
+        top: Math.max(0, targetScrollTop),
+        behavior: "smooth",
+      });
+    },
+    [],
+  );
+
+  const syncFindPanelState = useCallback(
+    (nextEditor: Editor, options?: { scrollToActive?: boolean }) => {
+      const nextState = getFindHighlightState(nextEditor);
+      setFindPanelState({
+        activeIndex: nextState.activeIndex,
+        matchCount: nextState.matches.length,
+      });
+
+      if (!options?.scrollToActive || nextState.activeIndex < 0) {
+        return;
+      }
+
+      const activeMatch = nextState.matches[nextState.activeIndex];
+      if (activeMatch) {
+        scrollToFindMatch(nextEditor, activeMatch);
+      }
+    },
+    [scrollToFindMatch],
+  );
+
+  const closeFindPanel = useCallback(() => {
+    setIsFindOpen(false);
+    setFindQuery("");
+    setFindPanelState(EMPTY_FIND_PANEL_STATE);
+
+    const nextEditor = liveEditorRef.current;
+    if (nextEditor) {
+      setFindHighlightQuery(nextEditor, "");
+    }
+
+    window.requestAnimationFrame(() => {
+      focusEditorWithoutScroll(selectionSnapshotRef.current, false);
+    });
+  }, [focusEditorWithoutScroll]);
+
+  const openFindPanel = useCallback((initialQuery: string) => {
+    setIsFindOpen(true);
+    setFindQuery(initialQuery);
+
+    window.requestAnimationFrame(() => {
+      const input = findInputRef.current;
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+      input.select();
+    });
+  }, []);
+
+  const navigateFindMatches = useCallback(
+    (direction: 1 | -1) => {
+      const nextEditor = liveEditorRef.current;
+      if (!nextEditor) {
+        return;
+      }
+
+      const currentState = getFindHighlightState(nextEditor);
+      if (currentState.matches.length === 0) {
+        return;
+      }
+
+      const baseIndex = currentState.activeIndex >= 0 ? currentState.activeIndex : 0;
+      const nextIndex =
+        (baseIndex + direction + currentState.matches.length) % currentState.matches.length;
+
+      setActiveFindHighlightMatch(nextEditor, nextIndex);
+      syncFindPanelState(nextEditor, { scrollToActive: true });
+    },
+    [syncFindPanelState],
   );
 
   const effectiveUpdateState = devPreviewUpdateState ?? updateState ?? null;
@@ -537,6 +711,7 @@ export const MarkdownEditor = ({
   const scheduleHoveredLinkHide = () => {
     clearHoveredLinkHideTimeout();
     hoveredLinkHideTimeoutRef.current = window.setTimeout(() => {
+      hoveredLinkRequestNonceRef.current += 1;
       setHoveredLink(null);
       hoveredLinkHideTimeoutRef.current = null;
     }, 140);
@@ -690,6 +865,7 @@ export const MarkdownEditor = ({
         Link.configure({
           autolink: true,
           defaultProtocol: "https",
+          isAllowedUri: (url, ctx) => ctx.defaultValidate(url) || isSafeLocalLinkTarget(url),
           linkOnPaste: true,
           openOnClick: false,
           HTMLAttributes: {
@@ -713,6 +889,7 @@ export const MarkdownEditor = ({
         TableHeader,
         TableCell,
         SlashCommand,
+        FindHighlightExtension,
         Placeholder.configure({
           placeholder: "Start with a title, then let markdown shortcuts shape the page.",
         }),
@@ -772,10 +949,82 @@ export const MarkdownEditor = ({
 
             clearHoveredLinkHideTimeout();
             const rect = link.getBoundingClientRect();
+            const placement = rect.bottom > window.innerHeight * 0.64 ? "above" : "below";
+            const tooltipTop = placement === "above" ? rect.top - 12 : rect.bottom + 12;
+            const tooltipLeft = clamp(rect.left + rect.width / 2, 96, window.innerWidth - 96);
+
+            // For external links (http(s), mailto), show a simple hint immediately
+            // without fetching a rich preview — only note links get the full card.
+            if (isExternalLink(href)) {
+              hoveredLinkRequestNonceRef.current += 1;
+              setHoveredLink({
+                href,
+                placement,
+                preview: null,
+                status: "hint",
+                tooltipLeft,
+                tooltipTop,
+              });
+              return false;
+            }
+
+            const requestNonce = hoveredLinkRequestNonceRef.current + 1;
+            hoveredLinkRequestNonceRef.current = requestNonce;
+
             setHoveredLink({
-              tooltipLeft: clamp(rect.left + rect.width / 2, 96, window.innerWidth - 96),
-              tooltipTop: rect.bottom + 10,
+              href,
+              placement,
+              preview: null,
+              status: "loading",
+              tooltipLeft,
+              tooltipTop,
             });
+
+            if (!window.glyph) {
+              setHoveredLink((current) =>
+                current?.href === href
+                  ? {
+                      ...current,
+                      preview: null,
+                      status: "hint",
+                    }
+                  : current,
+              );
+              return false;
+            }
+
+            void window.glyph
+              .getLinkPreview(filePathRef.current, href)
+              .then((preview) => {
+                if (requestNonce !== hoveredLinkRequestNonceRef.current) {
+                  return;
+                }
+
+                setHoveredLink((current) =>
+                  current?.href === href
+                    ? {
+                        ...current,
+                        preview,
+                        status: preview ? "preview" : "hint",
+                      }
+                    : current,
+                );
+              })
+              .catch(() => {
+                if (requestNonce !== hoveredLinkRequestNonceRef.current) {
+                  return;
+                }
+
+                setHoveredLink((current) =>
+                  current?.href === href
+                    ? {
+                        ...current,
+                        preview: null,
+                        status: "hint",
+                      }
+                    : current,
+                );
+              });
             return false;
           },
           mouseout: (_view, _event) => {
@@ -789,6 +1038,7 @@ export const MarkdownEditor = ({
           },
           scroll: () => {
             setImageControls(null);
+            hoveredLinkRequestNonceRef.current += 1;
             clearHoveredLinkHideTimeout();
             setHoveredLink(null);
             return false;
@@ -808,6 +1058,9 @@ export const MarkdownEditor = ({
         refreshTableControls(nextEditor);
         refreshImageControls(nextEditor);
         refreshOutline(nextEditor);
+        if (isFindOpenRef.current) {
+          syncFindPanelState(nextEditor);
+        }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
         const nextMarkdown = (nextEditor.storage as any).markdown.getMarkdown() as string;
@@ -822,9 +1075,12 @@ export const MarkdownEditor = ({
         });
         refreshTableControls(nextEditor);
         refreshImageControls(nextEditor);
+        if (isFindOpenRef.current) {
+          syncFindPanelState(nextEditor);
+        }
       },
     },
-    [rememberSelectionSnapshot],
+    [rememberSelectionSnapshot, syncFindPanelState],
   );
 
   useEffect(() => {
@@ -840,7 +1096,10 @@ export const MarkdownEditor = ({
     refreshTableControls(editor);
     refreshImageControls(editor);
     refreshOutline(editor);
-  }, [content, editor, refreshOutline]);
+    if (isFindOpenRef.current) {
+      syncFindPanelState(editor);
+    }
+  }, [content, editor, refreshOutline, syncFindPanelState]);
 
   useEffect(() => {
     const targetKey = scrollRestorationKey ?? filePath;
@@ -925,6 +1184,39 @@ export const MarkdownEditor = ({
     liveEditorRef.current = editor;
     editor.setEditable(isEditable);
   }, [editor, isEditable]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    if (!isFindOpen) {
+      setFindHighlightQuery(editor, "");
+      setFindPanelState(EMPTY_FIND_PANEL_STATE);
+      return;
+    }
+
+    setFindHighlightQuery(editor, deferredFindQuery);
+    syncFindPanelState(editor, {
+      scrollToActive: Boolean(deferredFindQuery.trim()),
+    });
+  }, [editor, deferredFindQuery, isFindOpen, syncFindPanelState]);
+
+  useEffect(() => {
+    if (!findRequest || !editor) {
+      return;
+    }
+
+    if (lastHandledFindRequestRef.current === findRequest.nonce) {
+      return;
+    }
+
+    lastHandledFindRequestRef.current = findRequest.nonce;
+    const selectedText = getSelectedEditorText(editor).replace(/\s+/g, " ").trim();
+    const initialQuery = selectedText && selectedText.length <= 120 ? selectedText : findQuery;
+
+    openFindPanel(initialQuery);
+  }, [editor, findQuery, findRequest, openFindPanel]);
 
   useEffect(() => {
     if (!editorFocusRequest || !editor) {
@@ -1172,170 +1464,303 @@ export const MarkdownEditor = ({
       {subheaderContent ? (
         <div className="border-b border-border/30">{subheaderContent}</div>
       ) : null}
-      <div
-        ref={scrollContainerRef}
-        className={`flex-1 min-h-0 overflow-y-auto relative [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${
-          shouldShowOutlineRail ? "xl:pr-[316px]" : ""
-        }`}
-        onScroll={() => {
-          setImageControls(null);
-          clearHoveredLinkHideTimeout();
-          setHoveredLink(null);
+      <div className="relative flex-1 min-h-0">
+        {isFindOpen ? (
+          <div
+            className={`pointer-events-none absolute top-2 right-0 z-30 flex justify-end px-4 ${
+              shouldShowOutlineRail ? "xl:pr-[324px]" : ""
+            }`}
+          >
+            <div className="pointer-events-auto flex items-center gap-1 rounded-lg border border-border/50 bg-card/95 px-2 py-1.5 shadow-sm ring-1 ring-black/[0.03] dark:ring-white/[0.04] supports-backdrop-filter:backdrop-blur-md">
+              <SearchIcon size={12} className="shrink-0 text-muted-foreground/70" />
+              <input
+                ref={findInputRef}
+                autoFocus
+                aria-label="Find in current note"
+                value={findQuery}
+                className="h-5 w-[160px] bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
+                onChange={(event) => {
+                  setFindQuery(event.target.value);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    navigateFindMatches(event.shiftKey ? -1 : 1);
+                    return;
+                  }
 
-          if (!editor) return;
-          const container = scrollContainerRef.current;
-          if (!container) return;
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    closeFindPanel();
+                    return;
+                  }
 
-          if (scrollPositionTimeoutRef.current) {
-            window.clearTimeout(scrollPositionTimeoutRef.current);
-          }
-          scrollPositionTimeoutRef.current = window.setTimeout(() => {
-            flushScrollPosition();
-            scrollPositionTimeoutRef.current = null;
-          }, 120);
+                  const primaryPressed =
+                    event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
+                  if (primaryPressed && event.key.toLowerCase() === "g") {
+                    event.preventDefault();
+                    navigateFindMatches(event.shiftKey ? -1 : 1);
+                  }
+                }}
+              />
+              {findQuery.trim() ? (
+                <span
+                  aria-live="polite"
+                  aria-label="Find results"
+                  className="min-w-[36px] text-right text-[11px] tabular-nums text-muted-foreground"
+                >
+                  {findPanelState.matchCount > 0
+                    ? `${findPanelState.activeIndex + 1}/${findPanelState.matchCount}`
+                    : "No matches"}
+                </span>
+              ) : null}
+              <div className="mx-0.5 h-3.5 w-px bg-border/40" />
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                type="button"
+                disabled={findPanelState.matchCount === 0}
+                aria-label="Previous match"
+                className="h-5 w-5"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  navigateFindMatches(-1);
+                }}
+              >
+                <ArrowUpIcon size={12} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                type="button"
+                disabled={findPanelState.matchCount === 0}
+                aria-label="Next match"
+                className="h-5 w-5"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  navigateFindMatches(1);
+                }}
+              >
+                <ArrowDownIcon size={12} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                type="button"
+                aria-label="Close find"
+                className="h-5 w-5"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  closeFindPanel();
+                }}
+              >
+                <XIcon size={12} />
+              </Button>
+            </div>
+          </div>
+        ) : null}
+        <div
+          ref={scrollContainerRef}
+          className={`h-full overflow-y-auto relative [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${
+            shouldShowOutlineRail ? "xl:pr-[316px]" : ""
+          }`}
+          onScroll={() => {
+            setImageControls(null);
+            hoveredLinkRequestNonceRef.current += 1;
+            clearHoveredLinkHideTimeout();
+            setHoveredLink(null);
 
-          const headings = outlineItemsRef.current;
-          if (headings.length === 0) {
-            setActiveHeadingId(null);
-            return;
-          }
+            if (!editor) return;
+            const container = scrollContainerRef.current;
+            if (!container) return;
 
-          const containerRect = container.getBoundingClientRect();
-          const remainingScroll =
-            container.scrollHeight - container.scrollTop - container.clientHeight;
+            if (scrollPositionTimeoutRef.current) {
+              window.clearTimeout(scrollPositionTimeoutRef.current);
+            }
+            scrollPositionTimeoutRef.current = window.setTimeout(() => {
+              flushScrollPosition();
+              scrollPositionTimeoutRef.current = null;
+            }, 120);
 
-          let activeId = headings[0].id;
-          for (const heading of headings) {
-            const nodeDom = editor.view.nodeDOM(heading.pos - 1);
-            if (nodeDom instanceof HTMLElement) {
-              const rect = nodeDom.getBoundingClientRect();
-              // Add a bit more tolerance so if we jump to 40px, it comfortably highlights
-              if (rect.top <= containerRect.top + 120) {
-                activeId = heading.id;
-              } else {
-                break;
+            const headings = outlineItemsRef.current;
+            if (headings.length === 0) {
+              setActiveHeadingId(null);
+              return;
+            }
+
+            const containerRect = container.getBoundingClientRect();
+            const remainingScroll =
+              container.scrollHeight - container.scrollTop - container.clientHeight;
+
+            let activeId = headings[0].id;
+            for (const heading of headings) {
+              const nodeDom = editor.view.nodeDOM(heading.pos - 1);
+              if (nodeDom instanceof HTMLElement) {
+                const rect = nodeDom.getBoundingClientRect();
+                // Add a bit more tolerance so if we jump to 40px, it comfortably highlights
+                if (rect.top <= containerRect.top + 120) {
+                  activeId = heading.id;
+                } else {
+                  break;
+                }
               }
             }
-          }
 
-          // When near the bottom of the document, activate the last heading.
-          // Use a generous threshold to account for bottom padding (pb-32 = 128px),
-          // sub-pixel rounding on high-DPI displays, and floating footer overlays.
-          if (remainingScroll < 150) {
-            activeId = headings[headings.length - 1].id;
-          }
+            // When near the bottom of the document, activate the last heading.
+            // Use a generous threshold to account for bottom padding (pb-32 = 128px),
+            // sub-pixel rounding on high-DPI displays, and floating footer overlays.
+            if (remainingScroll < 150) {
+              activeId = headings[headings.length - 1].id;
+            }
 
-          setActiveHeadingId(activeId);
-        }}
-      >
-        {topContent ? <div className="mx-auto max-w-[800px] px-10 pt-5">{topContent}</div> : null}
-        {tableControls.active ? (
-          <div className="sticky top-4 z-20 h-0 overflow-visible">
-            <div
-              className={`pointer-events-none flex justify-end ${
-                shouldShowOutlineRail ? "xl:pr-[316px]" : "pr-6"
-              }`}
-            >
-              <div className="pointer-events-auto flex max-w-[min(720px,calc(100vw-2rem))] flex-wrap items-center justify-center gap-2 rounded-2xl border border-border/70 bg-card/95 px-3 py-2 shadow-lg supports-backdrop-filter:backdrop-blur-sm">
-                <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Table
-                </span>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  type="button"
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().addRowAfter().run()}
-                >
-                  Add Row
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  type="button"
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().addColumnAfter().run()}
-                >
-                  Add Column
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  type="button"
-                  disabled={!tableControls.canDeleteRow}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().deleteRow().run()}
-                >
-                  Remove Row
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  type="button"
-                  disabled={!tableControls.canDeleteColumn}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().deleteColumn().run()}
-                >
-                  Remove Column
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  type="button"
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().toggleHeaderRow().run()}
-                >
-                  Toggle Header
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="xs"
-                  type="button"
-                  disabled={!tableControls.canDeleteTable}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => editor?.chain().focus().deleteTable().run()}
-                >
-                  Delete Table
-                </Button>
+            setActiveHeadingId(activeId);
+          }}
+        >
+          {topContent ? <div className="mx-auto max-w-[800px] px-10 pt-5">{topContent}</div> : null}
+          {tableControls.active ? (
+            <div className="sticky top-4 z-20 h-0 overflow-visible">
+              <div
+                className={`pointer-events-none flex justify-center pl-52 pr-6 ${
+                  shouldShowOutlineRail ? "xl:pr-[316px]" : ""
+                }`}
+              >
+                <div className="pointer-events-auto flex items-center gap-1.5 rounded-2xl border border-border/70 bg-card/95 px-2.5 py-1.5 shadow-lg supports-backdrop-filter:backdrop-blur-sm">
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().addRowAfter().run()}
+                  >
+                    Add Row
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().addColumnAfter().run()}
+                  >
+                    Add Column
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    type="button"
+                    disabled={!tableControls.canDeleteRow}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().deleteRow().run()}
+                  >
+                    Remove Row
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    type="button"
+                    disabled={!tableControls.canDeleteColumn}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().deleteColumn().run()}
+                  >
+                    Remove Column
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().toggleHeaderRow().run()}
+                  >
+                    Toggle Header
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="xs"
+                    type="button"
+                    disabled={!tableControls.canDeleteTable}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => editor?.chain().focus().deleteTable().run()}
+                  >
+                    Delete Table
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        ) : null}
-        {hoveredLink ? (
-          <div
-            className="pointer-events-none fixed z-30"
-            style={{
-              left: hoveredLink.tooltipLeft,
-              top: hoveredLink.tooltipTop,
-              transform: "translateX(-50%)",
-            }}
-          >
-            <div className="inline-flex max-w-[220px] items-center rounded-md bg-foreground px-3 py-1.5 text-xs text-background shadow-sm">
-              {linkOpenShortcutHint}
-            </div>
-          </div>
-        ) : null}
-        {imageControls ? (
-          <div
-            className="fixed z-30"
-            style={{
-              left: imageControls.left,
-              top: imageControls.top,
-            }}
-          >
-            <Button
-              variant="destructive"
-              size="icon-xs"
-              type="button"
-              className="shadow-md"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={handleDeleteSelectedImage}
+          ) : null}
+          {hoveredLink ? (
+            <div
+              className={`fixed z-30 ${hoveredLink.status === "preview" && hoveredLink.preview ? "w-[min(320px,calc(100vw-2rem))]" : ""}`}
+              style={{
+                left: hoveredLink.tooltipLeft,
+                top: hoveredLink.tooltipTop,
+                transform:
+                  hoveredLink.placement === "above"
+                    ? "translate(-50%, calc(-100% - 4px))"
+                    : "translateX(-50%)",
+              }}
+              onMouseEnter={clearHoveredLinkHideTimeout}
+              onMouseLeave={scheduleHoveredLinkHide}
             >
-              <TrashIcon size={12} />
-            </Button>
-          </div>
-        ) : null}
-        <EditorContent editor={editor} />
+              {hoveredLink.status === "preview" && hoveredLink.preview ? (
+                <div
+                  aria-label="Note link preview"
+                  className="rounded-2xl border border-border/70 bg-card/95 p-3 shadow-lg supports-backdrop-filter:backdrop-blur-sm"
+                >
+                  <div className="space-y-2">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-foreground">
+                        {hoveredLink.preview.title}
+                      </p>
+                      <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                        {hoveredLink.preview.displayPath}
+                      </p>
+                    </div>
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      {hoveredLink.preview.excerpt || "This note does not have preview text yet."}
+                    </p>
+                    <p className="text-[11px] font-medium text-muted-foreground">
+                      {linkOpenShortcutHint}
+                    </p>
+                  </div>
+                </div>
+              ) : hoveredLink.status === "loading" ? (
+                <div
+                  aria-label="Loading preview"
+                  className="rounded-xl border border-border/60 bg-card/95 px-3 py-2 shadow-md supports-backdrop-filter:backdrop-blur-sm"
+                >
+                  <p className="text-xs text-muted-foreground">Loading&hellip;</p>
+                </div>
+              ) : (
+                <div
+                  aria-label="Link hint"
+                  className="rounded-xl border border-border/60 bg-card/95 px-3 py-1.5 shadow-md supports-backdrop-filter:backdrop-blur-sm"
+                >
+                  <p className="text-xs text-muted-foreground">{linkOpenShortcutHint}</p>
+                </div>
+              )}
+            </div>
+          ) : null}
+          {imageControls ? (
+            <div
+              className="fixed z-30"
+              style={{
+                left: imageControls.left,
+                top: imageControls.top,
+              }}
+            >
+              <Button
+                variant="destructive"
+                size="icon-xs"
+                type="button"
+                className="shadow-md"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleDeleteSelectedImage}
+              >
+                <TrashIcon size={12} />
+              </Button>
+            </div>
+          ) : null}
+          <EditorContent editor={editor} />
+        </div>
       </div>
       {shouldShowOutlineRail ? (
         <aside className="pointer-events-none absolute right-8 top-[88px] z-20 hidden xl:block w-[240px] animate-in fade-in slide-in-from-right-2 duration-200 ease-out">

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -5,7 +5,7 @@ import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortc
 import type { NoteTab, ShortcutSetting, TabMovePosition } from "@/shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 import type { UpdateState } from "@/shared/workspace";
-import type { EditorFocusRequest } from "@/types/markdown-editor";
+import type { EditorFindRequest, EditorFocusRequest } from "@/types/markdown-editor";
 
 import { MarkdownEditor } from "./markdown-editor";
 import { NoteTabsBar } from "./note-tabs-bar";
@@ -15,6 +15,7 @@ type NoteViewProps = {
   fileName: string | null;
   filePath: string | null;
   editorFocusRequest: EditorFocusRequest | null;
+  findRequest: EditorFindRequest | null;
   initialScrollTop: number;
   saveStateLabel: string;
   footerMetaLabel: string;
@@ -59,6 +60,7 @@ export function NoteView({
   fileName,
   filePath,
   editorFocusRequest,
+  findRequest,
   initialScrollTop,
   saveStateLabel,
   footerMetaLabel,
@@ -126,6 +128,7 @@ export function NoteView({
       fileName={fileName}
       filePath={filePath}
       editorFocusRequest={editorFocusRequest}
+      findRequest={findRequest}
       initialScrollTop={initialScrollTop}
       saveStateLabel={saveStateLabel}
       footerMetaLabel={footerMetaLabel}

--- a/apps/desktop/src/components/tiptap-extension/find-highlight.ts
+++ b/apps/desktop/src/components/tiptap-extension/find-highlight.ts
@@ -1,0 +1,175 @@
+import { Extension, type Editor } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+type FindHighlightMatch = {
+  from: number;
+  to: number;
+};
+
+export type FindHighlightState = {
+  activeIndex: number;
+  decorations: DecorationSet;
+  matches: FindHighlightMatch[];
+  query: string;
+};
+
+type FindHighlightMeta =
+  | {
+      activeIndex?: number;
+      query?: string;
+    }
+  | undefined;
+
+const EMPTY_FIND_HIGHLIGHT_STATE: FindHighlightState = {
+  activeIndex: -1,
+  decorations: DecorationSet.empty,
+  matches: [],
+  query: "",
+};
+
+export const FIND_HIGHLIGHT_PLUGIN_KEY = new PluginKey<FindHighlightState>("glyphFindHighlight");
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function collectFindHighlightMatches(doc: ProseMirrorNode, query: string): FindHighlightMatch[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const matches: FindHighlightMatch[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) {
+      return;
+    }
+
+    const text = node.text.toLowerCase();
+    let fromIndex = 0;
+
+    while (fromIndex <= text.length - normalizedQuery.length) {
+      const matchIndex = text.indexOf(normalizedQuery, fromIndex);
+      if (matchIndex === -1) {
+        break;
+      }
+
+      const from = pos + matchIndex;
+      const to = from + normalizedQuery.length;
+
+      matches.push({ from, to });
+      fromIndex = matchIndex + Math.max(normalizedQuery.length, 1);
+    }
+  });
+
+  return matches;
+}
+
+function buildFindHighlightState(
+  doc: ProseMirrorNode,
+  query: string,
+  activeIndex: number,
+): FindHighlightState {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) {
+    return EMPTY_FIND_HIGHLIGHT_STATE;
+  }
+
+  const matches = collectFindHighlightMatches(doc, normalizedQuery);
+  if (matches.length === 0) {
+    return {
+      activeIndex: -1,
+      decorations: DecorationSet.empty,
+      matches: [],
+      query: normalizedQuery,
+    };
+  }
+
+  const nextActiveIndex = clamp(activeIndex, 0, matches.length - 1);
+  const decorations = DecorationSet.create(
+    doc,
+    matches.map((match, index) =>
+      Decoration.inline(match.from, match.to, {
+        class:
+          index === nextActiveIndex
+            ? "glyph-find-match glyph-find-match-active"
+            : "glyph-find-match",
+      }),
+    ),
+  );
+
+  return {
+    activeIndex: nextActiveIndex,
+    decorations,
+    matches,
+    query: normalizedQuery,
+  };
+}
+
+export const FindHighlightExtension = Extension.create({
+  name: "findHighlight",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<FindHighlightState>({
+        key: FIND_HIGHLIGHT_PLUGIN_KEY,
+        state: {
+          init: () => EMPTY_FIND_HIGHLIGHT_STATE,
+          apply: (transaction, pluginState, _oldState, newState) => {
+            const meta = transaction.getMeta(FIND_HIGHLIGHT_PLUGIN_KEY) as FindHighlightMeta;
+
+            if (meta) {
+              return buildFindHighlightState(
+                newState.doc,
+                meta.query ?? pluginState.query,
+                meta.activeIndex ?? pluginState.activeIndex,
+              );
+            }
+
+            if (transaction.docChanged && pluginState.query) {
+              return buildFindHighlightState(
+                newState.doc,
+                pluginState.query,
+                pluginState.activeIndex,
+              );
+            }
+
+            return pluginState;
+          },
+        },
+        props: {
+          decorations(state) {
+            return FIND_HIGHLIGHT_PLUGIN_KEY.getState(state)?.decorations ?? DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+export function getFindHighlightState(editor: Editor | null): FindHighlightState {
+  if (!editor) {
+    return EMPTY_FIND_HIGHLIGHT_STATE;
+  }
+
+  return FIND_HIGHLIGHT_PLUGIN_KEY.getState(editor.state) ?? EMPTY_FIND_HIGHLIGHT_STATE;
+}
+
+export function setFindHighlightQuery(editor: Editor, query: string, activeIndex = 0) {
+  editor.view.dispatch(
+    editor.state.tr.setMeta(FIND_HIGHLIGHT_PLUGIN_KEY, {
+      activeIndex,
+      query,
+    }),
+  );
+}
+
+export function setActiveFindHighlightMatch(editor: Editor, activeIndex: number) {
+  editor.view.dispatch(
+    editor.state.tr.setMeta(FIND_HIGHLIGHT_PLUGIN_KEY, {
+      activeIndex,
+    }),
+  );
+}

--- a/apps/desktop/src/components/tiptap-extension/find-highlight.ts
+++ b/apps/desktop/src/components/tiptap-extension/find-highlight.ts
@@ -43,26 +43,49 @@ function collectFindHighlightMatches(doc: ProseMirrorNode, query: string): FindH
 
   const matches: FindHighlightMatch[] = [];
 
+  // Walk block-level nodes that contain inline content (paragraphs, headings,
+  // etc.). For each block we flatten all child text nodes into a single
+  // lowercase string and build a parallel position map so that matches
+  // spanning adjacent text nodes (e.g. across bold/italic marks) are found.
   doc.descendants((node, pos) => {
-    if (!node.isText || !node.text) {
-      return;
+    if (!node.isBlock || !node.inlineContent) {
+      return; // keep descending into container blocks
     }
 
-    const text = node.text.toLowerCase();
+    let flatText = "";
+    const positionMap: number[] = [];
+
+    node.forEach((child, offset) => {
+      if (child.isText && child.text) {
+        const basePos = pos + 1 + offset;
+        for (let i = 0; i < child.text.length; i++) {
+          positionMap.push(basePos + i);
+        }
+        flatText += child.text.toLowerCase();
+      } else {
+        // Non-text inline node (image, hard break) — sentinel prevents
+        // false matches across non-text boundaries.
+        flatText += "\n";
+        positionMap.push(-1);
+      }
+    });
+
     let fromIndex = 0;
 
-    while (fromIndex <= text.length - normalizedQuery.length) {
-      const matchIndex = text.indexOf(normalizedQuery, fromIndex);
+    while (fromIndex <= flatText.length - normalizedQuery.length) {
+      const matchIndex = flatText.indexOf(normalizedQuery, fromIndex);
       if (matchIndex === -1) {
         break;
       }
 
-      const from = pos + matchIndex;
-      const to = from + normalizedQuery.length;
+      const from = positionMap[matchIndex];
+      const to = positionMap[matchIndex + normalizedQuery.length - 1] + 1;
 
       matches.push({ from, to });
       fromIndex = matchIndex + Math.max(normalizedQuery.length, 1);
     }
+
+    return false; // already processed inline children via node.forEach
   });
 
   return matches;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -151,6 +151,9 @@ export const useDesktopAppController = (
     mode: "start" | "end" | "preserve";
     nonce: number;
   } | null>(null);
+  const [findRequest, setFindRequest] = useState<{
+    nonce: number;
+  } | null>(null);
   const [hasBooted, setHasBooted] = useState(false);
   const [outlineJumpRequest, setOutlineJumpRequest] = useState<{
     id: string;
@@ -244,6 +247,18 @@ export const useDesktopAppController = (
       });
     });
   }, []);
+
+  const requestFindInNote = useCallback(() => {
+    if (!activeFile) {
+      return;
+    }
+
+    setIsPaletteOpen(false);
+    setIsSettingsOpen(false);
+    setFindRequest({
+      nonce: Date.now(),
+    });
+  }, [activeFile, setIsPaletteOpen, setIsSettingsOpen]);
 
   const syncTrackedPaths = useCallback(
     async (oldPath: string, nextPath?: string) => {
@@ -1526,6 +1541,7 @@ export const useDesktopAppController = (
     setIsWorkspaceMode,
     navigateBack,
     navigateForward,
+    requestFindInNote,
     triggerUpdateAction,
     isPaletteOpen,
     isSettingsOpen,
@@ -1897,6 +1913,11 @@ export const useDesktopAppController = (
         return;
       }
 
+      if (command === "find-in-note") {
+        requestFindInNote();
+        return;
+      }
+
       if (command === "toggle-sidebar") {
         setIsSidebarCollapsed((prev) => !prev);
         return;
@@ -1985,6 +2006,7 @@ export const useDesktopAppController = (
     syncOpenedFile,
     syncWorkspace,
     glyph,
+    requestFindInNote,
     toggleFocusMode,
     triggerUpdateAction,
     setIsPaletteOpen,
@@ -2008,6 +2030,7 @@ export const useDesktopAppController = (
     createFolder,
     draftContent,
     editorFocusRequest,
+    findRequest,
     error,
     files,
     folderRevealLabel,
@@ -2040,6 +2063,7 @@ export const useDesktopAppController = (
     pinnedNotes,
     readingTime,
     revealInFinder,
+    requestFindInNote,
     requestOutlineJump,
     saveSettings,
     saveStateLabel,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -20,6 +20,7 @@ type UseKeyboardShortcutsOptions = {
   setIsWorkspaceMode: React.Dispatch<React.SetStateAction<boolean>>;
   navigateBack: () => Promise<void>;
   navigateForward: () => Promise<void>;
+  requestFindInNote: () => void;
   triggerUpdateAction: () => Promise<void>;
   isPaletteOpen: boolean;
   isSettingsOpen: boolean;
@@ -46,6 +47,7 @@ export function useKeyboardShortcuts({
   setIsWorkspaceMode,
   navigateBack,
   navigateForward,
+  requestFindInNote,
   triggerUpdateAction,
   isPaletteOpen,
   isSettingsOpen,
@@ -130,6 +132,7 @@ export function useKeyboardShortcuts({
       const globalShortcutIds = new Set([
         "toggle-sidebar",
         "command-palette",
+        "find-in-note",
         "settings",
         "navigate-back",
         "navigate-forward",
@@ -151,6 +154,9 @@ export function useKeyboardShortcuts({
             break;
           case "command-palette":
             setIsPaletteOpen((value) => !value);
+            break;
+          case "find-in-note":
+            requestFindInNote();
             break;
           case "settings":
             setIsSettingsOpen((value) => !value);
@@ -256,6 +262,7 @@ export function useKeyboardShortcuts({
     setIsWorkspaceMode,
     navigateBack,
     navigateForward,
+    requestFindInNote,
     triggerUpdateAction,
     isPaletteOpen,
     isSettingsOpen,

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -2,6 +2,7 @@ import type { ShortcutSetting } from "./workspace.js";
 
 export type ShortcutId =
   | "command-palette"
+  | "find-in-note"
   | "new-note"
   | "new-folder"
   | "close-tab"
@@ -37,30 +38,51 @@ export type ShortcutEventLike = {
   repeat?: boolean;
 };
 
-export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
-  // App shortcuts (fire globally, even from inside the editor)
-  { id: "command-palette", label: "Command Palette", keys: "⌘ P" },
-  { id: "new-note", label: "New Note", keys: "⌘ N" },
-  { id: "new-folder", label: "New Folder", keys: "⇧ ⌘ N" },
-  { id: "close-tab", label: "Close Tab", keys: "⌘ W" },
-  { id: "close-other-tabs", label: "Close Other Tabs", keys: "⇧ ⌘ W" },
-  { id: "open-file", label: "Open File", keys: "⌘ O" },
-  { id: "open-folder", label: "Open Folder", keys: "⇧ ⌘ O" },
-  { id: "check-updates", label: "Update Action", keys: "⇧ ⌘ U" },
-  { id: "save", label: "Save", keys: "⌘ S" },
-  { id: "settings", label: "Settings", keys: "⌘ ," },
-  { id: "toggle-sidebar", label: "Toggle Sidebar", keys: "⌘ \\" },
-  { id: "navigate-back", label: "Navigate Back", keys: "⌘ [" },
-  { id: "navigate-forward", label: "Navigate Forward", keys: "⌘ ]" },
-  { id: "focus-mode", label: "Toggle Focus Mode", keys: "⇧ ⌘ F" },
-];
-
 export const MODIFIER_TOKENS = {
   cmdOrCtrl: "⌘",
   ctrl: "Ctrl+",
   alt: "⌥",
   shift: "⇧",
 } as const;
+
+export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
+  // App shortcuts (fire globally, even from inside the editor)
+  { id: "command-palette", label: "Command Palette", keys: `${MODIFIER_TOKENS.cmdOrCtrl} P` },
+  { id: "find-in-note", label: "Find in Note", keys: `${MODIFIER_TOKENS.cmdOrCtrl} F` },
+  { id: "new-note", label: "New Note", keys: `${MODIFIER_TOKENS.cmdOrCtrl} N` },
+  {
+    id: "new-folder",
+    label: "New Folder",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} N`,
+  },
+  { id: "close-tab", label: "Close Tab", keys: `${MODIFIER_TOKENS.cmdOrCtrl} W` },
+  {
+    id: "close-other-tabs",
+    label: "Close Other Tabs",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} W`,
+  },
+  { id: "open-file", label: "Open File", keys: `${MODIFIER_TOKENS.cmdOrCtrl} O` },
+  {
+    id: "open-folder",
+    label: "Open Folder",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} O`,
+  },
+  {
+    id: "check-updates",
+    label: "Update Action",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} U`,
+  },
+  { id: "save", label: "Save", keys: `${MODIFIER_TOKENS.cmdOrCtrl} S` },
+  { id: "settings", label: "Settings", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ,` },
+  { id: "toggle-sidebar", label: "Toggle Sidebar", keys: `${MODIFIER_TOKENS.cmdOrCtrl} \\` },
+  { id: "navigate-back", label: "Navigate Back", keys: `${MODIFIER_TOKENS.cmdOrCtrl} [` },
+  { id: "navigate-forward", label: "Navigate Forward", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ]` },
+  {
+    id: "focus-mode",
+    label: "Toggle Focus Mode",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} F`,
+  },
+];
 
 export function getPrimaryShortcutPrefix(platform?: string): string {
   const normalizedPlatform = platform?.toLowerCase() ?? "";

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -60,6 +60,13 @@ export type ResolvedLinkTarget = {
   target: string;
 };
 
+export type NoteLinkPreview = {
+  targetPath: string;
+  title: string;
+  excerpt: string;
+  displayPath: string;
+};
+
 export type SearchResult = {
   path: string;
   name: string;
@@ -145,6 +152,7 @@ export type AppCommand =
   | "previous-tab"
   | "search"
   | "quick-open"
+  | "find-in-note"
   | "toggle-sidebar"
   | "focus-mode";
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -366,6 +366,17 @@ body {
   scrollbar-width: none; /* Firefox */
 }
 
+.glyph-find-match {
+  border-radius: calc(var(--radius) * 0.75);
+  background: color-mix(in oklch, var(--color-primary) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--color-primary) 18%, transparent);
+}
+
+.glyph-find-match-active {
+  background: color-mix(in oklch, var(--color-primary) 24%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--color-primary) 38%, transparent);
+}
+
 /* macOS drag region for window controls */
 .app-drag-region {
   -webkit-app-region: drag;

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -8,6 +8,10 @@ export type EditorFocusRequest = {
   nonce: number;
 };
 
+export type EditorFindRequest = {
+  nonce: number;
+};
+
 export type MarkdownEditorProps = {
   content: string;
   fileName: string | null;
@@ -16,6 +20,7 @@ export type MarkdownEditorProps = {
   initialScrollTop?: number | null;
   scrollRestorationKey?: string | null;
   editorFocusRequest?: EditorFocusRequest | null;
+  findRequest?: EditorFindRequest | null;
   workspaceRootPath?: string | null;
   saveStateLabel: string;
   footerMetaLabel?: string;

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -9,6 +9,7 @@ import type {
   UpdateState,
   FileDocument,
   FileOpenResult,
+  NoteLinkPreview,
   ResolvedLinkTarget,
   SearchResult,
   WorkspaceChangeEvent,
@@ -26,6 +27,10 @@ declare global {
         currentFilePath: string | null,
         href: string,
       ) => Promise<ResolvedLinkTarget | null>;
+      getLinkPreview: (
+        currentFilePath: string | null,
+        href: string,
+      ) => Promise<NoteLinkPreview | null>;
       openFolder: (dirPath?: string) => Promise<WorkspaceSnapshot | null>;
       openDefaultWorkspace: () => Promise<WorkspaceSnapshot | null>;
       openDocument: () => Promise<FileDocument | null>;


### PR DESCRIPTION
## Summary
- add a true in-note `Cmd/Ctrl+F` flow with inline match highlighting, result counts, next/previous navigation, selection-prefill, and menu/command-palette/shortcut wiring
- add hover previews for local markdown note links, including title, excerpt, relative path, and existing `Cmd/Ctrl+Click` open behavior
- preserve safe relative note links like `notes/nested-note.md` inside the editor so linked notes stay interactive instead of being stripped during link sanitization
- extend the Electron smoke suite to cover find-in-note and local note-link preview behavior end to end

## Notes
- note previews are only shown for resolved markdown-note targets; unresolved or non-note links still fall back to the lighter open-link hint
- the desktop commit hook also re-ran repo linting and typechecking before the final commit was created

## Testing
- `pnpm typecheck:desktop`
- `pnpm lint:desktop`
- `pnpm test:e2e:desktop`

Closes #142
Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Find in current note" — open with ⌘/Ctrl+F (or via Edit menu), navigate matches with Enter/Shift+Enter, close with Escape; preserves editor focus when dismissed.
  * Added note link previews — hover markdown note links to see a preview card showing the linked note’s title, excerpt, and path.

* **Tests**
  * Added end-to-end tests for find-in-note behavior and note link preview display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->