### PR TITLE
feat(repo): add welcome note onboarding and web asset fixes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -93,6 +93,10 @@ let watcherDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let changedPathsBatch = new Set<string>();
 const MARKDOWN_EXTENSIONS = [".md", ".mdx", ".markdown"] as const;
 const UPDATE_CHECK_INTERVAL_MS = 1000 * 60 * 60 * 6;
+const WELCOME_NOTE_VERSION = 3;
+const WELCOME_NOTE_FILE_NAME = "Welcome to Glyph.md";
+const LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME = "glyph-welcome-hero.svg";
+const WELCOME_NOTE_IMAGE_URL = "https://glyph.falakgala.dev/og-image.png";
 const skillsService = createSkillsService({
   projectRoot: null,
   onLibraryChanged: (event) => {
@@ -955,6 +959,8 @@ async function getLinkPreview(
 function getDefaultSettings(): AppSettings {
   return {
     defaultWorkspacePath: getDefaultWorkspacePath(),
+    hasSeenWelcomeNote: false,
+    welcomeNoteVersionSeen: 0,
     themeId: "aura",
     themeMode: "light",
     hiddenFiles: [],
@@ -1260,6 +1266,13 @@ async function sanitizeSettingsWithFileValidation(input: unknown): Promise<AppSe
       candidate.defaultWorkspacePath.trim().length > 0
         ? candidate.defaultWorkspacePath
         : defaults.defaultWorkspacePath,
+    hasSeenWelcomeNote:
+      typeof candidate.hasSeenWelcomeNote === "boolean" ? candidate.hasSeenWelcomeNote : false,
+    welcomeNoteVersionSeen:
+      typeof candidate.welcomeNoteVersionSeen === "number" &&
+      Number.isFinite(candidate.welcomeNoteVersionSeen)
+        ? Math.max(0, Math.trunc(candidate.welcomeNoteVersionSeen))
+        : 0,
     themeId:
       typeof candidate.themeId === "string" && candidate.themeId.trim().length > 0
         ? candidate.themeId
@@ -1443,6 +1456,134 @@ async function ensureWorkspace(dirPath: string) {
   await fs.mkdir(dirPath, { recursive: true });
 }
 
+function buildWelcomeNoteContent() {
+  return `# Welcome to Glyph
+
+![Welcome to Glyph](${WELCOME_NOTE_IMAGE_URL})
+
+Glyph is a local-first markdown app built around folders, shortcuts, and a writing surface that stays out of your way.
+
+## Start here
+
+- Create notes with \`Cmd/Ctrl + N\`
+- Jump anywhere with the Command Palette using \`Cmd/Ctrl + P\`
+- Use slash commands like \`/heading\`, \`/table\`, and \`/task list\`
+- Open your notes directly from the folders you already own
+
+## What Glyph can do
+
+| Area | What you can try |
+| --- | --- |
+| Writing | Headings, lists, tasks, tables, links, code blocks, and images |
+| Navigation | Tabs, global search, in-note find, outline jump, and back/forward history |
+| File workflow | Reveal in Finder or Explorer, copy note paths, and keep everything as plain markdown |
+| Output | Copy as markdown or export a note as PDF |
+
+## A few useful links
+
+- [GitHub releases](https://github.com/FALAK097/glyph/releases)
+- [Project changelog](https://github.com/FALAK097/glyph/blob/main/CHANGELOG.md)
+- [Report an issue or request a feature](https://github.com/FALAK097/glyph/issues)
+
+## Example task list
+
+- [ ] Create your first note
+- [ ] Pin an important file
+- [ ] Try the command palette
+- [ ] Export something to PDF
+
+## Example table
+
+| Shortcut | Action |
+| --- | --- |
+| \`Cmd/Ctrl + N\` | New note |
+| \`Cmd/Ctrl + P\` | Open the command palette |
+| \`Cmd/Ctrl + F\` | Find in the current note |
+
+## Example code block
+
+\`\`\`md
+# Daily note
+
+- Capture ideas quickly
+- Link related notes together
+- Keep everything in plain markdown
+\`\`\`
+
+## Your files stay local
+
+This note is just a normal markdown file inside your Glyph workspace. You can rename it, move it, edit it, or delete it. Once it is gone, Glyph will not recreate it.
+`;
+}
+
+async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
+  const welcomeNotePath = path.join(settings.defaultWorkspacePath, WELCOME_NOTE_FILE_NAME);
+  const legacyWelcomeNoteImagePath = path.join(
+    settings.defaultWorkspacePath,
+    LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME,
+  );
+
+  if (settings.welcomeNoteVersionSeen >= WELCOME_NOTE_VERSION) {
+    return {
+      settings,
+      shouldOpenWelcomeNote: false,
+      welcomeNotePath,
+    };
+  }
+
+  const workspacePath = settings.defaultWorkspacePath;
+  await ensureWorkspace(workspacePath);
+  await fs.rm(legacyWelcomeNoteImagePath, { force: true });
+  let nextWelcomeNoteContent = buildWelcomeNoteContent();
+  let shouldRewriteWelcomeNote = false;
+  try {
+    const existingWelcomeNote = await fs.readFile(welcomeNotePath, "utf8");
+    const updatedWelcomeNote = existingWelcomeNote.replace(
+      /!\[Welcome to Glyph]\([^)]+\)/,
+      `![Welcome to Glyph](${WELCOME_NOTE_IMAGE_URL})`,
+    );
+    shouldRewriteWelcomeNote = updatedWelcomeNote !== existingWelcomeNote;
+    nextWelcomeNoteContent = updatedWelcomeNote;
+  } catch (error) {
+    const code =
+      typeof error === "object" && error && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    if (code === "ENOENT") {
+      shouldRewriteWelcomeNote = true;
+    } else {
+      throw error;
+    }
+  }
+
+  try {
+    await fs.writeFile(welcomeNotePath, nextWelcomeNoteContent, {
+      encoding: "utf8",
+      flag: shouldRewriteWelcomeNote ? "w" : "wx",
+    });
+  } catch (error) {
+    const code =
+      typeof error === "object" && error && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    if (code !== "EEXIST") {
+      throw error;
+    }
+  }
+
+  const nextSettings = {
+    ...settings,
+    hasSeenWelcomeNote: true,
+    welcomeNoteVersionSeen: WELCOME_NOTE_VERSION,
+  };
+  await saveSettings(nextSettings);
+  return {
+    settings: nextSettings,
+    shouldOpenWelcomeNote: true,
+    welcomeNotePath,
+  };
+}
+
 async function readMarkdownFile(filePath: string) {
   let raw: string;
   try {
@@ -1562,14 +1703,26 @@ function getPreferredWorkspaceFilePath(filePaths: string[]) {
   return filePaths[0] ?? null;
 }
 
-async function openWorkspace(dirPath: string): Promise<WorkspaceSnapshot> {
+async function openWorkspace(
+  dirPath: string,
+  options?: {
+    preferredActiveFilePath?: string | null;
+  },
+): Promise<WorkspaceSnapshot> {
   await ensureWorkspace(dirPath);
   activeWorkspaceRoot = dirPath;
   await skillsService.setProjectRoot(dirPath);
 
   const tree = await buildDirectoryTree(dirPath);
   searchableFilesCache = await collectMarkdownFiles(tree);
-  const activeFilePath = getPreferredWorkspaceFilePath(searchableFilesCache);
+  const preferredActiveFilePath = options?.preferredActiveFilePath
+    ? path.normalize(options.preferredActiveFilePath)
+    : null;
+  const activeFilePath =
+    preferredActiveFilePath &&
+    searchableFilesCache.some((filePath) => path.normalize(filePath) === preferredActiveFilePath)
+      ? preferredActiveFilePath
+      : getPreferredWorkspaceFilePath(searchableFilesCache);
   const activeFile = activeFilePath ? await readMarkdownFile(activeFilePath) : null;
 
   if (watcherDebounceTimer) {
@@ -1819,8 +1972,12 @@ ipcMain.handle("workspace:openFolder", async (_event, dirPath?: string) => {
 });
 
 ipcMain.handle("workspace:openDefault", async () => {
-  const settings = await loadSettings();
-  return openWorkspace(settings.defaultWorkspacePath);
+  const { settings, shouldOpenWelcomeNote, welcomeNotePath } = await ensureWelcomeNoteForFirstRun(
+    await loadSettings(),
+  );
+  return openWorkspace(settings.defaultWorkspacePath, {
+    preferredActiveFilePath: shouldOpenWelcomeNote ? welcomeNotePath : null,
+  });
 });
 
 function assertBasename(name: string) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1534,7 +1534,23 @@ async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
   const workspacePath = settings.defaultWorkspacePath;
   await ensureWorkspace(workspacePath);
   await fs.rm(legacyWelcomeNoteImagePath, { force: true });
+  const workspaceEntries = await fs.readdir(workspacePath, { withFileTypes: true });
+  const hasOtherWorkspaceContent = workspaceEntries.some((entry) => {
+    if (
+      entry.name === WELCOME_NOTE_FILE_NAME ||
+      entry.name === LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME
+    ) {
+      return false;
+    }
+
+    if (entry.name === ".DS_Store") {
+      return false;
+    }
+
+    return entry.isDirectory() || (entry.isFile() && isMarkdownFile(entry.name));
+  });
   let nextWelcomeNoteContent = buildWelcomeNoteContent();
+  let shouldOpenWelcomeNote = false;
   let shouldRewriteWelcomeNote = false;
   try {
     const existingWelcomeNote = await fs.readFile(welcomeNotePath, "utf8");
@@ -1550,7 +1566,21 @@ async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
         ? String((error as { code?: unknown }).code)
         : "";
     if (code === "ENOENT") {
-      shouldRewriteWelcomeNote = true;
+      if (hasOtherWorkspaceContent) {
+        const nextSettings = {
+          ...settings,
+          hasSeenWelcomeNote: true,
+          welcomeNoteVersionSeen: WELCOME_NOTE_VERSION,
+        };
+        await saveSettings(nextSettings);
+        return {
+          settings: nextSettings,
+          shouldOpenWelcomeNote: false,
+          welcomeNotePath,
+        };
+      }
+
+      shouldOpenWelcomeNote = true;
     } else {
       throw error;
     }
@@ -1559,7 +1589,7 @@ async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
   try {
     await fs.writeFile(welcomeNotePath, nextWelcomeNoteContent, {
       encoding: "utf8",
-      flag: shouldRewriteWelcomeNote ? "w" : "wx",
+      flag: shouldRewriteWelcomeNote || !shouldOpenWelcomeNote ? "w" : "wx",
     });
   } catch (error) {
     const code =
@@ -1579,7 +1609,7 @@ async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
   await saveSettings(nextSettings);
   return {
     settings: nextSettings,
-    shouldOpenWelcomeNote: true,
+    shouldOpenWelcomeNote,
     welcomeNotePath,
   };
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -95,7 +95,6 @@ const MARKDOWN_EXTENSIONS = [".md", ".mdx", ".markdown"] as const;
 const UPDATE_CHECK_INTERVAL_MS = 1000 * 60 * 60 * 6;
 const WELCOME_NOTE_VERSION = 3;
 const WELCOME_NOTE_FILE_NAME = "Welcome to Glyph.md";
-const LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME = "glyph-welcome-hero.svg";
 const WELCOME_NOTE_IMAGE_URL = "https://glyph.falakgala.dev/og-image.png";
 const skillsService = createSkillsService({
   projectRoot: null,
@@ -1518,10 +1517,6 @@ This note is just a normal markdown file inside your Glyph workspace. You can re
 
 async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
   const welcomeNotePath = path.join(settings.defaultWorkspacePath, WELCOME_NOTE_FILE_NAME);
-  const legacyWelcomeNoteImagePath = path.join(
-    settings.defaultWorkspacePath,
-    LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME,
-  );
 
   if (settings.welcomeNoteVersionSeen >= WELCOME_NOTE_VERSION) {
     return {
@@ -1533,13 +1528,9 @@ async function ensureWelcomeNoteForFirstRun(settings: AppSettings) {
 
   const workspacePath = settings.defaultWorkspacePath;
   await ensureWorkspace(workspacePath);
-  await fs.rm(legacyWelcomeNoteImagePath, { force: true });
   const workspaceEntries = await fs.readdir(workspacePath, { withFileTypes: true });
   const hasOtherWorkspaceContent = workspaceEntries.some((entry) => {
-    if (
-      entry.name === WELCOME_NOTE_FILE_NAME ||
-      entry.name === LEGACY_WELCOME_NOTE_IMAGE_FILE_NAME
-    ) {
+    if (entry.name === WELCOME_NOTE_FILE_NAME) {
       return false;
     }
 
@@ -1748,11 +1739,16 @@ async function openWorkspace(
   const preferredActiveFilePath = options?.preferredActiveFilePath
     ? path.normalize(options.preferredActiveFilePath)
     : null;
-  const activeFilePath =
-    preferredActiveFilePath &&
-    searchableFilesCache.some((filePath) => path.normalize(filePath) === preferredActiveFilePath)
-      ? preferredActiveFilePath
-      : getPreferredWorkspaceFilePath(searchableFilesCache);
+  const preferredActiveFileMatch = preferredActiveFilePath
+    ? (searchableFilesCache.find(
+        (filePath) =>
+          normalizePathForComparison(filePath) ===
+          normalizePathForComparison(preferredActiveFilePath),
+      ) ?? null)
+    : null;
+  const activeFilePath = preferredActiveFileMatch
+    ? preferredActiveFileMatch
+    : getPreferredWorkspaceFilePath(searchableFilesCache);
   const activeFile = activeFilePath ? await readMarkdownFile(activeFilePath) : null;
 
   if (watcherDebounceTimer) {
@@ -2002,12 +1998,21 @@ ipcMain.handle("workspace:openFolder", async (_event, dirPath?: string) => {
 });
 
 ipcMain.handle("workspace:openDefault", async () => {
-  const { settings, shouldOpenWelcomeNote, welcomeNotePath } = await ensureWelcomeNoteForFirstRun(
-    await loadSettings(),
-  );
-  return openWorkspace(settings.defaultWorkspacePath, {
-    preferredActiveFilePath: shouldOpenWelcomeNote ? welcomeNotePath : null,
-  });
+  const settings = await loadSettings();
+
+  try {
+    const {
+      settings: nextSettings,
+      shouldOpenWelcomeNote,
+      welcomeNotePath,
+    } = await ensureWelcomeNoteForFirstRun(settings);
+    return openWorkspace(nextSettings.defaultWorkspacePath, {
+      preferredActiveFilePath: shouldOpenWelcomeNote ? welcomeNotePath : null,
+    });
+  } catch (error) {
+    console.error("Failed to provision welcome note:", error);
+    return openWorkspace(settings.defaultWorkspacePath);
+  }
 });
 
 function assertBasename(name: string) {

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1590,7 +1590,7 @@ export const useDesktopAppController = (
             try {
               return await glyph.openDefaultWorkspace();
             } catch {
-              return null;
+              // If welcome-note setup fails, still try opening the folder directly.
             }
           }
 

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -765,7 +765,6 @@ export const useDesktopAppController = (
         setIsWorkspaceMode(true);
         setSidebarNodes((prev) => upsertSidebarFile(prev, file));
         pushHistory(file.path);
-        requestEditorFocus("preserve");
         return file;
       })();
 
@@ -1587,6 +1586,14 @@ export const useDesktopAppController = (
       let bootFocusMode: "start" | "end" | "preserve" = "start";
       const tryOpenWorkspace = async (targetPath: string | null) => {
         if (targetPath) {
+          if (isSamePath(targetPath, nextSettings.defaultWorkspacePath)) {
+            try {
+              return await glyph.openDefaultWorkspace();
+            } catch {
+              return null;
+            }
+          }
+
           try {
             const existingWorkspace = await glyph.getSidebarNode("directory", targetPath);
             if (existingWorkspace) {

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -98,6 +98,8 @@ export type EditorPreferences = {
 
 export type AppSettings = {
   defaultWorkspacePath: string;
+  hasSeenWelcomeNote: boolean;
+  welcomeNoteVersionSeen: number;
   themeId: string;
   themeMode: ThemeMode;
   hiddenFiles: string[];

--- a/apps/web/public/og-image/index.html
+++ b/apps/web/public/og-image/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0; url=/og-image.png" />
+    <link rel="canonical" href="https://glyph.falakgala.dev/og-image.png" />
+    <title>Glyph Open Graph Image</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #faf8f2;
+      }
+
+      img {
+        display: block;
+        width: min(100vw, 1200px);
+        height: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      window.location.replace("/og-image.png");
+    </script>
+    <img src="/og-image.png" alt="Glyph Open Graph preview" width="1200" height="630" />
+  </body>
+</html>

--- a/apps/web/public/og-image/index.html
+++ b/apps/web/public/og-image/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <meta http-equiv="refresh" content="0; url=/og-image.png" />
-    <link rel="canonical" href="https://glyph.falakgala.dev/og-image.png" />
+    <link rel="canonical" href="/og-image.png" />
     <title>Glyph Open Graph Image</title>
     <style>
       :root {

--- a/apps/web/src/home-page.tsx
+++ b/apps/web/src/home-page.tsx
@@ -297,7 +297,7 @@ export function HomePage() {
             <div id="install-with-homebrew" className="clean-home__brew">
               <div className="clean-home__brew-row">
                 <code className="clean-home__brew-command">
-                  <span className="clean-home__brew-prefix">{BREW_COMMAND_PREFIX}</span>
+                  <span className="clean-home__brew-prefix">{BREW_COMMAND_PREFIX}</span>{" "}
                   <span className="clean-home__brew-formula">{BREW_COMMAND_FORMULA}</span>
                 </code>
                 <button

--- a/apps/web/src/home-page.tsx
+++ b/apps/web/src/home-page.tsx
@@ -185,6 +185,11 @@ const faqItems: FaqItem[] = [
   },
 ];
 
+const BREW_COMMAND_PREFIX = "brew install --cask";
+const BREW_COMMAND_FORMULA = BREW_INSTALL_COMMAND.startsWith(`${BREW_COMMAND_PREFIX} `)
+  ? BREW_INSTALL_COMMAND.slice(BREW_COMMAND_PREFIX.length + 1)
+  : BREW_INSTALL_COMMAND;
+
 type ShotCardProps = {
   shot: Shot;
   variant?: "default" | "hero";
@@ -291,7 +296,10 @@ export function HomePage() {
 
             <div id="install-with-homebrew" className="clean-home__brew">
               <div className="clean-home__brew-row">
-                <code className="clean-home__brew-command">{BREW_INSTALL_COMMAND}</code>
+                <code className="clean-home__brew-command">
+                  <span className="clean-home__brew-prefix">{BREW_COMMAND_PREFIX}</span>
+                  <span className="clean-home__brew-formula">{BREW_COMMAND_FORMULA}</span>
+                </code>
                 <button
                   type="button"
                   aria-label={hasCopiedBrew ? "Copied command" : "Copy command"}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1146,7 +1146,8 @@ body {
 }
 
 .clean-home__brew {
-  width: max-content;
+  width: fit-content;
+  max-width: 100%;
   margin-top: 1.35rem;
   margin-inline: auto;
   overflow: hidden;
@@ -1160,23 +1161,30 @@ body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
-  align-items: start;
+  align-items: center;
   padding: 0.95rem 1rem;
 }
 
 .clean-home__brew-command {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.65rem;
   min-width: 0;
   overflow-x: auto;
   color: var(--ink-soft);
   font-size: 0.94rem;
   line-height: 1.8;
-  white-space: nowrap;
   scrollbar-width: none;
 }
 
 .clean-home__brew-command::-webkit-scrollbar {
   display: none;
+}
+
+.clean-home__brew-prefix,
+.clean-home__brew-formula {
+  white-space: nowrap;
 }
 
 .clean-home__brew-copy {
@@ -1639,8 +1647,40 @@ body {
     align-items: flex-start;
   }
 
+  .clean-home__brew {
+    width: 100%;
+  }
+
   .clean-home__brew-row {
-    grid-template-columns: 1fr;
+    position: relative;
+    display: block;
+    padding-right: 3.75rem;
+  }
+
+  .clean-home__brew-command {
+    overflow-x: visible;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.1rem;
+    font-size: 0.86rem;
+    line-height: 1.5;
+  }
+
+  .clean-home__brew-prefix,
+  .clean-home__brew-formula {
+    white-space: nowrap;
+  }
+
+  .clean-home__brew-copy {
+    position: absolute;
+    top: 0.95rem;
+    right: 1rem;
+    justify-self: auto;
+    align-self: auto;
+    border: 0;
+    background: transparent;
+    padding: 0.15rem;
+    color: var(--ink-muted);
   }
 
   .clean-home__brew-fallback-row {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1666,11 +1666,6 @@ body {
     line-height: 1.5;
   }
 
-  .clean-home__brew-prefix,
-  .clean-home__brew-formula {
-    white-space: nowrap;
-  }
-
   .clean-home__brew-copy {
     position: absolute;
     top: 0.95rem;


### PR DESCRIPTION
## Summary
- add a first-run Welcome to Glyph note and explicitly open it once during desktop boot
- keep the cursor stable while untitled drafts become real files
- fix the mobile Homebrew install card and normalize OG image URLs to og-image.png
- add a redirecting /og-image route for the website

## Validation
- pnpm typecheck:desktop
- pnpm typecheck:web
- commit hooks: fmt, lint, and workspace typecheck

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop now shows a persisted welcome note on first run and remembers its seen/version state.
  * Added a lightweight redirect page for the app's social preview image.

* **Behavior**
  * Default workspace opening flow updated to prefer the welcome note when applicable and respect a requested active file.
  * Removed an automatic editor-focus trigger after creating a new draft.

* **Style**
  * Improved Homebrew install command layout and responsive styling for mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->