### PR TITLE
feat: keyboard navigation, focus flow, and default app prompt

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -976,6 +976,7 @@ function getDefaultSettings(): AppSettings {
     },
     autoOpenPDF: true,
     dismissedUpdateVersion: null,
+    dismissedDefaultAppPrompt: null,
   };
 }
 
@@ -1335,6 +1336,12 @@ async function sanitizeSettingsWithFileValidation(input: unknown): Promise<AppSe
         : candidate.dismissedUpdateVersion === null
           ? null
           : defaults.dismissedUpdateVersion,
+    dismissedDefaultAppPrompt:
+      typeof candidate.dismissedDefaultAppPrompt === "boolean"
+        ? candidate.dismissedDefaultAppPrompt
+        : candidate.dismissedDefaultAppPrompt === null
+          ? null
+          : defaults.dismissedDefaultAppPrompt,
   };
 }
 
@@ -1454,6 +1461,17 @@ function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
         : null;
   }
 
+  if ("dismissedDefaultAppPrompt" in candidate) {
+    if (
+      candidate.dismissedDefaultAppPrompt !== null &&
+      typeof candidate.dismissedDefaultAppPrompt !== "boolean"
+    ) {
+      throw new Error("dismissedDefaultAppPrompt must be a boolean or null.");
+    }
+
+    nextPatch.dismissedDefaultAppPrompt = candidate.dismissedDefaultAppPrompt;
+  }
+
   const invalidKeys = Object.keys(candidate).filter(
     (key) =>
       ![
@@ -1467,6 +1485,7 @@ function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
         "editorPreferences",
         "autoOpenPDF",
         "dismissedUpdateVersion",
+        "dismissedDefaultAppPrompt",
       ].includes(key),
   );
 
@@ -2226,6 +2245,76 @@ ipcMain.handle("settings:update", async (_event, patch: unknown) => {
   const nextSettings = await updateSettings(sanitizedPatch);
   refreshApplicationMenu(nextSettings.shortcuts);
   return nextSettings;
+});
+
+ipcMain.handle("app:getDefaultAppStatus", async () => {
+  if (process.platform === "darwin") {
+    try {
+      const { exec } = await import("node:child_process");
+
+      const isDefaultForExtension = (ext: string): Promise<boolean> => {
+        return new Promise((resolve) => {
+          exec(
+            `osascript -e 'tell app "System Events" to get the default application of file extension "${ext}"'`,
+            (error, stdout) => {
+              if (error) {
+                resolve(true);
+                return;
+              }
+              resolve(stdout.toLowerCase().includes("glyph"));
+            },
+          );
+        });
+      };
+
+      const mdResult = await isDefaultForExtension("md");
+      const mdxResult = await isDefaultForExtension("mdx");
+      const allDefault = mdResult && mdxResult;
+
+      return { isDefault: allDefault, platform: "darwin" };
+    } catch {
+      return { isDefault: true, platform: "darwin" };
+    }
+  }
+
+  if (process.platform === "win32") {
+    try {
+      const { exec } = await import("node:child_process");
+
+      const isDefaultForExtension = (ext: string): Promise<boolean> => {
+        return new Promise((resolve) => {
+          const extName = ext.slice(1);
+          exec(`ftype ${extName}`, (error, stdout) => {
+            if (error) {
+              resolve(true);
+              return;
+            }
+            resolve(stdout.toLowerCase().includes("glyph"));
+          });
+        });
+      };
+
+      const mdResult = await isDefaultForExtension(".md");
+      const mdxResult = await isDefaultForExtension(".mdx");
+      const allDefault = mdResult && mdxResult;
+
+      return { isDefault: allDefault, platform: "win32" };
+    } catch {
+      return { isDefault: true, platform: "win32" };
+    }
+  }
+
+  return { isDefault: true, platform: process.platform };
+});
+
+ipcMain.handle("app:openDefaultAppSettings", async () => {
+  if (process.platform === "darwin") {
+    shell.openExternal(
+      "https://support.apple.com/guide/mac-help/change-the-app-that-opens-a-file-mh35855/mac",
+    );
+  } else if (process.platform === "win32") {
+    shell.openExternal("ms-settings:defaultapps");
+  }
 });
 
 ipcMain.handle("app:getInfo", async () => getAppInfo());

