### PR TITLE
feat(desktop): dismiss update notification + fix Windows keyboard shortcuts

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -974,6 +974,7 @@ function getDefaultSettings(): AppSettings {
       showOutline: true,
     },
     autoOpenPDF: true,
+    dismissedUpdateVersion: null,
   };
 }
 
@@ -1294,6 +1295,11 @@ async function sanitizeSettingsWithFileValidation(input: unknown): Promise<AppSe
     editorPreferences: normalizeEditorPreferences(candidate.editorPreferences),
     autoOpenPDF:
       typeof candidate.autoOpenPDF === "boolean" ? candidate.autoOpenPDF : defaults.autoOpenPDF,
+    dismissedUpdateVersion:
+      typeof candidate.dismissedUpdateVersion === "string" ||
+      candidate.dismissedUpdateVersion === null
+        ? candidate.dismissedUpdateVersion
+        : defaults.dismissedUpdateVersion,
   };
 }
 
@@ -1399,6 +1405,17 @@ function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
     nextPatch.autoOpenPDF = candidate.autoOpenPDF;
   }
 
+  if ("dismissedUpdateVersion" in candidate) {
+    if (
+      candidate.dismissedUpdateVersion !== null &&
+      typeof candidate.dismissedUpdateVersion !== "string"
+    ) {
+      throw new Error("dismissedUpdateVersion must be a string or null.");
+    }
+
+    nextPatch.dismissedUpdateVersion = candidate.dismissedUpdateVersion;
+  }
+
   const invalidKeys = Object.keys(candidate).filter(
     (key) =>
       ![
@@ -1411,6 +1428,7 @@ function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
         "sidebar",
         "editorPreferences",
         "autoOpenPDF",
+        "dismissedUpdateVersion",
       ].includes(key),
   );
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1296,10 +1296,11 @@ async function sanitizeSettingsWithFileValidation(input: unknown): Promise<AppSe
     autoOpenPDF:
       typeof candidate.autoOpenPDF === "boolean" ? candidate.autoOpenPDF : defaults.autoOpenPDF,
     dismissedUpdateVersion:
-      typeof candidate.dismissedUpdateVersion === "string" ||
-      candidate.dismissedUpdateVersion === null
-        ? candidate.dismissedUpdateVersion
-        : defaults.dismissedUpdateVersion,
+      typeof candidate.dismissedUpdateVersion === "string"
+        ? candidate.dismissedUpdateVersion.trim().replace(/^v/i, "")
+        : candidate.dismissedUpdateVersion === null
+          ? null
+          : defaults.dismissedUpdateVersion,
   };
 }
 
@@ -1413,7 +1414,10 @@ function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
       throw new Error("dismissedUpdateVersion must be a string or null.");
     }
 
