### PR TITLE
feat(desktop): add zoom controls for editor content

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1252,3 +1252,73 @@ test("reset zoom to 100% via click on percentage", async ({}, testInfo) => {
     await glyph.stop(testInfo);
   }
 });
+
+test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Default zoom should be 100%
+    await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
+
+    // Press Cmd+Shift+= (Zoom In) - on macOS the default shortcut requires Shift to produce +
+    await glyph.window.keyboard.press("Meta+Shift+=");
+
+    // Settings should persist the new zoom level (100 + 10 = 110)
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(110);
+
+    // Button should now show 110%
+    await expect(glyph.window.getByRole("button", { name: /110%/ })).toBeVisible();
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("zoom reset via keyboard shortcut returns to 100%", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Zoom in first
+    const zoomInButton = glyph.window.getByRole("button", { name: "Zoom in" });
+    await zoomInButton.click();
+
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(110);
+
+    // Press Cmd+0 (Reset Zoom)
+    await glyph.window.keyboard.press("Meta+0");
+
+    // Settings should return to 100
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(100);
+
+    // Button should show 100%
+    await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1263,8 +1263,8 @@ test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo
     // Default zoom should be 100%
     await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
 
-    // Press Cmd+Shift+= (Zoom In) - on macOS the default shortcut requires Shift to produce +
-    await glyph.window.keyboard.press("Meta+Shift+=");
+    // Press Ctrl+Shift+= (Zoom In) - keyboard shortcut uses CommandOrControl
+    await glyph.window.keyboard.press(`${modKey}+Shift+=`);
 
     // Settings should persist the new zoom level (100 + 10 = 110)
     await expect
@@ -1303,8 +1303,8 @@ test("zoom reset via keyboard shortcut returns to 100%", async ({}, testInfo) =>
       })
       .toBe(110);
 
-    // Press Cmd+0 (Reset Zoom)
-    await glyph.window.keyboard.press("Meta+0");
+    // Press Ctrl+0 (Reset Zoom)
+    await glyph.window.keyboard.press(`${modKey}+0`);
 
     // Settings should return to 100
     await expect

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1263,8 +1263,8 @@ test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo
     // Default zoom should be 100%
     await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
 
-    // Press Ctrl+Shift+= (Zoom In) - keyboard shortcut uses CommandOrControl
-    await glyph.window.keyboard.press(`${modKey}+Shift+=`);
+    // Press Ctrl++ (Zoom In) - using + key which is Shift+= on most keyboards
+    await glyph.window.keyboard.press(`${modKey}++`);
 
     // Settings should persist the new zoom level (100 + 10 = 110)
     await expect

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1141,3 +1141,114 @@ test("focus mode persists in settings", async ({}, testInfo) => {
     await glyph.stop(testInfo);
   }
 });
+
+test("zoom controls appear in toolbar when a note is open", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Zoom controls should be visible in the toolbar
+    const zoomInButton = glyph.window.getByRole("button", { name: "Zoom in" });
+    const zoomOutButton = glyph.window.getByRole("button", { name: "Zoom out" });
+
+    await expect(zoomInButton).toBeVisible();
+    await expect(zoomOutButton).toBeVisible();
+
+    // Default zoom level should be 100%
+    await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("zoom in increases editor scale", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Click zoom in button
+    const zoomInButton = glyph.window.getByRole("button", { name: "Zoom in" });
+    await zoomInButton.click();
+
+    // Settings should persist the new zoom level
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(110);
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("zoom out decreases editor scale", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Click zoom out button twice
+    const zoomOutButton = glyph.window.getByRole("button", { name: "Zoom out" });
+    await zoomOutButton.click();
+    await zoomOutButton.click();
+
+    // Settings should persist the new zoom level
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(80);
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("reset zoom to 100% via click on percentage", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+
+    // Zoom in first (settings file should now have 110)
+    const zoomInButton = glyph.window.getByRole("button", { name: "Zoom in" });
+    await zoomInButton.click();
+
+    // Wait for settings to persist
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(110);
+
+    // Click the zoom percentage button to reset it to 100%
+    const zoomLevelButton = glyph.window.locator("button", { hasText: /110%/ });
+    await zoomLevelButton.click();
+
+    // Should return to 100%
+    await expect
+      .poll(async () => {
+        const settings = await readJson<{
+          editorPreferences?: { editorScale?: number };
+        }>(glyph.sandbox.settingsPath);
+        return settings?.editorPreferences?.editorScale ?? null;
+      })
+      .toBe(100);
+  } finally {
+    await glyph.stop(testInfo);
+  }
+});

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1253,7 +1253,7 @@ test("reset zoom to 100% via click on percentage", async ({}, testInfo) => {
   }
 });
 