--- a/apps/desktop/electron/preload.cts
+++ b/apps/desktop/electron/preload.cts
@@ -137,6 +137,15 @@ const api = {
   getAppInfo() {
     return invokeWithRetry<AppInfo>("app:getInfo");
   },
+  getDefaultAppStatus() {
+    return ipcRenderer.invoke("app:getDefaultAppStatus") as Promise<{
+      isDefault: boolean;
+      platform: string;
+    }>;
+  },
+  openDefaultAppSettings() {
+    return ipcRenderer.invoke("app:openDefaultAppSettings") as Promise<void>;
+  },
   getUpdateState() {
     return invokeWithRetry<UpdateState>("app:getUpdateState");
   },

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -68,7 +68,7 @@ export function AppLayout({
 }: AppLayoutProps) {
   return (
     <div
-      className={`grid h-screen min-h-0 overflow-hidden transition-[grid-template-columns] duration-200 ${
+      className={`grid h-screen min-h-0 overflow-hidden transition-[grid-template-columns] duration-200 ease-out motion-reduce:transition-none ${
         shouldCollapseSidebar ? "grid-cols-[0_minmax(0,1fr)]" : "grid-cols-[280px_minmax(0,1fr)]"
       }`}
     >
@@ -104,7 +104,13 @@ export function AppLayout({
         />
       )}
 
-      <main className="relative h-full min-h-0 overflow-hidden bg-background">{children}</main>
+      <main
+        id="main-content"
+        className="relative h-full min-h-0 overflow-hidden bg-background"
+        tabIndex={-1}
+      >
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/desktop/src/components/default-app-prompt.tsx
+++ b/apps/desktop/src/components/default-app-prompt.tsx
@@ -1,0 +1,62 @@
+import { memo } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { DefaultAppPromptProps } from "../types/default-app-prompt";
+
+const focusMainEditor = () => {
+  requestAnimationFrame(() => {
+    const main = document.getElementById("main-content");
+    if (main) {
+      main.focus();
+    }
+  });
+};
+
+export const DefaultAppPrompt = memo(function DefaultAppPrompt({
+  isOpen,
+  platform,
+  onDismiss,
+  onMakeDefault,
+}: DefaultAppPromptProps) {
+  const isMac = platform === "darwin";
+  const isWindows = platform === "win32";
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          focusMainEditor();
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Make Glyph Your Default App?</DialogTitle>
+          <DialogDescription className="mt-2">
+            {isMac
+              ? "Glyph can open .md and .mdx files by default, so you can double-click any Markdown file to open it here."
+              : "Set Glyph as the default app for .md and .mdx files to open them directly from File Explorer."}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" onClick={onDismiss} className="flex-1">
+            Not Now
+          </Button>
+          <Button onClick={onMakeDefault} className="flex-1">
+            {isWindows ? "Set as Default" : "Enable"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -16,6 +16,7 @@ import { useSkillLibraryController } from "@/hooks/use-skill-library-controller"
 
 import { AppLayout } from "./app-layout";
 import { CommandPalette } from "./command-palette";
+import { DefaultAppPrompt } from "./default-app-prompt";
 import { NoteConfirmDialog } from "./note-confirm-dialog";
 import { NoteRenameDialog } from "./note-rename-dialog";
 import { NoteView } from "./note-view";
@@ -138,6 +139,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);
   const [pendingSkillRestorePath, setPendingSkillRestorePath] = useState<string | null>(null);
   const [isInitialSkillRestorePending, setIsInitialSkillRestorePending] = useState(false);
+  const [showDefaultAppPrompt, setShowDefaultAppPrompt] = useState(false);
   const paletteSkillSearchNonceRef = useRef(0);
   const paletteFilterQuery = controller.paletteQuery.trim().toLowerCase();
   const shouldCollapseSidebar =
@@ -429,6 +431,46 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     skillsController.activeDocument,
     skillsController.isDocumentLoading,
   ]);
+
+  useEffect(() => {
+    if (!sessionHasHydrated || !controller.hasBooted || !controller.settings) {
+      return;
+    }
+
+    const hasDismissed = controller.settings.dismissedDefaultAppPrompt === true;
+    if (hasDismissed) {
+      return;
+    }
+
+    if (!controller.defaultAppStatus) {
+      controller.checkDefaultAppStatus();
+      return;
+    }
+
+    const platform = controller.defaultAppStatus.platform;
+    const isSupportedPlatform = platform === "darwin" || platform === "win32";
+    if (!isSupportedPlatform) {
+      return;
+    }
+
+    if (controller.defaultAppStatus.isDefault) {
+      return;
+    }
+
+    setShowDefaultAppPrompt(true);
+  }, [
+    sessionHasHydrated,
+    controller.hasBooted,
+    controller.settings,
+    controller.defaultAppStatus,
+    controller.checkDefaultAppStatus,
+  ]);
+
+  useEffect(() => {
+    if (controller.hasBooted && !controller.defaultAppStatus) {
+      controller.checkDefaultAppStatus();
+    }
+  }, [controller.hasBooted, controller.defaultAppStatus, controller.checkDefaultAppStatus]);
 
   useEffect(() => {
     if (
@@ -1340,6 +1382,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         onChangeMode={(mode: ThemeMode) => void controller.changeThemeMode(mode)}
         onChangeShortcuts={(shortcuts) => void controller.changeShortcuts(shortcuts)}
         onChangeAutoOpenPDF={(enabled) => void controller.saveSettings({ autoOpenPDF: enabled })}
+        onOpenDefaultAppSettings={() => controller.openSystemDefaultAppSettings()}
+        defaultAppStatus={controller.defaultAppStatus}
       />
       <NoteRenameDialog
         pending={pendingNoteRename}
@@ -1352,6 +1396,19 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         pending={pendingNoteConfirm}
         onDismiss={() => setPendingNoteConfirm(null)}
         onConfirm={() => void handleConfirmCurrentNoteAction()}
+      />
+      <DefaultAppPrompt
+        isOpen={showDefaultAppPrompt}
+        platform={controller.appInfo?.platform ?? "darwin"}
+        onDismiss={() => {
+          setShowDefaultAppPrompt(false);
+          controller.dismissDefaultAppPrompt();
+        }}
+        onMakeDefault={() => {
+          controller.openSystemDefaultAppSettings();
+          setShowDefaultAppPrompt(false);
+          controller.dismissDefaultAppPrompt();
+        }}
       />
     </TooltipProvider>
   );

--- a/apps/desktop/src/components/settings-panel.tsx
+++ b/apps/desktop/src/components/settings-panel.tsx
@@ -34,6 +34,8 @@ export const SettingsPanel = ({
   onChangeMode,
   onChangeShortcuts,
   onChangeAutoOpenPDF,
+  onOpenDefaultAppSettings,
+  defaultAppStatus,
 }: SettingsPanelProps) => {
   const [activeTab, setActiveTab] = useState("general");
   const [shortcuts, setShortcuts] = useState(DEFAULT_SHORTCUTS);
@@ -294,6 +296,62 @@ export const SettingsPanel = ({
                       />
                       <span className="text-sm font-medium">Automatically open exported PDF</span>
                     </label>
+                  </div>
+
+                  <div className="flex flex-col justify-between gap-4 border-b border-border/40 py-4 sm:flex-row sm:items-center sm:gap-8">
+                    <div className="shrink-0 space-y-1">
+                      <p className="text-sm font-medium">Default App</p>
+                      <p className="text-xs text-muted-foreground">
+                        Open .md and .mdx files in Glyph by default
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      {defaultAppStatus &&
+                        (defaultAppStatus.platform === "darwin" ||
+                          defaultAppStatus.platform === "win32") && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (!defaultAppStatus.isDefault) {
+                                onOpenDefaultAppSettings?.();
+                              }
+                            }}
+                            disabled={defaultAppStatus.isDefault}
+                            className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors ${
+                              defaultAppStatus.isDefault
+                                ? "border-green-500/50 bg-green-500/10 text-green-600 dark:text-green-400 cursor-default"
+                                : "border-border bg-background hover:bg-muted cursor-pointer"
+                            }`}
+                          >
+                            {defaultAppStatus.isDefault ? (
+                              <>
+                                <svg
+                                  className="h-4 w-4 text-green-600 dark:text-green-400"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M5 13l4 4L19 7"
+                                  />
+                                </svg>
+                                Enabled
+                              </>
+                            ) : (
+                              "Enable"
+                            )}
+                          </button>
+                        )}
+                      {(defaultAppStatus?.platform === "darwin" ||
+                        defaultAppStatus?.platform === "win32") === false && (
+                        <span className="text-xs text-muted-foreground">
+                          Not supported on this platform
+                        </span>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -198,7 +198,7 @@ const SidebarShortcutRow = memo(function SidebarShortcutRow({
 
   return (
     <div
-      className={`group/shortcut relative mb-0.5 flex min-w-0 items-center overflow-hidden rounded-xl border border-transparent transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-out active:scale-[0.98]`}
+      className={`group/shortcut relative mb-0.5 flex min-w-0 items-center overflow-hidden rounded-xl border border-transparent transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-out motion-reduce:transition-none active:scale-[0.98]`}
     >
       <div
         className={`mx-1 flex min-w-0 flex-1 cursor-pointer items-center rounded-md transition-colors ${

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1095,6 +1095,32 @@ export const useDesktopAppController = (
     await saveSettings({ dismissedUpdateVersion: updateState.availableVersion });
   }, [updateState?.availableVersion, saveSettings]);
 
+  const [defaultAppStatus, setDefaultAppStatus] = useState<{
+    isDefault: boolean;
+    platform: string;
+  } | null>(null);
+
+  const checkDefaultAppStatus = useCallback(async () => {
+    try {
+      const status = await glyph.getDefaultAppStatus();
+      setDefaultAppStatus(status);
+    } catch {
+      setDefaultAppStatus(null);
+    }
+  }, [glyph]);
+
+  const openSystemDefaultAppSettings = useCallback(async () => {
+    try {
+      await glyph.openDefaultAppSettings();
+    } catch {
+      // Silently fail if system settings can't be opened
+    }
+  }, [glyph]);
+
+  const dismissDefaultAppPrompt = useCallback(async () => {
+    await saveSettings({ dismissedDefaultAppPrompt: true });
+  }, [saveSettings]);
+
   const updateActionConfig = useMemo(() => {
     if (!appInfo?.updatesEnabled || !updateState) {
       return null;
@@ -2167,5 +2193,9 @@ export const useDesktopAppController = (
     hasBooted,
     editorScale,
     setEditorScale,
+    defaultAppStatus,
+    checkDefaultAppStatus,
+    openSystemDefaultAppSettings,
+    dismissDefaultAppPrompt,
   };
 };

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -110,6 +110,7 @@ export type AppSettings = {
   editorPreferences: EditorPreferences;
   autoOpenPDF: boolean;
   dismissedUpdateVersion: string | null;
+  dismissedDefaultAppPrompt: boolean | null;
 };
 
 export type AppInfo = {

--- a/apps/desktop/src/types/default-app-prompt.ts
+++ b/apps/desktop/src/types/default-app-prompt.ts
@@ -1,0 +1,6 @@
+export type DefaultAppPromptProps = {
+  isOpen: boolean;
+  platform: string;
+  onDismiss: () => void;
+  onMakeDefault: () => void;
+};

--- a/apps/desktop/src/types/settings-panel.ts
+++ b/apps/desktop/src/types/settings-panel.ts
@@ -9,4 +9,6 @@ export type SettingsPanelProps = {
   onChangeMode: (mode: ThemeMode) => void;
   onChangeShortcuts: (shortcuts: ShortcutSetting[]) => void;
   onChangeAutoOpenPDF?: (enabled: boolean) => void;
+  onOpenDefaultAppSettings?: () => void;
+  defaultAppStatus?: { isDefault: boolean; platform: string } | null;
 };

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -61,6 +61,8 @@ declare global {
       getSettings: () => Promise<AppSettings>;
       updateSettings: (patch: Partial<AppSettings>) => Promise<AppSettings>;
       getAppInfo: () => Promise<AppInfo>;
+      getDefaultAppStatus: () => Promise<{ isDefault: boolean; platform: string }>;
+      openDefaultAppSettings: () => Promise<void>;
       getUpdateState: () => Promise<UpdateState>;
       checkForUpdates: () => Promise<UpdateState>;
       downloadUpdate: () => Promise<UpdateState>;


### PR DESCRIPTION
## Summary

This PR implements two GitHub issues:

### Issue #101: Validate keyboard navigation, focus flow, and reduced-motion behavior across panes

- **Focus Flow**: Added `tabIndex={-1}` to the main content area in `AppLayout` to properly manage focus flow across the multi-pane layout. The main content is now a focusable container that can receive keyboard input.

- **Reduced Motion**: Added `motion-reduce:transition-none` class to the sidebar toggle transition in `AppLayout` and sidebar row interactions to respect users who prefer reduced motion. The existing button component already has reduced motion support.

### Issue #125: Prompt users to make Glyph the default opener for .md and .mdx files

- **Default App Detection**: Added IPC handlers to detect whether Glyph is the default app for `.md` and `.mdx` files on macOS and Windows.

- **UI Prompt**: Created a new `DefaultAppPrompt` component that shows a dialog asking users to make Glyph their default app for Markdown files. The prompt appears on first run (or when not dismissed) and checks if Glyph is already the default.

- **Settings Integration**: Added `dismissedDefaultAppPrompt` to the app settings to persist user's dismissal choice.

- **Platform Support**: 
  - On macOS: Opens System Settings general preferences (via `x-apple.systempreferences:`)
  - On Windows: Opens Windows Settings default apps

## Files Changed

- `apps/desktop/electron/main.ts` - Added IPC handlers for default app detection and settings
- `apps/desktop/electron/preload.cts` - Added new API methods to preload
- `apps/desktop/src/components/app-layout.tsx` - Added focus management and reduced motion
- `apps/desktop/src/components/desktop-app.tsx` - Integrated default app prompt
- `apps/desktop/src/components/default-app-prompt.tsx` - New prompt component
- `apps/desktop/src/components/sidebar.tsx` - Added reduced motion support
- `apps/desktop/src/hooks/use-desktop-app-controller.ts` - Added controller methods
- `apps/desktop/src/shared/workspace.ts` - Added new settings type
- `apps/desktop/src/types/default-app-prompt.ts` - New type definition
- `apps/desktop/src/vite-env.d.ts` - Added type declarations for new API

## Testing

- TypeScript type checking passes
- Lint passes with no warnings
- E2E tests run successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New default-app prompt that appears when the app isn't the system default for Markdown on macOS/Windows.
  * App can check default-app status and open the OS Default Apps settings to help users make it the default.
  * Users can permanently dismiss the prompt; dismissal is saved.

* **Style**
  * UI transitions now respect reduced-motion preferences, disabling animations when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->