### PR TITLE
fix(desktop): harden manual macOS update flow

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -309,6 +309,24 @@ async function savePersistedUpdateState(next: PersistedUpdateState) {
   return next;
 }
 
+async function clearPersistedStagedUpdateState() {
+  const loadedState = await loadPersistedUpdateState();
+  const nextPersistedUpdateState = {
+    ...loadedState,
+    stagedVersion: null,
+    stagedReleaseName: null,
+    stagedReleaseNotes: null,
+  };
+
+  persistedUpdateState = nextPersistedUpdateState;
+
+  if (JSON.stringify(nextPersistedUpdateState) !== JSON.stringify(loadedState)) {
+    await queuePersistedUpdateStateWrite(nextPersistedUpdateState);
+  }
+
+  return nextPersistedUpdateState;
+}
+
 function queuePersistedUpdateStateWrite(next: PersistedUpdateState) {
   persistedUpdateState = next;
 
@@ -486,7 +504,12 @@ function wireAutoUpdater() {
   if (getUpdatesMode() !== "automatic") {
     setUpdateState({
       status: "idle",
+      availableVersion: null,
+      downloadedVersion: null,
       releasePageUrl: null,
+      releaseName: null,
+      releaseNotes: null,
+      progressPercent: null,
       checkedAt: new Date().toISOString(),
       errorMessage: null,
     });
@@ -603,7 +626,16 @@ async function checkForAppUpdates() {
 
   if (updatesMode === "manual") {
     if (updateState.status === "downloading" || updateState.status === "downloaded") {
-      return updateState;
+      void clearPersistedStagedUpdateState();
+      setUpdateState({
+        status: "idle",
+        downloadedVersion: null,
+        releasePageUrl: null,
+        releaseName: null,
+        releaseNotes: null,
+        progressPercent: null,
+        errorMessage: null,
+      });
     }
 
     return checkForManualReleaseUpdates();
@@ -2146,6 +2178,8 @@ app
       // loaded yet so broadcastUpdateState inside hydrate is a no-op anyway.
       // We re-broadcast after createWindow finishes.
       void hydratePersistedUpdateState();
+    } else if (app.isPackaged && !isDev) {
+      void clearPersistedStagedUpdateState();
     }
 
     if (process.platform === "darwin" && app.dock) {

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1267,6 +1267,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                     ? () => void controller.togglePinnedFile(controller.activeFile!.path)
                     : undefined
                 }
+                updatesMode={controller.appInfo?.updatesMode}
                 onUpdateAction={() => void controller.triggerUpdateAction()}
               />
             )}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -382,6 +382,7 @@ export const MarkdownEditor = ({
   isActiveFilePinned,
   onOutlineJumpHandled,
   updateState,
+  updatesMode,
   onUpdateAction,
   isFocusMode,
   showOutline = true,
@@ -598,7 +599,7 @@ export const MarkdownEditor = ({
   );
 
   const effectiveUpdateState = devPreviewUpdateState ?? updateState ?? null;
-  const updateStateFlags = useUpdateStateFlags(effectiveUpdateState);
+  const updateStateFlags = useUpdateStateFlags(effectiveUpdateState, updatesMode);
   const isFocusLayout = Boolean(isFocusMode);
   const revealInFolderLabel = folderRevealLabel ?? getFolderRevealLabel(navigator.platform);
   const isMacLike = useMemo(() => navigator.platform.includes("Mac"), []);

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { getDisplayFileName } from "@/lib/paths";
 import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
-import type { NoteTab, ShortcutSetting, TabMovePosition } from "@/shared/workspace";
+import type { AppInfo, NoteTab, ShortcutSetting, TabMovePosition } from "@/shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 import type { UpdateState } from "@/shared/workspace";
 import type { EditorFindRequest, EditorFocusRequest } from "@/types/markdown-editor";
@@ -35,6 +35,7 @@ type NoteViewProps = {
   outlineItems: OutlineItem[];
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;
+  updatesMode?: AppInfo["updatesMode"];
   onContentChange: (value: string) => void;
   onSelectTab: (path: string) => void;
   onCloseTab: (path: string) => void;
@@ -80,6 +81,7 @@ export function NoteView({
   outlineItems,
   outlineJumpRequest,
   updateState,
+  updatesMode,
   onContentChange,
   onSelectTab,
   onCloseTab,
@@ -178,6 +180,7 @@ export function NoteView({
       scrollRestorationKey={filePath}
       showOutline={showOutline}
       updateState={updateState}
+      updatesMode={updatesMode}
       onUpdateAction={onUpdateAction}
     />
   );

--- a/apps/desktop/src/components/update-notification.tsx
+++ b/apps/desktop/src/components/update-notification.tsx
@@ -1,16 +1,20 @@
 import { useMemo } from "react";
 
-import type { UpdateState } from "@/shared/workspace";
+import type { AppInfo, UpdateState } from "@/shared/workspace";
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 type UpdateNotificationProps = {
   updateState: UpdateState | null;
+  updatesMode?: AppInfo["updatesMode"];
   onUpdateAction: (() => void) | undefined;
 };
 
-export function useUpdateStateFlags(updateState: UpdateState | null) {
+export function useUpdateStateFlags(
+  updateState: UpdateState | null,
+  updatesMode?: AppInfo["updatesMode"],
+) {
   return useMemo((): {
     shouldShowUpdateActionButton: boolean;
     updateButtonLabel: string;
@@ -30,7 +34,10 @@ export function useUpdateStateFlags(updateState: UpdateState | null) {
 
     const shouldShowUpdateActionButton = shouldShowUpdateButton || shouldShowChangelogButton;
     const isManualReleaseButton =
-      updateState?.status === "available" && Boolean(updateState?.releasePageUrl);
+      updatesMode === "manual" &&
+      (updateState?.status === "available" ||
+        updateState?.status === "downloading" ||
+        updateState?.status === "downloaded");
 
     const updateButtonLabel = shouldShowChangelogButton
       ? "View changelog"
@@ -62,7 +69,9 @@ export function useUpdateStateFlags(updateState: UpdateState | null) {
                 ? `Glyph hit an update error. ${updateState.errorMessage}`
                 : "Check whether a newer Glyph release is available";
 
-    const isUpdateButtonDisabled = updateState?.status === "downloading";
+    const isUpdateButtonDisabled = isManualReleaseButton
+      ? false
+      : updateState?.status === "downloading";
     const updateButtonVariant =
       shouldShowChangelogButton || isManualReleaseButton ? "outline" : "default";
 
@@ -73,17 +82,21 @@ export function useUpdateStateFlags(updateState: UpdateState | null) {
       isUpdateButtonDisabled,
       updateButtonVariant,
     };
-  }, [updateState]);
+  }, [updateState, updatesMode]);
 }
 
-export function UpdateNotification({ updateState, onUpdateAction }: UpdateNotificationProps) {
+export function UpdateNotification({
+  updateState,
+  updatesMode,
+  onUpdateAction,
+}: UpdateNotificationProps) {
   const {
     shouldShowUpdateActionButton,
     updateButtonLabel,
     updateButtonTooltip,
     isUpdateButtonDisabled,
     updateButtonVariant,
-  } = useUpdateStateFlags(updateState);
+  } = useUpdateStateFlags(updateState, updatesMode);
 
   if (!shouldShowUpdateActionButton || !onUpdateAction) {
     return null;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -47,6 +47,7 @@ const NOTE_NAME_SAFE_CHAR_PATTERN = /[^a-zA-Z0-9-_\s]/g;
 const TITLE_PREFIX_PATTERN = /^#+\s*/;
 const NOTE_NAME_MAX_LENGTH = 50;
 const APP_CHANGELOG_URL = "https://github.com/FALAK097/glyph/blob/main/CHANGELOG.md";
+const APP_RELEASES_URL = "https://github.com/FALAK097/glyph/releases";
 
 const getRenamedFolderFilePath = (
   oldFolderPath: string,
@@ -1029,8 +1030,12 @@ export const useDesktopAppController = (
     }
 
     if (appInfo.updatesMode === "manual") {
-      if (updateState.status === "available" && updateState.releasePageUrl) {
-        await glyph.openExternal(updateState.releasePageUrl);
+      if (
+        updateState.status === "available" ||
+        updateState.status === "downloading" ||
+        updateState.status === "downloaded"
+      ) {
+        await glyph.openExternal(updateState.releasePageUrl ?? APP_RELEASES_URL);
         return;
       }
 
@@ -1082,12 +1087,15 @@ export const useDesktopAppController = (
 
     const isManualReleaseAction =
       appInfo.updatesMode === "manual" &&
-      updateState.status === "available" &&
-      Boolean(updateState.releasePageUrl);
+      (updateState.status === "available" ||
+        updateState.status === "downloading" ||
+        updateState.status === "downloaded");
     if (isManualReleaseAction) {
       return {
         title: "Download Latest Release",
-        subtitle: "Open GitHub Releases to download and install manually",
+        subtitle: updateState.availableVersion
+          ? `Open GitHub Releases to download Glyph ${updateState.availableVersion} manually`
+          : "Open GitHub Releases to download and install manually",
         isDisabled: false,
       };
     }

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import type { UpdateState } from "../shared/workspace";
+import type { AppInfo, UpdateState } from "../shared/workspace";
 import type { OutlineItem } from "@/types/navigation";
 
 export type EditorFocusRequest = {
@@ -50,6 +50,7 @@ export type MarkdownEditorProps = {
   isActiveFilePinned?: boolean;
   onOutlineJumpHandled?: () => void;
   updateState?: UpdateState | null;
+  updatesMode?: AppInfo["updatesMode"];
   onUpdateAction?: () => void;
   isFocusMode?: boolean;
   showOutline?: boolean;


### PR DESCRIPTION
## Summary
- harden the macOS manual-update flow so stale `downloading`/`downloaded` updater state is cleared instead of surfacing a restart/install path
- route actionable macOS update CTAs back to GitHub Releases even if stale state leaks through, while keeping Windows automatic updates unchanged
- clear staged updater metadata on non-automatic startup so old staged state cannot keep confusing future macOS builds

## Testing
- pnpm fmt:check
- pnpm --filter @glyph/desktop lint
- pnpm --filter @glyph/desktop typecheck
- pnpm --filter @glyph/desktop build
- pnpm test:e2e:desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual update mode handling: fixed persisted state clearing and enhanced update button availability during downloads.
  * Added fallback to GitHub releases page when release information is unavailable.

* **New Features**
  * Manual update mode now displays available version details in update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->