-    nextPatch.dismissedUpdateVersion = candidate.dismissedUpdateVersion;
+    nextPatch.dismissedUpdateVersion =
+      typeof candidate.dismissedUpdateVersion === "string"
+        ? candidate.dismissedUpdateVersion.trim().replace(/^v/i, "")
+        : null;
   }
 
   const invalidKeys = Object.keys(candidate).filter(

--- a/apps/desktop/src/components/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import type { CommandPaletteItem, CommandPaletteProps } from "../types/command-palette";
+import { splitShortcutTokens } from "../shared/shortcuts";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -227,16 +228,16 @@ export const CommandPalette = memo(
                             ) : null}
                             {item.shortcut
                               ? (() => {
-                                  const shortcut = item.shortcut;
+                                  const tokens = splitShortcutTokens(item.shortcut);
 
                                   return (
                                     <div className="flex gap-1">
-                                      {shortcut.split("").map((char, index) => (
+                                      {tokens.map((token, tokenIdx) => (
                                         <kbd
-                                          key={`${item.id}:${shortcut.slice(0, index + 1)}`}
+                                          key={`${item.id}:${tokenIdx}:${token}`}
                                           className="rounded border border-border/40 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
                                         >
-                                          {char}
+                                          {token}
                                         </kbd>
                                       ))}
                                     </div>

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1268,7 +1268,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                     : undefined
                 }
                 updatesMode={controller.appInfo?.updatesMode}
+                dismissedUpdateVersion={controller.settings?.dismissedUpdateVersion ?? null}
                 onUpdateAction={() => void controller.triggerUpdateAction()}
+                onDismissUpdateAction={() => void controller.dismissUpdateNotification()}
               />
             )}
           </div>

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -22,6 +22,7 @@ import {
   PinOffIcon,
   PlusIcon,
   SearchIcon,
+  XIcon,
 } from "@/components/icons";
 import { FileManagerLogo } from "./file-manager-logo";
 
@@ -53,6 +54,8 @@ type EditorToolbarProps = {
   updateButtonLabel: string;
   updateButtonTooltip: string;
   onUpdateAction: (() => void) | undefined;
+  onDismissUpdateAction: (() => void) | undefined;
+  isManualReleaseButton: boolean;
   headerPaddingClass: string;
   onOpenSettings: (() => void) | undefined;
   headerAccessory: React.ReactNode;
@@ -94,6 +97,8 @@ export function EditorToolbar({
   updateButtonLabel,
   updateButtonTooltip,
   onUpdateAction,
+  onDismissUpdateAction,
+  isManualReleaseButton,
   headerPaddingClass,
   onOpenSettings,
   headerAccessory,
@@ -262,21 +267,35 @@ export function EditorToolbar({
           </div>
         ) : null}
         {shouldShowUpdateActionButton && onUpdateAction ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <div className="flex items-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={updateButtonVariant}
+                  size="sm"
+                  className="h-8 shrink-0 rounded-full px-3 text-xs font-semibold shadow-sm"
+                  onClick={onUpdateAction}
+                  disabled={isUpdateButtonDisabled}
+                  type="button"
+                >
+                  {updateButtonLabel}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{updateButtonTooltip}</TooltipContent>
+            </Tooltip>
+            {isManualReleaseButton && onDismissUpdateAction && (
               <Button
-                variant={updateButtonVariant}
-                size="sm"
-                className="h-8 shrink-0 rounded-full px-3 text-xs font-semibold shadow-sm"
-                onClick={onUpdateAction}
-                disabled={isUpdateButtonDisabled}
+                variant="ghost"
+                size="icon-sm"
+                className="ml-1 h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted"
+                onClick={onDismissUpdateAction}
+                aria-label="Dismiss update notification"
                 type="button"
               >
-                {updateButtonLabel}
+                <XIcon size={14} />
               </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{updateButtonTooltip}</TooltipContent>
-          </Tooltip>
+            )}
+          </div>
         ) : null}
         {headerAccessory ? <div className="mr-1 flex items-center">{headerAccessory}</div> : null}
         <DropdownMenu>

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -284,16 +284,21 @@ export function EditorToolbar({
               <TooltipContent side="bottom">{updateButtonTooltip}</TooltipContent>
             </Tooltip>
             {isManualReleaseButton && onDismissUpdateAction && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="ml-1 h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted"
-                onClick={onDismissUpdateAction}
-                aria-label="Dismiss update notification"
-                type="button"
-              >
-                <XIcon size={14} />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="ml-1 h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted"
+                    onClick={onDismissUpdateAction}
+                    aria-label="Dismiss update notification"
+                    type="button"
+                  >
+                    <XIcon size={14} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Dismiss update</TooltipContent>
+              </Tooltip>
             )}
           </div>
         ) : null}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -384,6 +384,8 @@ export const MarkdownEditor = ({
   updateState,
   updatesMode,
   onUpdateAction,
+  onDismissUpdateAction,
+  dismissedUpdateVersion,
   isFocusMode,
   showOutline = true,
   onToggleFocusMode,
@@ -599,7 +601,11 @@ export const MarkdownEditor = ({
   );
 
   const effectiveUpdateState = devPreviewUpdateState ?? updateState ?? null;
-  const updateStateFlags = useUpdateStateFlags(effectiveUpdateState, updatesMode);
+  const updateStateFlags = useUpdateStateFlags(
+    effectiveUpdateState,
+    updatesMode,
+    dismissedUpdateVersion,
+  );
   const isFocusLayout = Boolean(isFocusMode);
   const revealInFolderLabel = folderRevealLabel ?? getFolderRevealLabel(navigator.platform);
   const isMacLike = useMemo(() => navigator.platform.includes("Mac"), []);
@@ -1449,6 +1455,8 @@ export const MarkdownEditor = ({
         updateButtonLabel={updateStateFlags.updateButtonLabel}
         updateButtonTooltip={updateStateFlags.updateButtonTooltip}
         onUpdateAction={onUpdateAction}
+        onDismissUpdateAction={onDismissUpdateAction}
+        isManualReleaseButton={updateStateFlags.isManualReleaseButton}
         headerPaddingClass={headerPaddingClass}
         onOpenSettings={onOpenSettings}
         headerAccessory={headerAccessory}

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -36,6 +36,7 @@ type NoteViewProps = {
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;
   updatesMode?: AppInfo["updatesMode"];
+  dismissedUpdateVersion?: string | null;
   onContentChange: (value: string) => void;
   onSelectTab: (path: string) => void;
   onCloseTab: (path: string) => void;
@@ -54,6 +55,7 @@ type NoteViewProps = {
   onToggleFocusMode: () => void;
   onTogglePinnedFile: (() => void) | undefined;
   onUpdateAction: () => void;
+  onDismissUpdateAction?: () => void;
 };
 
 export function NoteView({
@@ -82,6 +84,7 @@ export function NoteView({
   outlineJumpRequest,
   updateState,
   updatesMode,
+  dismissedUpdateVersion,
   onContentChange,
   onSelectTab,
   onCloseTab,
@@ -100,6 +103,7 @@ export function NoteView({
   onToggleFocusMode,
   onTogglePinnedFile,
   onUpdateAction,
+  onDismissUpdateAction,
 }: NoteViewProps) {
   const handleOpenCommandPalette = useCallback(() => {
     onOpenCommandPalette();
@@ -151,19 +155,26 @@ export function NoteView({
       onToggleSidebar={onToggleSidebar}
       isSidebarCollapsed={isSidebarCollapsed}
       onCreateNote={onCreateNote}
-      toggleSidebarShortcut={getShortcutDisplay(shortcuts, "toggle-sidebar")}
-      newNoteShortcut={getShortcutDisplay(shortcuts, "new-note")}
+      toggleSidebarShortcut={getShortcutDisplay(shortcuts, "toggle-sidebar", navigator.platform)}
+      newNoteShortcut={getShortcutDisplay(shortcuts, "new-note", navigator.platform)}
       onOpenSettings={handleOpenSettings}
       onOpenCommandPalette={handleOpenCommandPalette}
       commandPaletteLabel="Search notes and skills"
       onOpenLinkedFile={onOpenLinkedFile}
-      commandPaletteShortcut={getShortcutDisplay(shortcuts, "command-palette") ?? "⌘P"}
+      commandPaletteShortcut={
+        getShortcutDisplay(shortcuts, "command-palette", navigator.platform) ??
+        (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P")
+      }
       onScrollPositionChange={onScrollPositionChange}
       onNavigateBack={onNavigateBack}
       onNavigateForward={onNavigateForward}
-      navigateBackShortcut={getShortcutDisplay(shortcuts, "navigate-back")}
-      navigateForwardShortcut={getShortcutDisplay(shortcuts, "navigate-forward")}
-      focusModeShortcut={getShortcutDisplay(shortcuts, "focus-mode")}
+      navigateBackShortcut={getShortcutDisplay(shortcuts, "navigate-back", navigator.platform)}
+      navigateForwardShortcut={getShortcutDisplay(
+        shortcuts,
+        "navigate-forward",
+        navigator.platform,
+      )}
+      focusModeShortcut={getShortcutDisplay(shortcuts, "focus-mode", navigator.platform)}
       onDeleteNote={onDeleteNote}
       onOpenNewWindow={onOpenNewWindow}
       canGoBack={canGoBack}
@@ -181,7 +192,9 @@ export function NoteView({
       showOutline={showOutline}
       updateState={updateState}
       updatesMode={updatesMode}
+      dismissedUpdateVersion={dismissedUpdateVersion}
       onUpdateAction={onUpdateAction}
+      onDismissUpdateAction={onDismissUpdateAction}
     />
   );
 }

--- a/apps/desktop/src/components/settings-panel.tsx
+++ b/apps/desktop/src/components/settings-panel.tsx
@@ -15,6 +15,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import {
   DEFAULT_SHORTCUTS,
   canonicalizeShortcut,
+  formatKeysForPlatform,
+  isMacPlatform,
   mergeShortcutSettings,
   MODIFIER_TOKENS,
 } from "../shared/shortcuts";
@@ -65,7 +67,15 @@ export const SettingsPanel = ({
 
   const formatKeyCombo = (e: React.KeyboardEvent<HTMLInputElement>): string => {
     const parts: string[] = [];
-    if (e.metaKey || e.ctrlKey) parts.push(MODIFIER_TOKENS.cmdOrCtrl);
+    const isMac = isMacPlatform(navigator.platform);
+
+    // On macOS: Cmd (metaKey) is the primary modifier, Ctrl is separate.
+    // On Windows/Linux: Ctrl (ctrlKey) is the primary modifier, ignore Win key (metaKey).
+    if (isMac) {
+      if (e.metaKey) parts.push(MODIFIER_TOKENS.cmdOrCtrl);
+    } else {
+      if (e.ctrlKey) parts.push(MODIFIER_TOKENS.cmdOrCtrl);
+    }
     if (e.altKey) parts.push(MODIFIER_TOKENS.alt);
     if (e.shiftKey) parts.push(MODIFIER_TOKENS.shift);
     const key = e.key;
@@ -320,7 +330,7 @@ export const SettingsPanel = ({
                         ref={inputRef}
                         type="text"
                         className="h-8 w-32 border-primary bg-background text-center font-mono text-xs shadow-sm"
-                        value={capturedKeys}
+                        value={formatKeysForPlatform(capturedKeys, navigator.platform)}
                         onKeyDown={handleKeyDown}
                         onBlur={() => {
                           if (capturedKeys && editingShortcut) {
@@ -349,7 +359,7 @@ export const SettingsPanel = ({
                           setConflictIds(new Set());
                         }}
                       >
-                        {shortcut.keys}
+                        {formatKeysForPlatform(shortcut.keys, navigator.platform)}
                       </Button>
                     )}
                   </div>

--- a/apps/desktop/src/components/settings-panel.tsx
+++ b/apps/desktop/src/components/settings-panel.tsx
@@ -71,6 +71,10 @@ export const SettingsPanel = ({
 
     // On macOS: Cmd (metaKey) is the primary modifier, Ctrl is separate.
     // On Windows/Linux: Ctrl (ctrlKey) is the primary modifier, ignore Win key (metaKey).
+    if (!isMac && e.metaKey) {
+      // Win key pressed on Windows/Linux — not a supported modifier; discard.
+      return "";
+    }
     if (isMac) {
       if (e.metaKey) parts.push(MODIFIER_TOKENS.cmdOrCtrl);
     } else {

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getDisplayFileName, normalizePath } from "@/lib/paths";
+import { getShortcutDisplay } from "@/shared/shortcuts";
 
 import type { NoteShortcutItem } from "@/types/navigation";
 import type {
@@ -534,7 +535,7 @@ export const Sidebar = ({
                       <PlusIcon size={12} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">{`New Note (${navigator.platform.includes("Mac") ? "⌘N" : "Ctrl+N"})`}</TooltipContent>
+                  <TooltipContent side="bottom">{`New Note (${getShortcutDisplay(null, "new-note", navigator.platform) ?? "⌘N"})`}</TooltipContent>
                 </Tooltip>
               ) : null}
               {onCreateFolder ? (
@@ -549,7 +550,7 @@ export const Sidebar = ({
                       <FolderPlusIcon size={12} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">{`New Folder (${navigator.platform.includes("Mac") ? "⇧⌘N" : "Ctrl+Shift+N"})`}</TooltipContent>
+                  <TooltipContent side="bottom">{`New Folder (${getShortcutDisplay(null, "new-folder", navigator.platform) ?? "⇧⌘N"})`}</TooltipContent>
                 </Tooltip>
               ) : null}
               <button

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -534,7 +534,7 @@ export const Sidebar = ({
                       <PlusIcon size={12} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">New Note (⌘N)</TooltipContent>
+                  <TooltipContent side="bottom">{`New Note (${navigator.platform.includes("Mac") ? "⌘N" : "Ctrl+N"})`}</TooltipContent>
                 </Tooltip>
               ) : null}
               {onCreateFolder ? (
@@ -549,7 +549,7 @@ export const Sidebar = ({
                       <FolderPlusIcon size={12} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">New Folder (⇧⌘N)</TooltipContent>
+                  <TooltipContent side="bottom">{`New Folder (${navigator.platform.includes("Mac") ? "⇧⌘N" : "Ctrl+Shift+N"})`}</TooltipContent>
                 </Tooltip>
               ) : null}
               <button

--- a/apps/desktop/src/components/skill-empty-pane.tsx
+++ b/apps/desktop/src/components/skill-empty-pane.tsx
@@ -75,7 +75,7 @@ export function SkillEmptyPane({
                 <span>Search notes and skills</span>
               </div>
               <span className="ml-4 flex-shrink-0 font-mono text-xs opacity-50">
-                {commandPaletteShortcut ?? (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P")}
+                {commandPaletteShortcut ?? (isMacLike ? "⌘P" : "Ctrl+P")}
               </span>
             </Button>
           </div>

--- a/apps/desktop/src/components/skill-empty-pane.tsx
+++ b/apps/desktop/src/components/skill-empty-pane.tsx
@@ -75,7 +75,7 @@ export function SkillEmptyPane({
                 <span>Search notes and skills</span>
               </div>
               <span className="ml-4 flex-shrink-0 font-mono text-xs opacity-50">
-                {commandPaletteShortcut ?? "⌘P"}
+                {commandPaletteShortcut ?? (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P")}
               </span>
             </Button>
           </div>

--- a/apps/desktop/src/components/skill-view.tsx
+++ b/apps/desktop/src/components/skill-view.tsx
@@ -64,8 +64,10 @@ export function SkillView({
   onReloadAfterExternalChange,
   onSelectDocumentTab,
 }: SkillViewProps) {
-  const commandPaletteShortcut = getShortcutDisplay(shortcuts, "command-palette") ?? "⌘P";
-  const toggleSidebarShortcut = getShortcutDisplay(shortcuts, "toggle-sidebar");
+  const commandPaletteShortcut =
+    getShortcutDisplay(shortcuts, "command-palette", navigator.platform) ??
+    (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P");
+  const toggleSidebarShortcut = getShortcutDisplay(shortcuts, "toggle-sidebar", navigator.platform);
 
   const handleOpenCommandPalette = useCallback(() => {
     onSetIsPaletteOpen(true);

--- a/apps/desktop/src/components/slash-command-list.tsx
+++ b/apps/desktop/src/components/slash-command-list.tsx
@@ -4,12 +4,19 @@ import type {
   SlashCommandListHandle,
   SlashCommandListProps,
 } from "../types/slash-command";
+import { formatKeysForPlatform, splitShortcutTokens } from "../shared/shortcuts";
 
-/** Split a shortcut string like "⌘ ⇧ B" into individual token spans. */
+/**
+ * Render a shortcut string as individual `<kbd>` token spans.
+ * Converts the internal format (e.g. "⌘ ⌥ 1") to the platform-appropriate
+ * display (e.g. "⌘⌥1" on macOS, "Ctrl+Alt+1" on Windows) then splits into
+ * per-key tokens.
+ */
 function ShortcutBadge({ shortcut }: { shortcut: string }) {
-  const tokens = shortcut.trim().split(/\s+/).filter(Boolean);
+  const display = formatKeysForPlatform(shortcut, navigator.platform);
+  const tokens = splitShortcutTokens(display);
   return (
-    <span className="slash-kbd-group" aria-label={shortcut}>
+    <span className="slash-kbd-group" aria-label={display}>
       {tokens.map((token, i) => (
         <kbd key={i} className="slash-kbd">
           {token}

--- a/apps/desktop/src/components/slash-command.ts
+++ b/apps/desktop/src/components/slash-command.ts
@@ -13,14 +13,16 @@ import type {
   SlashCommandListHandle,
   SlashCommandWithKey,
 } from "../types/slash-command";
+import { MODIFIER_TOKENS } from "../shared/shortcuts";
 
 /**
  * Hardcoded TipTap/StarterKit default shortcuts displayed as hints in the
  * slash command menu. These are the real bindings — not configurable — so the
  * hint always matches what actually works in the editor.
  *
- * macOS symbols: ⌘ = Cmd, ⌥ = Alt/Option, ⇧ = Shift
- * Windows/Linux: ⌘ → Ctrl, ⌥ → Alt
+ * Stored in the internal space-separated token format (same as settings
+ * shortcuts) and converted to the platform-appropriate display form at
+ * render time by the ShortcutBadge component.
  */
 const COMMANDS: SlashCommandWithKey[] = [
   {
@@ -30,7 +32,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["h1", "heading", "title", "#"],
     group: "Headings",
     icon: "Heading01Icon",
-    shortcut: "⌘⌥1",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} ${MODIFIER_TOKENS.alt} 1`,
   },
   {
     id: "h2",
@@ -39,7 +41,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["h2", "heading", "##"],
     group: "Headings",
     icon: "Heading02Icon",
-    shortcut: "⌘⌥2",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} ${MODIFIER_TOKENS.alt} 2`,
   },
   {
     id: "h3",
@@ -48,7 +50,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["h3", "heading", "###"],
     group: "Headings",
     icon: "Heading03Icon",
-    shortcut: "⌘⌥3",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} ${MODIFIER_TOKENS.alt} 3`,
   },
   {
     id: "bullet",
@@ -84,7 +86,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["quote", "blockquote", ">"],
     group: "Blocks",
     icon: "QuoteDownIcon",
-    shortcut: "⌘⇧B",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} ${MODIFIER_TOKENS.shift} B`,
   },
   {
     id: "table",
@@ -120,7 +122,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["bold", "strong", "**"],
     group: "Inline",
     icon: "TextBoldIcon",
-    shortcut: "⌘B",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} B`,
   },
   {
     id: "italic",
@@ -129,7 +131,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["italic", "emphasis", "*"],
     group: "Inline",
     icon: "TextItalicIcon",
-    shortcut: "⌘I",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} I`,
   },
   {
     id: "strike",
@@ -138,7 +140,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["strike", "strikethrough", "~~"],
     group: "Inline",
     icon: "TextStrikethroughIcon",
-    shortcut: "⌘⇧S",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} ${MODIFIER_TOKENS.shift} S`,
   },
   {
     id: "inlinecode",
@@ -147,7 +149,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["inline", "code", "`"],
     group: "Inline",
     icon: "CodeSimpleIcon",
-    shortcut: "⌘E",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} E`,
   },
   {
     id: "link",
@@ -156,7 +158,7 @@ const COMMANDS: SlashCommandWithKey[] = [
     keywords: ["link", "url", "[]()"],
     group: "Inline",
     icon: "Link01Icon",
-    shortcut: "⌘K",
+    shortcut: `${MODIFIER_TOKENS.cmdOrCtrl} K`,
   },
   {
     id: "image",

--- a/apps/desktop/src/components/update-notification.tsx
+++ b/apps/desktop/src/components/update-notification.tsx
@@ -9,11 +9,14 @@ type UpdateNotificationProps = {
   updateState: UpdateState | null;
   updatesMode?: AppInfo["updatesMode"];
   onUpdateAction: (() => void) | undefined;
+  dismissedUpdateVersion?: string | null;
+  onDismissUpdateAction?: (() => void) | undefined;
 };
 
 export function useUpdateStateFlags(
   updateState: UpdateState | null,
   updatesMode?: AppInfo["updatesMode"],
+  dismissedUpdateVersion?: string | null,
 ) {
   return useMemo((): {
     shouldShowUpdateActionButton: boolean;
@@ -21,6 +24,7 @@ export function useUpdateStateFlags(
     updateButtonTooltip: string;
     isUpdateButtonDisabled: boolean | undefined;
     updateButtonVariant: "default" | "outline";
+    isManualReleaseButton: boolean;
   } => {
     const shouldShowUpdateButton =
       updateState?.status === "error" ||
@@ -32,12 +36,20 @@ export function useUpdateStateFlags(
       (updateState?.status === "idle" || updateState?.status === "not-available") &&
       Boolean(updateState?.recentlyInstalledVersion);
 
-    const shouldShowUpdateActionButton = shouldShowUpdateButton || shouldShowChangelogButton;
     const isManualReleaseButton =
       updatesMode === "manual" &&
       (updateState?.status === "available" ||
         updateState?.status === "downloading" ||
         updateState?.status === "downloaded");
+
+    const isDismissed = Boolean(
+      isManualReleaseButton &&
+      updateState?.availableVersion &&
+      updateState.availableVersion === dismissedUpdateVersion,
+    );
+
+    const shouldShowUpdateActionButton =
+      !isDismissed && (shouldShowUpdateButton || shouldShowChangelogButton);
 
     const updateButtonLabel = shouldShowChangelogButton
       ? "View changelog"
@@ -81,14 +93,16 @@ export function useUpdateStateFlags(
       updateButtonTooltip,
       isUpdateButtonDisabled,
       updateButtonVariant,
+      isManualReleaseButton,
     };
-  }, [updateState, updatesMode]);
+  }, [updateState, updatesMode, dismissedUpdateVersion]);
 }
 
 export function UpdateNotification({
   updateState,
   updatesMode,
   onUpdateAction,
+  dismissedUpdateVersion,
 }: UpdateNotificationProps) {
   const {
     shouldShowUpdateActionButton,
@@ -96,7 +110,7 @@ export function UpdateNotification({
     updateButtonTooltip,
     isUpdateButtonDisabled,
     updateButtonVariant,
-  } = useUpdateStateFlags(updateState, updatesMode);
+  } = useUpdateStateFlags(updateState, updatesMode, dismissedUpdateVersion);
 
   if (!shouldShowUpdateActionButton || !onUpdateAction) {
     return null;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1035,7 +1035,7 @@ export const useDesktopAppController = (
         updateState.status === "downloaded"
       ) {
         if (updateState.availableVersion) {
-          await saveSettings({ dismissedUpdateVersion: updateState.availableVersion });
+          void saveSettings({ dismissedUpdateVersion: updateState.availableVersion });
         }
         await glyph.openExternal(updateState.releasePageUrl ?? APP_RELEASES_URL);
         return;
@@ -1106,6 +1106,7 @@ export const useDesktopAppController = (
           ? `Open GitHub Releases to download Glyph ${updateState.availableVersion} manually`
           : "Open GitHub Releases to download and install manually",
         isDisabled: false,
+        isManualRelease: true,
       };
     }
 
@@ -1265,6 +1266,21 @@ export const useDesktopAppController = (
                 if (!updateActionConfig.isDisabled) {
                   void triggerUpdateAction();
                 }
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
+      ...(updateActionConfig?.isManualRelease
+        ? [
+            {
+              id: "dismiss-update",
+              title: "Dismiss Update Notification",
+              subtitle: "Hide the update banner for this version",
+              section: "Actions",
+              kind: "command" as const,
+              onSelect: () => {
+                void dismissUpdateNotification();
                 setIsPaletteOpen(false);
               },
             },

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1034,6 +1034,9 @@ export const useDesktopAppController = (
         updateState.status === "downloading" ||
         updateState.status === "downloaded"
       ) {
+        if (updateState.availableVersion) {
+          await saveSettings({ dismissedUpdateVersion: updateState.availableVersion });
+        }
         await glyph.openExternal(updateState.releasePageUrl ?? APP_RELEASES_URL);
         return;
       }
@@ -1066,7 +1069,14 @@ export const useDesktopAppController = (
     ) {
       await glyph.checkForUpdates();
     }
-  }, [appInfo?.updatesEnabled, appInfo?.updatesMode, glyph, updateState]);
+  }, [appInfo?.updatesEnabled, appInfo?.updatesMode, glyph, updateState, saveSettings]);
+
+  const dismissUpdateNotification = useCallback(async () => {
+    if (!updateState?.availableVersion) {
+      return;
+    }
+    await saveSettings({ dismissedUpdateVersion: updateState.availableVersion });
+  }, [updateState?.availableVersion, saveSettings]);
 
   const updateActionConfig = useMemo(() => {
     if (!appInfo?.updatesEnabled || !updateState) {
@@ -1199,7 +1209,7 @@ export const useDesktopAppController = (
         id: "new-note",
         title: "New note",
         subtitle: "Create a fresh markdown note",
-        shortcut: getShortcutDisplay(shortcuts, "new-note"),
+        shortcut: getShortcutDisplay(shortcuts, "new-note", appInfo?.platform),
         section: "Actions",
         kind: "command",
         onSelect: () => void createNote(),
@@ -1208,7 +1218,7 @@ export const useDesktopAppController = (
         id: "new-folder",
         title: "New folder",
         subtitle: "Create a new folder in the current directory",
-        shortcut: "⇧⌘N",
+        shortcut: getShortcutDisplay(shortcuts, "new-folder", appInfo?.platform),
         section: "Actions",
         kind: "command",
         onSelect: () => void createFolder(),
@@ -1217,7 +1227,7 @@ export const useDesktopAppController = (
         id: "open-file",
         title: "Open File",
         subtitle: "Open an existing markdown file",
-        shortcut: getShortcutDisplay(shortcuts, "open-file"),
+        shortcut: getShortcutDisplay(shortcuts, "open-file", appInfo?.platform),
         section: "Actions",
         kind: "command",
         onSelect: async () => {
@@ -1230,7 +1240,7 @@ export const useDesktopAppController = (
         id: "open-folder",
         title: "Open Folder",
         subtitle: "Open a folder as a workspace",
-        shortcut: getShortcutDisplay(shortcuts, "open-folder"),
+        shortcut: getShortcutDisplay(shortcuts, "open-folder", appInfo?.platform),
         section: "Actions",
         kind: "command",
         onSelect: async () => {
@@ -1248,7 +1258,7 @@ export const useDesktopAppController = (
               id: "check-updates",
               title: updateActionConfig.title,
               subtitle: updateActionConfig.subtitle,
-              shortcut: getShortcutDisplay(shortcuts, "check-updates"),
+              shortcut: getShortcutDisplay(shortcuts, "check-updates", appInfo?.platform),
               section: "Actions",
               kind: "command" as const,
               onSelect: () => {
@@ -1264,7 +1274,7 @@ export const useDesktopAppController = (
         id: "settings",
         title: "Settings",
         subtitle: "Adjust workspace defaults",
-        shortcut: getShortcutDisplay(shortcuts, "settings"),
+        shortcut: getShortcutDisplay(shortcuts, "settings", appInfo?.platform),
         section: "Actions",
         kind: "command",
         onSelect: () => {
@@ -1276,7 +1286,7 @@ export const useDesktopAppController = (
         id: "navigate-back",
         title: "Navigate Back",
         subtitle: "Go to previous file in history",
-        shortcut: getShortcutDisplay(shortcuts, "navigate-back"),
+        shortcut: getShortcutDisplay(shortcuts, "navigate-back", appInfo?.platform),
         section: "Navigation",
         kind: "command",
         onSelect: () => {
@@ -1288,7 +1298,7 @@ export const useDesktopAppController = (
         id: "navigate-forward",
         title: "Navigate Forward",
         subtitle: "Go to next file in history",
-        shortcut: getShortcutDisplay(shortcuts, "navigate-forward"),
+        shortcut: getShortcutDisplay(shortcuts, "navigate-forward", appInfo?.platform),
         section: "Navigation",
         kind: "command",
         onSelect: () => {
@@ -1330,7 +1340,7 @@ export const useDesktopAppController = (
               id: "close-tab",
               title: "Close Current Tab",
               subtitle: "Close the current note tab",
-              shortcut: getShortcutDisplay(shortcuts, "close-tab"),
+              shortcut: getShortcutDisplay(shortcuts, "close-tab", appInfo?.platform),
               section: "Tabs",
               kind: "command" as const,
               onSelect: () => {
@@ -1349,7 +1359,7 @@ export const useDesktopAppController = (
               id: "close-other-tabs",
               title: "Close Other Tabs",
               subtitle: "Keep only the current note open",
-              shortcut: getShortcutDisplay(shortcuts, "close-other-tabs"),
+              shortcut: getShortcutDisplay(shortcuts, "close-other-tabs", appInfo?.platform),
               section: "Tabs",
               kind: "command" as const,
               onSelect: () => {
@@ -1365,7 +1375,7 @@ export const useDesktopAppController = (
       {
         id: "toggle-focus-mode",
         title: isFocusMode ? "Exit Focus Mode" : "Enter Focus Mode",
-        shortcut: getShortcutDisplay(shortcuts, "focus-mode"),
+        shortcut: getShortcutDisplay(shortcuts, "focus-mode", appInfo?.platform),
         subtitle: "Hide navigation and keep the note centered",
         section: "View",
         kind: "command",
@@ -1499,6 +1509,7 @@ export const useDesktopAppController = (
   useKeyboardShortcuts({
     glyph,
     shortcuts,
+    platform: appInfo?.platform ?? navigator.platform,
     activeFile,
     saveActiveNote: async () => {
       const activeTab = getActiveTab();
@@ -2093,6 +2104,7 @@ export const useDesktopAppController = (
     toggleOutline,
     togglePinnedFile,
     triggerUpdateAction,
+    dismissUpdateNotification,
     updateState,
     updateDraftContent: handleDraftChange,
     visibleSidebarNodes,

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1484,6 +1484,7 @@ export const useDesktopAppController = (
       closeOtherNoteTabs,
       createNote,
       createFolder,
+      dismissUpdateNotification,
       glyph,
       isActiveFilePinned,
       isFocusMode,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { matchShortcut, isPrimaryModifierPressed } from "@/shared/shortcuts";
+import { matchShortcut, isPrimaryModifierPressed, MODIFIER_TOKENS } from "@/shared/shortcuts";
 import type { FileDocument, ShortcutSetting, WorkspaceSnapshot } from "@/shared/workspace";
 
 type UseKeyboardShortcutsOptions = {
@@ -99,9 +99,13 @@ export function useKeyboardShortcuts({
       }
 
       const isPreviousBracketShortcut =
-        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ [", platform);
+        primaryPressed &&
+        !event.altKey &&
+        matchShortcut(event, `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} [`, platform);
       const isNextBracketShortcut =
-        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ ]", platform);
+        primaryPressed &&
+        !event.altKey &&
+        matchShortcut(event, `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} ]`, platform);
       const isPreviousCtrlTabShortcut =
         !hasConfiguredShortcutMatch &&
         event.ctrlKey &&

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 
-import { matchShortcut } from "@/shared/shortcuts";
+import { matchShortcut, isPrimaryModifierPressed } from "@/shared/shortcuts";
 import type { FileDocument, ShortcutSetting, WorkspaceSnapshot } from "@/shared/workspace";
 
 type UseKeyboardShortcutsOptions = {
   glyph: NonNullable<Window["glyph"]>;
   shortcuts: ShortcutSetting[];
+  platform: string;
   activeFile: FileDocument | null;
   saveActiveNote: () => Promise<void>;
   createNote: () => Promise<void>;
@@ -33,6 +34,7 @@ type UseKeyboardShortcutsOptions = {
 export function useKeyboardShortcuts({
   glyph,
   shortcuts,
+  platform,
   activeFile,
   saveActiveNote,
   createNote,
@@ -80,9 +82,9 @@ export function useKeyboardShortcuts({
       }
 
       const hasConfiguredShortcutMatch = shortcuts.some((entry) =>
-        matchShortcut(event, entry.keys),
+        matchShortcut(event, entry.keys, platform),
       );
-      const primaryPressed = event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
+      const primaryPressed = isPrimaryModifierPressed(event, platform);
       if (
         !hasConfiguredShortcutMatch &&
         primaryPressed &&
@@ -97,9 +99,9 @@ export function useKeyboardShortcuts({
       }
 
       const isPreviousBracketShortcut =
-        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ [");
+        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ [", platform);
       const isNextBracketShortcut =
-        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ ]");
+        primaryPressed && !event.altKey && matchShortcut(event, "⇧ ⌘ ]", platform);
       const isPreviousCtrlTabShortcut =
         !hasConfiguredShortcutMatch &&
         event.ctrlKey &&
@@ -144,7 +146,7 @@ export function useKeyboardShortcuts({
         "close-other-tabs",
       ]);
       const globalShortcut = shortcuts.find(
-        (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys),
+        (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys, platform),
       );
       if (globalShortcut) {
         event.preventDefault();
@@ -192,7 +194,7 @@ export function useKeyboardShortcuts({
       // Allow save shortcut even inside editable inputs (e.g. the editor)
       if (isEditableInput) {
         const saveShortcut = shortcuts.find(
-          (entry) => entry.id === "save" && matchShortcut(event, entry.keys),
+          (entry) => entry.id === "save" && matchShortcut(event, entry.keys, platform),
         );
 
         if (saveShortcut && activeFile) {
@@ -204,7 +206,7 @@ export function useKeyboardShortcuts({
 
       if (!isEditableInput) {
         const shortcut = shortcuts.find(
-          (entry) => !globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys),
+          (entry) => !globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys, platform),
         );
 
         if (shortcut) {
@@ -247,6 +249,7 @@ export function useKeyboardShortcuts({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [
     shortcuts,
+    platform,
     activeFile,
     saveActiveNote,
     glyph,

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -45,6 +45,48 @@ export const MODIFIER_TOKENS = {
   shift: "⇧",
 } as const;
 
+/**
+ * Returns true when the given platform string identifies macOS.
+ * Accepts `navigator.platform` values (e.g. "MacIntel") and
+ * `process.platform` values (e.g. "darwin").
+ */
+export function isMacPlatform(platform?: string): boolean {
+  const normalized = platform?.toLowerCase() ?? "";
+  return normalized.includes("mac") || normalized === "darwin";
+}
+
+/**
+ * Converts an internal shortcut key string (e.g. "⇧ ⌘ N") to the
+ * platform-appropriate display format.
+ *
+ * - macOS  → compact symbol form: "⇧⌘N"
+ * - Windows/Linux → text form: "Ctrl+Shift+N"
+ */
+export function formatKeysForPlatform(keys: string, platform?: string): string {
+  if (isMacPlatform(platform)) {
+    return keys.replace(/\s+/g, "");
+  }
+
+  const parsed = parseShortcut(keys);
+  if (!parsed) {
+    return keys.replace(/\s+/g, "");
+  }
+
+  const parts: string[] = [];
+  if (parsed.primary) {
+    parts.push("Ctrl");
+  }
+  if (parsed.shift) {
+    parts.push("Shift");
+  }
+  if (parsed.alt) {
+    parts.push("Alt");
+  }
+  parts.push(formatShortcutKey(parsed.key));
+
+  return parts.join("+");
+}
+
 export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   // App shortcuts (fire globally, even from inside the editor)
   { id: "command-palette", label: "Command Palette", keys: `${MODIFIER_TOKENS.cmdOrCtrl} P` },
@@ -85,11 +127,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
 ];
 
 export function getPrimaryShortcutPrefix(platform?: string): string {
-  const normalizedPlatform = platform?.toLowerCase() ?? "";
-
-  return normalizedPlatform.includes("mac") || normalizedPlatform === "darwin"
-    ? MODIFIER_TOKENS.cmdOrCtrl
-    : MODIFIER_TOKENS.ctrl;
+  return isMacPlatform(platform) ? MODIFIER_TOKENS.cmdOrCtrl : MODIFIER_TOKENS.ctrl;
 }
 
 export const MAX_DIRECT_NOTE_TAB_SHORTCUTS = 9;
@@ -142,10 +180,7 @@ export function getAdjacentTabShortcutDisplay(
   direction: "next" | "previous",
   platform?: string,
 ): string {
-  const normalizedPlatform = platform?.toLowerCase() ?? "";
-  const isMacPlatform = normalizedPlatform.includes("mac") || normalizedPlatform === "darwin";
-
-  if (isMacPlatform) {
+  if (isMacPlatform(platform)) {
     return direction === "next" ? "⇧⌘]" : "⇧⌘[";
   }
 
@@ -157,14 +192,12 @@ export function matchAdjacentTabShortcut(
   direction: "next" | "previous",
   platform?: string,
 ): boolean {
-  const normalizedPlatform = platform?.toLowerCase() ?? "";
-  const isMacPlatform = normalizedPlatform.includes("mac") || normalizedPlatform === "darwin";
-
   return matchShortcut(
     event,
-    isMacPlatform
+    isMacPlatform(platform)
       ? `⇧ ⌘ ${direction === "next" ? "]" : "["}`
       : `${direction === "next" ? "⌘ Tab" : "⇧ ⌘ Tab"}`,
+    platform,
   );
 }
 
@@ -364,12 +397,37 @@ export function getShortcutKeys(
 export function getShortcutDisplay(
   shortcuts: ShortcutSetting[] | undefined | null,
   id: ShortcutId,
+  platform?: string,
 ): string | undefined {
   const keys = getShortcutKeys(shortcuts, id);
-  return keys?.replace(/\s+/g, "");
+  if (!keys) {
+    return undefined;
+  }
+
+  return formatKeysForPlatform(keys, platform);
 }
 
-export function matchShortcut(event: ShortcutEventLike, shortcut: string): boolean {
+/**
+ * Returns true when the platform's primary modifier is pressed — `Meta` (⌘)
+ * on macOS, `Ctrl` on Windows/Linux — without the other modifier also being
+ * held. The platform string should come from `navigator.platform` (renderer)
+ * or `process.platform` (main process).
+ */
+export function isPrimaryModifierPressed(event: ShortcutEventLike, platform?: string): boolean {
+  const isMac = isMacPlatform(platform);
+
+  if (isMac) {
+    return event.metaKey && !event.ctrlKey;
+  }
+
+  return event.ctrlKey && !event.metaKey;
+}
+
+export function matchShortcut(
+  event: ShortcutEventLike,
+  shortcut: string,
+  platform?: string,
+): boolean {
   if (event.repeat) {
     return false;
   }
@@ -380,7 +438,7 @@ export function matchShortcut(event: ShortcutEventLike, shortcut: string): boole
   }
 
   const eventKey = normalizeShortcutKeyToken(event.key);
-  const primaryPressed = event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
+  const primaryPressed = isPrimaryModifierPressed(event, platform);
 
   return (
     eventKey === parsed.key &&
@@ -388,6 +446,21 @@ export function matchShortcut(event: ShortcutEventLike, shortcut: string): boole
     event.altKey === parsed.alt &&
     event.shiftKey === parsed.shift
   );
+}
+
+/**
+ * Split a platform-display shortcut string into individual key tokens for
+ * rendering in `<kbd>` elements.
+ *
+ * - macOS  compact symbols: "⇧⌘N" → ["⇧", "⌘", "N"]
+ * - Windows text form:      "Ctrl+Shift+N" → ["Ctrl", "Shift", "N"]
+ */
+export function splitShortcutTokens(shortcut: string): string[] {
+  if (shortcut.includes("+")) {
+    return shortcut.split("+").filter(Boolean);
+  }
+
+  return shortcut.split("");
 }
 
 export function toElectronAccelerator(shortcut: string): string | undefined {

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -460,7 +460,22 @@ export function splitShortcutTokens(shortcut: string): string[] {
     return shortcut.split("+").filter(Boolean);
   }
 
-  return shortcut.split("");
+  // macOS compact form: scan for known single-char modifier symbols, then
+  // treat the remainder as the key token (which may be multi-char, e.g. "Tab").
+  const MODIFIER_SYMBOLS = ["⌘", "⌥", "⇧", "⌃"];
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < shortcut.length) {
+    if (MODIFIER_SYMBOLS.includes(shortcut[i])) {
+      tokens.push(shortcut[i]);
+      i++;
+    } else {
+      // Everything remaining is the key (handles "Tab", "F1", single chars, etc.)
+      tokens.push(shortcut.slice(i));
+      break;
+    }
+  }
+  return tokens.filter(Boolean);
 }
 
 export function toElectronAccelerator(shortcut: string): string | undefined {

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -108,6 +108,7 @@ export type AppSettings = {
   sidebar: SidebarState;
   editorPreferences: EditorPreferences;
   autoOpenPDF: boolean;
+  dismissedUpdateVersion: string | null;
 };
 
 export type AppInfo = {

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -52,6 +52,8 @@ export type MarkdownEditorProps = {
   updateState?: UpdateState | null;
   updatesMode?: AppInfo["updatesMode"];
   onUpdateAction?: () => void;
+  onDismissUpdateAction?: () => void;
+  dismissedUpdateVersion?: string | null;
   isFocusMode?: boolean;
   showOutline?: boolean;
   onToggleFocusMode?: () => void;


### PR DESCRIPTION
## Summary

- **Dismissable update notification**: When manual update mode shows the "Download latest release" button, users can now dismiss it via an X button. The dismissed version is persisted in settings so it survives restarts and only reappears when a newer version is detected. Clicking the download button also auto-dismisses the notification.
- **Windows keyboard shortcut fix**: Shortcuts now display and behave correctly on Windows — showing `Ctrl+Shift+N` instead of macOS symbols like `⇧⌘N`. The primary modifier check is platform-aware (Ctrl on Windows, Cmd on macOS), preventing the Windows key from erroneously triggering shortcuts. All display surfaces are covered: command palette, settings panel, sidebar tooltips, editor toolbar, slash command menu, and shortcut recording.

## Changes

### Dismiss update notification
- Added `dismissedUpdateVersion` to `AppSettings` (type, defaults, validation, sanitization)
- `useUpdateStateFlags()` suppresses the notification when the dismissed version matches the latest release
- X dismiss button added next to "Download latest release" in `EditorToolbar`
- Clicking the download button itself also persists the dismissal
- Wired through `useDesktopAppController` → `DesktopApp` → component chain

### Windows shortcut display & behavior
- Added `isMacPlatform()`, `formatKeysForPlatform()`, `isPrimaryModifierPressed()`, and `splitShortcutTokens()` helpers to `shared/shortcuts.ts`
- `matchShortcut()` now accepts an optional `platform` parameter — only `Ctrl` triggers on Windows, only `Cmd` on macOS
- All `getShortcutDisplay()` call sites pass `platform` for correct rendering
- Settings panel shortcut recording only maps `Ctrl` (not `Meta`/Win key) to the primary modifier on Windows
- Command palette renders shortcut tokens via `splitShortcutTokens()` (handles both `"⌘P"` and `"Ctrl+P"` formats)
- Slash command definitions converted from hardcoded macOS symbols to internal token format with platform-aware display
- Sidebar tooltips and empty-state fallbacks are platform-aware

## Testing
- `pnpm typecheck` — passes
- `pnpm lint` (oxlint) — 0 warnings, 0 errors
- `oxfmt --check` — all files formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dismiss update notifications for specific versions — dismiss action in the update UI and command palette, persisted across sessions.

* **Improvements**
  * Platform-aware shortcut display and rendering (Mac symbols vs. Ctrl/Win text) across the app.
  * More reliable, platform-sensitive shortcut matching and keyboard shortcut behavior.
  * Update UI respects dismissed versions and hides manual-release actions when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->