-test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo) => {
+test("zoom in via command palette increases editor scale", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -1263,8 +1263,8 @@ test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo
     // Default zoom should be 100%
     await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
 
-    // Press Ctrl+= (Zoom In) - shortcut is Ctrl+= without Shift
-    await glyph.window.keyboard.press(`${modKey}+=`);
+    // Trigger "Zoom In" via command palette (more reliable cross-platform than raw keyboard shortcut)
+    await selectPaletteItem(glyph.window, "zoom in", /zoom in/i);
 
     // Settings should persist the new zoom level (100 + 10 = 110)
     await expect

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1263,8 +1263,8 @@ test("zoom in via keyboard shortcut increases editor scale", async ({}, testInfo
     // Default zoom should be 100%
     await expect(glyph.window.getByRole("button", { name: /100%/ })).toBeVisible();
 
-    // Press Ctrl++ (Zoom In) - using + key which is Shift+= on most keyboards
-    await glyph.window.keyboard.press(`${modKey}++`);
+    // Press Ctrl+= (Zoom In) - shortcut is Ctrl+= without Shift
+    await glyph.window.keyboard.press(`${modKey}+=`);
 
     // Settings should persist the new zoom level (100 + 10 = 110)
     await expect

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1067,6 +1067,21 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
     accelerator: getAccelerator("focus-mode"),
     click: () => mainWindow?.webContents.send("app:command", "focus-mode" satisfies AppCommand),
   };
+  const zoomInItem: Electron.MenuItemConstructorOptions = {
+    label: "Zoom In",
+    accelerator: getAccelerator("zoom-in"),
+    click: () => mainWindow?.webContents.send("app:command", "zoom-in" satisfies AppCommand),
+  };
+  const zoomOutItem: Electron.MenuItemConstructorOptions = {
+    label: "Zoom Out",
+    accelerator: getAccelerator("zoom-out"),
+    click: () => mainWindow?.webContents.send("app:command", "zoom-out" satisfies AppCommand),
+  };
+  const zoomResetItem: Electron.MenuItemConstructorOptions = {
+    label: "Reset Zoom",
+    accelerator: getAccelerator("zoom-reset"),
+    click: () => mainWindow?.webContents.send("app:command", "zoom-reset" satisfies AppCommand),
+  };
 
   const viewSubmenu: Electron.MenuItemConstructorOptions[] = isDev
     ? [
@@ -1075,8 +1090,20 @@ function buildApplicationMenu(shortcuts: AppSettings["shortcuts"]) {
         { role: "toggleDevTools" },
         { type: "separator" },
         focusModeItem,
+        { type: "separator" },
+        zoomInItem,
+        zoomOutItem,
+        zoomResetItem,
       ]
-    : [{ role: "togglefullscreen" }, { type: "separator" }, focusModeItem];
+    : [
+        { role: "togglefullscreen" },
+        { type: "separator" },
+        focusModeItem,
+        { type: "separator" },
+        zoomInItem,
+        zoomOutItem,
+        zoomResetItem,
+      ];
 
   const menuTemplate: Electron.MenuItemConstructorOptions[] = [
     {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -972,6 +972,7 @@ function getDefaultSettings(): AppSettings {
     editorPreferences: {
       focusMode: false,
       showOutline: true,
+      editorScale: 100,
     },
     autoOpenPDF: true,
     dismissedUpdateVersion: null,
@@ -1017,9 +1018,12 @@ function normalizePersistedFileList(input: unknown) {
 function normalizeEditorPreferences(
   input: Partial<AppSettings["editorPreferences"]> | undefined,
 ): AppSettings["editorPreferences"] {
+  const editorScale =
+    typeof input?.editorScale === "number" ? Math.min(200, Math.max(50, input.editorScale)) : 100;
   return {
     focusMode: typeof input?.focusMode === "boolean" ? input.focusMode : false,
     showOutline: typeof input?.showOutline === "boolean" ? input.showOutline : true,
+    editorScale,
   };
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1018,8 +1018,11 @@ function normalizePersistedFileList(input: unknown) {
 function normalizeEditorPreferences(
   input: Partial<AppSettings["editorPreferences"]> | undefined,
 ): AppSettings["editorPreferences"] {
+  const rawScale = input?.editorScale;
   const editorScale =
-    typeof input?.editorScale === "number" ? Math.min(200, Math.max(50, input.editorScale)) : 100;
+    typeof rawScale === "number" && Number.isFinite(rawScale)
+      ? Math.min(200, Math.max(50, rawScale))
+      : 100;
   return {
     focusMode: typeof input?.focusMode === "boolean" ? input.focusMode : false,
     showOutline: typeof input?.showOutline === "boolean" ? input.showOutline : true,

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1262,6 +1262,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 }
                 onOutlineJumpHandled={controller.clearOutlineJumpRequest}
                 onToggleFocusMode={() => void controller.toggleFocusMode()}
+                editorScale={controller.editorScale}
+                onEditorScaleChange={(scale) => void controller.setEditorScale(scale)}
                 onTogglePinnedFile={
                   controller.activeFile
                     ? () => void controller.togglePinnedFile(controller.activeFile!.path)

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -881,7 +881,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         shortcut:
           getShortcutDisplay(controller.shortcuts, "zoom-in", navigator.platform) ?? undefined,
         onSelect: () => {
-          controller.setEditorScale(Math.min(200, controller.editorScale + 10));
+          void controller.setEditorScale(Math.min(200, controller.editorScale + 10));
+          closePalette();
         },
       },
       {
@@ -893,7 +894,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         shortcut:
           getShortcutDisplay(controller.shortcuts, "zoom-out", navigator.platform) ?? undefined,
         onSelect: () => {
-          controller.setEditorScale(Math.max(50, controller.editorScale - 10));
+          void controller.setEditorScale(Math.max(50, controller.editorScale - 10));
+          closePalette();
         },
       },
       {
@@ -905,7 +907,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         shortcut:
           getShortcutDisplay(controller.shortcuts, "zoom-reset", navigator.platform) ?? undefined,
         onSelect: () => {
-          controller.setEditorScale(100);
+          void controller.setEditorScale(100);
+          closePalette();
         },
       },
     ];
@@ -925,6 +928,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     viewerMode,
     controller.editorScale,
     controller.shortcuts,
+    closePalette,
   ]);
 
   const skillPaletteItems = useMemo<CommandPaletteItem[]>(() => {

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { getDisplayFileName, isSamePath } from "@/lib/paths";
 import { countGroupedSkills, groupSkillsForBrowse } from "@/lib/skill-groups";
 import { formatByteSize } from "@/lib/format-byte-size";
+import { getShortcutDisplay } from "@/shared/shortcuts";
 import { SKILL_AGENT_CATALOG } from "@/shared/skill-agent-catalog";
 import type { SkillEntry, SkillSourceKind, SkillToolKind } from "@/shared/skills";
 import { useSessionStore } from "@/store/session";
@@ -877,6 +878,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         subtitle: "Increase editor zoom level",
         section: "Note",
         kind: "command",
+        shortcut:
+          getShortcutDisplay(controller.shortcuts, "zoom-in", navigator.platform) ?? undefined,
         onSelect: () => {
           controller.setEditorScale(Math.min(200, controller.editorScale + 10));
         },
@@ -887,6 +890,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         subtitle: "Decrease editor zoom level",
         section: "Note",
         kind: "command",
+        shortcut:
+          getShortcutDisplay(controller.shortcuts, "zoom-out", navigator.platform) ?? undefined,
         onSelect: () => {
           controller.setEditorScale(Math.max(50, controller.editorScale - 10));
         },
@@ -897,6 +902,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         subtitle: "Reset editor zoom to 100%",
         section: "Note",
         kind: "command",
+        shortcut:
+          getShortcutDisplay(controller.shortcuts, "zoom-reset", navigator.platform) ?? undefined,
         onSelect: () => {
           controller.setEditorScale(100);
         },
@@ -917,6 +924,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     paletteFilterQuery,
     viewerMode,
     controller.editorScale,
+    controller.shortcuts,
   ]);
 
   const skillPaletteItems = useMemo<CommandPaletteItem[]>(() => {

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -871,6 +871,36 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
           void handleExportCurrentNote();
         },
       },
+      {
+        id: "zoom-in",
+        title: "Zoom In",
+        subtitle: "Increase editor zoom level",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          controller.setEditorScale(Math.min(200, controller.editorScale + 10));
+        },
+      },
+      {
+        id: "zoom-out",
+        title: "Zoom Out",
+        subtitle: "Decrease editor zoom level",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          controller.setEditorScale(Math.max(50, controller.editorScale - 10));
+        },
+      },
+      {
+        id: "zoom-reset",
+        title: "Reset Zoom",
+        subtitle: "Reset editor zoom to 100%",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          controller.setEditorScale(100);
+        },
+      },
     ];
 
     return items.filter((item) => matchesPaletteQuery(query, item.title, item.subtitle));
@@ -886,6 +916,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     handleRevealCurrentNote,
     paletteFilterQuery,
     viewerMode,
+    controller.editorScale,
   ]);
 
   const skillPaletteItems = useMemo<CommandPaletteItem[]>(() => {

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -23,6 +23,8 @@ import {
   PlusIcon,
   SearchIcon,
   XIcon,
+  ZoomInIcon,
+  ZoomOutIcon,
 } from "@/components/icons";
 import { FileManagerLogo } from "./file-manager-logo";
 
@@ -68,6 +70,11 @@ type EditorToolbarProps = {
   onExportPDF: () => Promise<void>;
   onTogglePinnedFile: (() => void) | undefined;
   isActiveFilePinned: boolean | undefined;
+  editorScale: number;
+  onEditorScaleChange: ((scale: number) => void) | undefined;
+  zoomInShortcut: string | undefined;
+  zoomOutShortcut: string | undefined;
+  zoomResetShortcut: string | undefined;
 };
 
 export function EditorToolbar({
@@ -111,7 +118,23 @@ export function EditorToolbar({
   onExportPDF,
   onTogglePinnedFile,
   isActiveFilePinned,
+  editorScale = 100,
+  onEditorScaleChange,
+  zoomInShortcut,
+  zoomOutShortcut,
+  zoomResetShortcut,
 }: EditorToolbarProps) {
+  const handleZoomIn = useCallback(() => {
+    onEditorScaleChange?.(Math.min(editorScale + 10, 110));
+  }, [editorScale, onEditorScaleChange]);
+
+  const handleZoomOut = useCallback(() => {
+    onEditorScaleChange?.(Math.max(editorScale - 10, 50));
+  }, [editorScale, onEditorScaleChange]);
+
+  const handleZoomReset = useCallback(() => {
+    onEditorScaleChange?.(100);
+  }, [onEditorScaleChange]);
   const handleCopy = useCallback(async () => {
     await onCopy();
   }, [onCopy]);
@@ -236,6 +259,54 @@ export function EditorToolbar({
               {commandPaletteShortcut}
             </span>
           </Button>
+        </div>
+      ) : null}
+
+      {/* Center: zoom controls (shown when there's a file open) */}
+      {fileName && onEditorScaleChange ? (
+        <div className="flex items-center gap-0.5 relative">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground hover:bg-muted"
+                onClick={handleZoomOut}
+                aria-label="Zoom out"
+                type="button"
+              >
+                <ZoomOutIcon size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              Zoom Out{zoomOutShortcut ? ` (${zoomOutShortcut})` : ""}
+            </TooltipContent>
+          </Tooltip>
+          <button
+            type="button"
+            onClick={handleZoomReset}
+            className="min-w-[48px] px-1.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+            aria-label={`Reset zoom to 100% (${zoomResetShortcut})`}
+          >
+            {editorScale}%
+          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground hover:bg-muted"
+                onClick={handleZoomIn}
+                aria-label="Zoom in"
+                type="button"
+              >
+                <ZoomInIcon size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              Zoom In{zoomInShortcut ? ` (${zoomInShortcut})` : ""}
+            </TooltipContent>
+          </Tooltip>
         </div>
       ) : null}
 

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -282,14 +282,21 @@ export function EditorToolbar({
               Zoom Out{zoomOutShortcut ? ` (${zoomOutShortcut})` : ""}
             </TooltipContent>
           </Tooltip>
-          <button
-            type="button"
-            onClick={handleZoomReset}
-            className="min-w-[48px] px-1.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
-            aria-label={`Reset zoom to 100% (${zoomResetShortcut})`}
-          >
-            {editorScale}%
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleZoomReset}
+                className="min-w-[48px] px-1.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+                aria-label={`Reset zoom to 100%${zoomResetShortcut ? ` (${zoomResetShortcut})` : ""}`}
+              >
+                {editorScale}%
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              Reset to 100%{zoomResetShortcut ? ` (${zoomResetShortcut})` : ""}
+            </TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -284,14 +284,20 @@ export function EditorToolbar({
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={handleZoomReset}
-                className="min-w-[48px] px-1.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
-                aria-label={`Reset zoom to 100%${zoomResetShortcut ? ` (${zoomResetShortcut})` : ""}`}
+                className="min-w-[48px] px-1.5 h-7 text-xs font-medium"
+                aria-label={
+                  zoomResetShortcut
+                    ? `Reset zoom to 100% (${zoomResetShortcut})`
+                    : "Reset zoom to 100%"
+                }
+                type="button"
               >
                 {editorScale}%
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               Reset to 100%{zoomResetShortcut ? ` (${zoomResetShortcut})` : ""}

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -291,8 +291,8 @@ export function EditorToolbar({
                 className="min-w-[48px] px-1.5 h-7 text-xs font-medium"
                 aria-label={
                   zoomResetShortcut
-                    ? `Reset zoom to 100% (${zoomResetShortcut})`
-                    : "Reset zoom to 100%"
+                    ? `${editorScale}% — Reset zoom to 100% (${zoomResetShortcut})`
+                    : `${editorScale}% — Reset zoom to 100%`
                 }
                 type="button"
               >

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -125,7 +125,7 @@ export function EditorToolbar({
   zoomResetShortcut,
 }: EditorToolbarProps) {
   const handleZoomIn = useCallback(() => {
-    onEditorScaleChange?.(Math.min(editorScale + 10, 110));
+    onEditorScaleChange?.(Math.min(editorScale + 10, 200));
   }, [editorScale, onEditorScaleChange]);
 
   const handleZoomOut = useCallback(() => {

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -86,3 +86,42 @@ export const PinOffIcon = (props: IconProps) => <HugeIcon icon={HugePinOffIcon} 
 
 export const FocusIcon = (props: IconProps) => <HugeIcon icon={Maximize01Svg} {...props} />;
 export const OutlineIcon = (props: IconProps) => <HugeIcon icon={ListViewSvg} {...props} />;
+
+export const ZoomInIcon = (props: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={props.size ?? 16}
+    height={props.size ?? 16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={props.color ?? "currentColor"}
+    strokeWidth={props.strokeWidth ?? 2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={props.className}
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+    <path d="M11 8v6" />
+    <path d="M8 11h6" />
+  </svg>
+);
+
+export const ZoomOutIcon = (props: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={props.size ?? 16}
+    height={props.size ?? 16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={props.color ?? "currentColor"}
+    strokeWidth={props.strokeWidth ?? 2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={props.className}
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+    <path d="M8 11h6" />
+  </svg>
+);

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -1779,7 +1779,6 @@ export const MarkdownEditor = ({
             </div>
           ) : null}
           <div
-            className="overflow-auto"
             style={{
               zoom: editorScale !== 100 ? `${editorScale}%` : undefined,
             }}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -390,11 +390,16 @@ export const MarkdownEditor = ({
   showOutline = true,
   onToggleFocusMode,
   focusModeShortcut,
+  zoomInShortcut,
+  zoomOutShortcut,
+  zoomResetShortcut,
   onTogglePinnedFile,
+  onEditorScaleChange,
   onScrollPositionChange,
   folderRevealLabel,
   documentLabel = "note",
   outlineJumpRequest,
+  editorScale = 100,
 }: MarkdownEditorProps) => {
   const lastSyncedMarkdown = useRef(content);
   const onChangeRef = useRef(onChange);
@@ -1469,6 +1474,11 @@ export const MarkdownEditor = ({
         onExportPDF={handleExportPDF}
         onTogglePinnedFile={onTogglePinnedFile}
         isActiveFilePinned={isActiveFilePinned}
+        editorScale={editorScale}
+        onEditorScaleChange={onEditorScaleChange}
+        zoomInShortcut={zoomInShortcut}
+        zoomOutShortcut={zoomOutShortcut}
+        zoomResetShortcut={zoomResetShortcut}
       />
       {subheaderContent ? (
         <div className="border-b border-border/30">{subheaderContent}</div>
@@ -1768,7 +1778,14 @@ export const MarkdownEditor = ({
               </Button>
             </div>
           ) : null}
-          <EditorContent editor={editor} />
+          <div
+            className="overflow-auto"
+            style={{
+              zoom: editorScale !== 100 ? `${editorScale}%` : undefined,
+            }}
+          >
+            <EditorContent editor={editor} />
+          </div>
         </div>
       </div>
       {shouldShowOutlineRail ? (

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -32,6 +32,11 @@ type NoteViewProps = {
   isActiveFilePinned: boolean;
   isFocusMode: boolean;
   showOutline: boolean;
+  editorScale: number;
+  onEditorScaleChange: (scale: number) => void;
+  zoomInShortcut?: string;
+  zoomOutShortcut?: string;
+  zoomResetShortcut?: string;
   outlineItems: OutlineItem[];
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;
@@ -80,6 +85,8 @@ export function NoteView({
   isActiveFilePinned,
   isFocusMode,
   showOutline,
+  editorScale,
+  onEditorScaleChange,
   outlineItems,
   outlineJumpRequest,
   updateState,
@@ -175,6 +182,9 @@ export function NoteView({
         navigator.platform,
       )}
       focusModeShortcut={getShortcutDisplay(shortcuts, "focus-mode", navigator.platform)}
+      zoomInShortcut={getShortcutDisplay(shortcuts, "zoom-in", navigator.platform)}
+      zoomOutShortcut={getShortcutDisplay(shortcuts, "zoom-out", navigator.platform)}
+      zoomResetShortcut={getShortcutDisplay(shortcuts, "zoom-reset", navigator.platform)}
       onDeleteNote={onDeleteNote}
       onOpenNewWindow={onOpenNewWindow}
       canGoBack={canGoBack}
@@ -190,6 +200,8 @@ export function NoteView({
       outlineJumpRequest={outlineJumpRequest}
       scrollRestorationKey={filePath}
       showOutline={showOutline}
+      editorScale={editorScale}
+      onEditorScaleChange={onEditorScaleChange}
       updateState={updateState}
       updatesMode={updatesMode}
       dismissedUpdateVersion={dismissedUpdateVersion}

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -34,9 +34,6 @@ type NoteViewProps = {
   showOutline: boolean;
   editorScale: number;
   onEditorScaleChange: (scale: number) => void;
-  zoomInShortcut?: string;
-  zoomOutShortcut?: string;
-  zoomResetShortcut?: string;
   outlineItems: OutlineItem[];
   outlineJumpRequest: { id: string; nonce: number } | null;
   updateState: UpdateState | null;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1990,6 +1990,23 @@ export const useDesktopAppController = (
         return;
       }
 
+      if (command === "zoom-in") {
+        const nextScale = Math.min(200, editorScale + 10);
+        await setEditorScale(nextScale);
+        return;
+      }
+
+      if (command === "zoom-out") {
+        const nextScale = Math.max(50, editorScale - 10);
+        await setEditorScale(nextScale);
+        return;
+      }
+
+      if (command === "zoom-reset") {
+        await setEditorScale(100);
+        return;
+      }
+
       if (command === "check-updates") {
         await triggerUpdateAction();
         return;
@@ -2073,6 +2090,8 @@ export const useDesktopAppController = (
     triggerUpdateAction,
     setIsPaletteOpen,
     setIsSidebarCollapsed,
+    setEditorScale,
+    editorScale,
   ]);
 
   return {

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1016,7 +1016,7 @@ export const useDesktopAppController = (
 
   const setEditorScale = useCallback(
     async (nextScale: number) => {
-      const clampedScale = Math.min(110, Math.max(50, nextScale));
+      const clampedScale = Math.min(200, Math.max(50, nextScale));
       await saveSettings({
         editorPreferences: {
           focusMode: isFocusMode,

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -234,6 +234,7 @@ export const useDesktopAppController = (
   const editorPreferences = settings?.editorPreferences;
   const isFocusMode = editorPreferences?.focusMode ?? false;
   const showOutline = editorPreferences?.showOutline ?? true;
+  const editorScale = editorPreferences?.editorScale ?? 100;
   const folderRevealLabel = getFolderRevealLabel(appInfo?.platform);
   const isActiveFilePinned = activeFile
     ? (settings?.pinnedFiles ?? []).some((filePath) => isSamePath(filePath, activeFile.path))
@@ -998,18 +999,34 @@ export const useDesktopAppController = (
       editorPreferences: {
         focusMode: !isFocusMode,
         showOutline,
+        editorScale,
       },
     });
-  }, [isFocusMode, showOutline, saveSettings]);
+  }, [isFocusMode, showOutline, editorScale, saveSettings]);
 
   const toggleOutline = useCallback(async () => {
     await saveSettings({
       editorPreferences: {
         focusMode: isFocusMode,
         showOutline: !showOutline,
+        editorScale,
       },
     });
-  }, [isFocusMode, showOutline, saveSettings]);
+  }, [isFocusMode, showOutline, editorScale, saveSettings]);
+
+  const setEditorScale = useCallback(
+    async (nextScale: number) => {
+      const clampedScale = Math.min(110, Math.max(50, nextScale));
+      await saveSettings({
+        editorPreferences: {
+          focusMode: isFocusMode,
+          showOutline,
+          editorScale: clampedScale,
+        },
+      });
+    },
+    [isFocusMode, showOutline, saveSettings],
+  );
 
   const triggerUpdateAction = useCallback(async () => {
     if (!updateState) {
@@ -1584,6 +1601,8 @@ export const useDesktopAppController = (
     setIsSettingsOpen,
     setIsSidebarCollapsed,
     toggleFocusMode,
+    setEditorScale,
+    editorScale,
   });
 
   // Boot sequence
@@ -2127,5 +2146,7 @@ export const useDesktopAppController = (
     visibleSidebarNodes,
     wordCount,
     hasBooted,
+    editorScale,
+    setEditorScale,
   };
 };

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -293,5 +293,7 @@ export function useKeyboardShortcuts({
     setIsSettingsOpen,
     setIsSidebarCollapsed,
     toggleFocusMode,
+    setEditorScale,
+    editorScale,
   ]);
 }

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -29,6 +29,8 @@ type UseKeyboardShortcutsOptions = {
   setIsSettingsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setIsSidebarCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
   toggleFocusMode: () => Promise<void>;
+  setEditorScale: (scale: number) => Promise<void>;
+  editorScale: number;
 };
 
 export function useKeyboardShortcuts({
@@ -57,6 +59,8 @@ export function useKeyboardShortcuts({
   setIsSettingsOpen,
   setIsSidebarCollapsed,
   toggleFocusMode,
+  setEditorScale,
+  editorScale,
 }: UseKeyboardShortcutsOptions) {
   useEffect(() => {
     const onKeyDown = async (event: KeyboardEvent) => {
@@ -148,6 +152,9 @@ export function useKeyboardShortcuts({
         "new-folder",
         "close-tab",
         "close-other-tabs",
+        "zoom-in",
+        "zoom-out",
+        "zoom-reset",
       ]);
       const globalShortcut = shortcuts.find(
         (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys, platform),
@@ -190,6 +197,15 @@ export function useKeyboardShortcuts({
             break;
           case "close-other-tabs":
             void closeOtherTabs();
+            break;
+          case "zoom-in":
+            void setEditorScale(Math.min(110, editorScale + 10));
+            break;
+          case "zoom-out":
+            void setEditorScale(Math.max(50, editorScale - 10));
+            break;
+          case "zoom-reset":
+            void setEditorScale(100);
             break;
         }
         return;

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -199,7 +199,7 @@ export function useKeyboardShortcuts({
             void closeOtherTabs();
             break;
           case "zoom-in":
-            void setEditorScale(Math.min(110, editorScale + 10));
+            void setEditorScale(Math.min(200, editorScale + 10));
             break;
           case "zoom-out":
             void setEditorScale(Math.max(50, editorScale - 10));

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -15,7 +15,10 @@ export type ShortcutId =
   | "toggle-sidebar"
   | "navigate-back"
   | "navigate-forward"
-  | "focus-mode";
+  | "focus-mode"
+  | "zoom-in"
+  | "zoom-out"
+  | "zoom-reset";
 
 export type ShortcutDefinition = ShortcutSetting & {
   id: ShortcutId;
@@ -124,6 +127,9 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     label: "Toggle Focus Mode",
     keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} F`,
   },
+  { id: "zoom-in", label: "Zoom In", keys: `${MODIFIER_TOKENS.cmdOrCtrl} =` },
+  { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
+  { id: "zoom-reset", label: "Reset Zoom", keys: `${MODIFIER_TOKENS.cmdOrCtrl} 0` },
 ];
 
 export function getPrimaryShortcutPrefix(platform?: string): string {

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -127,11 +127,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     label: "Toggle Focus Mode",
     keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} F`,
   },
-  {
-    id: "zoom-in",
-    label: "Zoom In",
-    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} =`,
-  },
+  { id: "zoom-in", label: "Zoom In", keys: `${MODIFIER_TOKENS.cmdOrCtrl} =` },
+  { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
   { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
   { id: "zoom-reset", label: "Reset Zoom", keys: `${MODIFIER_TOKENS.cmdOrCtrl} 0` },
 ];

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -129,7 +129,6 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   },
   { id: "zoom-in", label: "Zoom In", keys: `${MODIFIER_TOKENS.cmdOrCtrl} =` },
   { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
-  { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
   { id: "zoom-reset", label: "Reset Zoom", keys: `${MODIFIER_TOKENS.cmdOrCtrl} 0` },
 ];
 

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -127,7 +127,11 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     label: "Toggle Focus Mode",
     keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} F`,
   },
-  { id: "zoom-in", label: "Zoom In", keys: `${MODIFIER_TOKENS.cmdOrCtrl} =` },
+  {
+    id: "zoom-in",
+    label: "Zoom In",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} =`,
+  },
   { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
   { id: "zoom-reset", label: "Reset Zoom", keys: `${MODIFIER_TOKENS.cmdOrCtrl} 0` },
 ];

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -94,6 +94,7 @@ export type SidebarState = {
 export type EditorPreferences = {
   focusMode: boolean;
   showOutline: boolean;
+  editorScale: number;
 };
 
 export type AppSettings = {

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -158,7 +158,10 @@ export type AppCommand =
   | "quick-open"
   | "find-in-note"
   | "toggle-sidebar"
-  | "focus-mode";
+  | "focus-mode"
+  | "zoom-in"
+  | "zoom-out"
+  | "zoom-reset";
 
 export type ExternalFileTarget = {
   path: string;

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -26,6 +26,10 @@ export type MarkdownEditorProps = {
   footerMetaLabel?: string;
   wordCount: number;
   readingTime: number;
+  editorScale?: number;
+  zoomInShortcut?: string;
+  zoomOutShortcut?: string;
+  zoomResetShortcut?: string;
   onChange: (value: string) => void;
   onToggleSidebar?: () => void;
   isSidebarCollapsed?: boolean;
@@ -61,6 +65,7 @@ export type MarkdownEditorProps = {
   onOpenNewWindow?: () => void;
   onDeleteNote?: () => void;
   onTogglePinnedFile?: () => void;
+  onEditorScaleChange?: (scale: number) => void;
   onScrollPositionChange?: (targetPath: string | null, scrollTop: number) => void;
   folderRevealLabel?: string;
   documentLabel?: string;


### PR DESCRIPTION
- Add editorScale to EditorPreferences (persisted in settings)
- Add zoom in/out/reset buttons in toolbar (shown when note is open)
- Keyboard shortcuts: Cmd+= (zoom in), Cmd+- (zoom out), Cmd+0 (reset)
- Uses CSS zoom property for focused editor scaling (50%-110%)
- Add zoom shortcuts to customizable shortcuts in settings
- Add e2e tests for zoom functionality

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom In/Out and Reset Zoom added to the editor toolbar and command palette (visible when a note is open); current percentage displayed and updates live.
  * Zoom range 50–200% in 10% steps, reset to 100%; setting persists across sessions.
  * View menu entries for Zoom In/Out/Reset.

* **Keyboard Shortcuts**
  * Cmd/Ctrl+Shift+= (Zoom In), Cmd/Ctrl+- (Zoom Out), Cmd/Ctrl+0 (Reset).

* **Tests**
  * Added smoke tests for toolbar controls, shortcuts, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->