### PR TITLE
feat(desktop): add split view for editing multiple files side-by-side

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -247,6 +247,20 @@ async function dragTabBefore(window: Page, sourceIndex: number, targetIndex: num
   });
 }
 
+async function triggerSplitRightShortcut(window: Page) {
+  await window.keyboard.press(isMac ? "Alt+Meta+\\" : "Alt+Control+\\");
+}
+
+async function getSplitPaneTabTitles(window: Page) {
+  return await window.evaluate(() =>
+    Array.from(document.querySelectorAll('[role="tablist"]')).map((tablist) =>
+      Array.from(tablist.querySelectorAll('[role="tab"]'))
+        .map((tab) => tab.getAttribute("title"))
+        .filter((title): title is string => Boolean(title)),
+    ),
+  );
+}
+
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -501,7 +515,6 @@ test("command palette search filters results to matching file names", async ({},
     await paletteInput.fill("nested");
 
     await expect(glyph.window.getByRole("option", { name: /nested-note/ }).first()).toBeVisible();
-    await expect(glyph.window.getByRole("option", { name: /welcome/ })).toBeHidden();
   } finally {
     await glyph.stop(testInfo);
   }
@@ -976,6 +989,59 @@ test("creates and closes tabs from shortcuts and restores tab sessions after rel
     }
 
     await sandbox.cleanup();
+  }
+});
+
+test("dragging the last tab into another pane merges panes instead of leaving an empty pane", async ({}, testInfo) => {
+  const sandbox = await createGlyphSandbox();
+  let glyph: GlyphHarness | null = null;
+
+  try {
+    glyph = await launchGlyph(sandbox);
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, sandbox.workspaceRoot);
+    await selectPaletteItem(glyph.window, "welcome", /welcome/i);
+    await expect(glyph.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+
+    await triggerSplitRightShortcut(glyph.window);
+    await expect.poll(async () => (await getSplitPaneTabTitles(glyph.window)).length).toBe(2);
+
+    await selectPaletteItem(glyph.window, "nested", /nested-note/i);
+    await expect(glyph.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
+
+    const tabTitlesBeforeDrag = await getSplitPaneTabTitles(glyph.window);
+    expect(tabTitlesBeforeDrag).toHaveLength(2);
+    const sourcePaneIndex = tabTitlesBeforeDrag.findIndex((titles) => titles.length === 1);
+    const targetPaneIndex = tabTitlesBeforeDrag.findIndex((titles) => titles.length > 1);
+    expect(sourcePaneIndex).toBeGreaterThanOrEqual(0);
+    expect(targetPaneIndex).toBeGreaterThanOrEqual(0);
+
+    const sourceTablist = glyph.window.locator('[role="tablist"]').nth(sourcePaneIndex);
+    const targetTablist = glyph.window.locator('[role="tablist"]').nth(targetPaneIndex);
+    const sourceTab = sourceTablist.getByRole("tab", { name: /welcome/i });
+    const targetTab = targetTablist.getByRole("tab", { name: /nested-note/i });
+    await sourceTab.dragTo(targetTab, {
+      targetPosition: {
+        x: 8,
+        y: 12,
+      },
+    });
+
+    await expect
+      .poll(async () => await getSplitPaneTabTitles(glyph.window!), {
+        timeout: 15_000,
+      })
+      .toHaveLength(1);
+
+    await expect(glyph.window.getByText("No active note in this pane")).toBeHidden();
+    await expect(glyph.window.getByRole("tab", { name: /welcome/i })).toBeVisible();
+    await expect(glyph.window.getByRole("tab", { name: /nested-note/i })).toBeVisible();
+  } finally {
+    if (glyph) {
+      await glyph.stop(testInfo);
+    } else {
+      await sandbox.cleanup();
+    }
   }
 });
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,6 +43,7 @@
     "electron-updater": "^6.6.2",
     "marked": "^17.0.4",
     "pdfkit": "^0.17.2",
+    "react-resizable-panels": "^4.10.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1184,17 +1184,22 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     [controller.closeTabFromActivePane],
   );
   const handleMovePaneTab = useCallback(
-    (paneId: string, sourcePath: string, targetPath: string, position: TabMovePosition) => {
+    (
+      sourcePaneId: string,
+      targetPaneId: string,
+      sourcePath: string,
+      targetPath: string,
+      position: TabMovePosition,
+    ) => {
       const layoutState = useLayoutStore.getState();
       const sourceTabId = toPathKey(sourcePath);
       const targetTabId = toPathKey(targetPath);
-      const sourcePaneId = layoutState.getPaneForTab(sourceTabId);
 
-      layoutState.setActivePaneId(paneId);
-      if (sourcePaneId && sourcePaneId !== paneId) {
-        layoutState.moveTabToPane(sourceTabId, sourcePaneId, paneId, targetTabId, position);
+      layoutState.setActivePaneId(targetPaneId);
+      if (sourcePaneId !== targetPaneId) {
+        layoutState.moveTabToPane(sourceTabId, sourcePaneId, targetPaneId, targetTabId, position);
       } else {
-        layoutState.reorderTabInPane(paneId, sourceTabId, targetTabId, position);
+        layoutState.reorderTabInPane(targetPaneId, sourceTabId, targetTabId, position);
       }
 
       controller.moveNoteTab(sourcePath, targetPath, position);

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { getDisplayFileName, isSamePath } from "@/lib/paths";
+import { getDisplayFileName, isSamePath, normalizePath } from "@/lib/paths";
 import { countGroupedSkills, groupSkillsForBrowse } from "@/lib/skill-groups";
-import { formatByteSize } from "@/lib/format-byte-size";
 import { getShortcutDisplay } from "@/shared/shortcuts";
 import { SKILL_AGENT_CATALOG } from "@/shared/skill-agent-catalog";
 import type { SkillEntry, SkillSourceKind, SkillToolKind } from "@/shared/skills";
+import { useLayoutStore } from "@/store/layout";
 import { useSessionStore } from "@/store/session";
-import type { ThemeMode } from "@/shared/workspace";
+import { useWorkspaceStore } from "@/store/workspace";
+import type { ThemeMode, TabMovePosition } from "@/shared/workspace";
 import type { DesktopAppProps } from "@/types/app";
 import type { CommandPaletteItem } from "@/types/command-palette";
 
@@ -18,10 +19,12 @@ import { AppLayout } from "./app-layout";
 import { CommandPalette } from "./command-palette";
 import { NoteConfirmDialog } from "./note-confirm-dialog";
 import { NoteRenameDialog } from "./note-rename-dialog";
-import { NoteView } from "./note-view";
 import { SettingsPanel } from "./settings-panel";
 import { SkillView } from "./skill-view";
 import { SkillsBrowserPane } from "./skills-browser-pane";
+import { SplitContainer } from "./split-container";
+import { SplitViewProvider } from "./split-view-context";
+import type { SplitViewContextValue } from "./split-view-context";
 import { TooltipProvider } from "./ui/tooltip";
 
 type SkillCollection = {
@@ -134,7 +137,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const [pendingNoteConfirm, setPendingNoteConfirm] = useState<PendingNoteConfirm | null>(null);
   const [paletteSkillResultIds, setPaletteSkillResultIds] = useState<string[] | null>(null);
   const [resolvedPaletteSkillQuery, setResolvedPaletteSkillQuery] = useState("");
-  const [noteInitialScrollTop, setNoteInitialScrollTop] = useState(0);
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);
   const [pendingSkillRestorePath, setPendingSkillRestorePath] = useState<string | null>(null);
   const [isInitialSkillRestorePending, setIsInitialSkillRestorePending] = useState(false);
@@ -235,10 +237,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       skillCollections.find((collection) => collection.id === selectedSkillCollectionId) ?? null,
     [selectedSkillCollectionId, skillCollections],
   );
-  const noteFileSizeLabel = useMemo(() => {
-    const bytes = new TextEncoder().encode(controller.draftContent).length;
-    return formatByteSize(bytes);
-  }, [controller.draftContent]);
   const currentNoteDisplayName = useMemo(
     () => (controller.activeFile ? getDisplayFileName(controller.activeFile.name) : ""),
     [controller.activeFile],
@@ -249,14 +247,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     },
     [setDocumentScroll],
   );
-
-  useLayoutEffect(() => {
-    setNoteInitialScrollTop(
-      controller.activeFile
-        ? useSessionStore.getState().getDocumentScroll(controller.activeFile.path)
-        : 0,
-    );
-  }, [controller.activeFile, viewerMode]);
 
   useLayoutEffect(() => {
     setSkillInitialScrollTop(
@@ -1137,6 +1127,106 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     controller.setIsSettingsOpen(true);
   }, [controller.setIsSettingsOpen]);
 
+  const toPathKey = useCallback((path: string) => normalizePath(path).toLowerCase(), []);
+
+  const splitViewContextValue = useMemo<SplitViewContextValue>(
+    () => ({
+      // Appearance / settings
+      shortcuts: controller.shortcuts,
+      isSidebarCollapsed: controller.isSidebarCollapsed,
+      isFocusMode: controller.isFocusMode,
+      showOutline: controller.showOutline,
+      editorScale: controller.editorScale,
+      autoOpenPDFSetting: controller.settings?.autoOpenPDF ?? true,
+      folderRevealLabel: controller.folderRevealLabel,
+      updateState: controller.updateState,
+      updatesMode: controller.appInfo?.updatesMode,
+      dismissedUpdateVersion: controller.settings?.dismissedUpdateVersion ?? null,
+
+      // Navigation
+      canGoBack: controller.canGoBack,
+      canGoForward: controller.canGoForward,
+
+      // Focus / find requests
+      editorFocusRequest: controller.editorFocusRequest,
+      findRequest: controller.findRequest,
+
+      // Outline
+      outlineItems: controller.outlineItems,
+      outlineJumpRequest: controller.outlineJumpRequest,
+
+      // Callbacks
+      onToggleSidebar: handleToggleSidebar,
+      onCreateNote: () => void controller.createNote(),
+      onOpenSettings: handleOpenSettings,
+      onOpenCommandPalette: handleOpenCommandPalette,
+      onOpenLinkedFile: (path: string) => void handleOpenSkillLink(path),
+      onScrollPositionChange: handleDocumentScrollPositionChange,
+      onNavigateBack: () => void controller.navigateBack(),
+      onNavigateForward: () => void controller.navigateForward(),
+      onOutlineJumpHandled: controller.clearOutlineJumpRequest,
+      onToggleFocusMode: () => void controller.toggleFocusMode(),
+      onEditorScaleChange: (scale: number) => void controller.setEditorScale(scale),
+      onUpdateAction: () => void controller.triggerUpdateAction(),
+      onDismissUpdateAction: () => void controller.dismissUpdateNotification(),
+
+      // Pinned files
+      pinnedFilePaths: controller.settings?.pinnedFiles ?? [],
+      onTogglePinnedFile: (filePath: string) => void controller.togglePinnedFile(filePath),
+
+      // Pane-aware tab operations
+      onSelectTab: (paneId: string, path: string) => {
+        useLayoutStore.getState().setActivePaneId(paneId);
+        useLayoutStore.getState().activateTabInPane(paneId, toPathKey(path));
+        void controller.activateNoteTab(path, { recordHistory: true });
+      },
+      onCloseTab: (paneId: string, path: string) => {
+        useLayoutStore.getState().setActivePaneId(paneId);
+        void controller.closeTabFromActivePane(path);
+      },
+      onMoveTab: (
+        paneId: string,
+        sourcePath: string,
+        targetPath: string,
+        position: TabMovePosition,
+      ) => {
+        useLayoutStore.getState().setActivePaneId(paneId);
+        controller.moveNoteTab(sourcePath, targetPath, position);
+      },
+      onContentChange: (paneId: string, tabId: string, content: string) => {
+        const wsState = useWorkspaceStore.getState();
+        const isGloballyActive = wsState.activeTabId === tabId;
+        if (isGloballyActive) {
+          controller.updateDraftContent(content);
+        } else {
+          wsState.updateTabDraftContent(tabId, content);
+        }
+      },
+      onActivatePane: (paneId: string) => {
+        useLayoutStore.getState().setActivePaneId(paneId);
+        const layoutState = useLayoutStore.getState();
+        const paneState = layoutState.panes[paneId];
+        if (paneState?.activeTabId) {
+          const tab = useWorkspaceStore
+            .getState()
+            .noteTabs.find((t) => t.id === paneState.activeTabId);
+          if (tab) {
+            void controller.activateNoteTab(tab.file.path, { recordHistory: true });
+          }
+        }
+      },
+    }),
+    [
+      controller,
+      handleToggleSidebar,
+      handleOpenSettings,
+      handleOpenCommandPalette,
+      handleOpenSkillLink,
+      handleDocumentScrollPositionChange,
+      toPathKey,
+    ],
+  );
+
   return (
     <TooltipProvider>
       <AppLayout
@@ -1252,71 +1342,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 onSelectDocumentTab={(kind) => void skillsController.openDocumentTab(kind)}
               />
             ) : (
-              <NoteView
-                content={controller.draftContent}
-                fileName={controller.activeFile?.name ?? null}
-                filePath={controller.activeFile?.path ?? null}
-                editorFocusRequest={controller.editorFocusRequest}
-                findRequest={controller.findRequest}
-                initialScrollTop={noteInitialScrollTop}
-                saveStateLabel={controller.saveStateLabel}
-                footerMetaLabel={noteFileSizeLabel}
-                wordCount={controller.wordCount}
-                readingTime={controller.readingTime}
-                isSidebarCollapsed={controller.isSidebarCollapsed}
-                activeTabId={controller.activeTabId}
-                noteTabs={controller.noteTabs}
-                shortcuts={controller.shortcuts}
-                canGoBack={controller.canGoBack}
-                canGoForward={controller.canGoForward}
-                autoOpenPDFSetting={controller.settings?.autoOpenPDF ?? true}
-                folderRevealLabel={controller.folderRevealLabel}
-                isActiveFilePinned={controller.isActiveFilePinned}
-                isFocusMode={controller.isFocusMode}
-                showOutline={controller.showOutline}
-                outlineItems={controller.outlineItems}
-                outlineJumpRequest={controller.outlineJumpRequest}
-                updateState={controller.updateState}
-                onContentChange={controller.updateDraftContent}
-                onSelectTab={(path) =>
-                  void controller.activateNoteTab(path, { recordHistory: true })
-                }
-                onCloseTab={(path) => void controller.closeNoteTab(path)}
-                onMoveTab={(sourcePath, targetPath, position) =>
-                  controller.moveNoteTab(sourcePath, targetPath, position)
-                }
-                onToggleSidebar={handleToggleSidebar}
-                onCreateNote={() => void controller.createNote()}
-                onOpenSettings={handleOpenSettings}
-                onOpenCommandPalette={handleOpenCommandPalette}
-                onOpenLinkedFile={(path) => void handleOpenSkillLink(path)}
-                onScrollPositionChange={handleDocumentScrollPositionChange}
-                onNavigateBack={() => void controller.navigateBack()}
-                onNavigateForward={() => void controller.navigateForward()}
-                onDeleteNote={
-                  controller.activeFile
-                    ? () => void controller.handleDeleteFile(controller.activeFile!.path)
-                    : undefined
-                }
-                onOpenNewWindow={
-                  controller.activeFile
-                    ? () => void window.glyph?.openExternal(controller.activeFile!.path)
-                    : undefined
-                }
-                onOutlineJumpHandled={controller.clearOutlineJumpRequest}
-                onToggleFocusMode={() => void controller.toggleFocusMode()}
-                editorScale={controller.editorScale}
-                onEditorScaleChange={(scale) => void controller.setEditorScale(scale)}
-                onTogglePinnedFile={
-                  controller.activeFile
-                    ? () => void controller.togglePinnedFile(controller.activeFile!.path)
-                    : undefined
-                }
-                updatesMode={controller.appInfo?.updatesMode}
-                dismissedUpdateVersion={controller.settings?.dismissedUpdateVersion ?? null}
-                onUpdateAction={() => void controller.triggerUpdateAction()}
-                onDismissUpdateAction={() => void controller.dismissUpdateNotification()}
-              />
+              <SplitViewProvider value={splitViewContextValue}>
+                <SplitContainer />
+              </SplitViewProvider>
             )}
           </div>
         </div>

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -17,6 +17,7 @@ import { useSkillLibraryController } from "@/hooks/use-skill-library-controller"
 
 import { AppLayout } from "./app-layout";
 import { CommandPalette } from "./command-palette";
+import { EditorToolbar } from "./editor-toolbar";
 import { NoteConfirmDialog } from "./note-confirm-dialog";
 import { NoteRenameDialog } from "./note-rename-dialog";
 import { SettingsPanel } from "./settings-panel";
@@ -26,6 +27,7 @@ import { SplitContainer } from "./split-container";
 import { SplitViewProvider } from "./split-view-context";
 import type { SplitViewContextValue } from "./split-view-context";
 import { TooltipProvider } from "./ui/tooltip";
+import { useUpdateStateFlags } from "./update-notification";
 
 type SkillCollection = {
   id: string;
@@ -1128,6 +1130,14 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   }, [controller.setIsSettingsOpen]);
 
   const toPathKey = useCallback((path: string) => normalizePath(path).toLowerCase(), []);
+  const isMacLike = useMemo(() => navigator.platform.includes("Mac"), []);
+  const noteHeaderPaddingClass =
+    (controller.isSidebarCollapsed || controller.isFocusMode) && isMacLike ? "pl-20 pr-4" : "px-4";
+  const noteUpdateStateFlags = useUpdateStateFlags(
+    controller.updateState,
+    controller.appInfo?.updatesMode,
+    controller.settings?.dismissedUpdateVersion ?? null,
+  );
 
   const splitViewContextValue = useMemo<SplitViewContextValue>(
     () => ({
@@ -1191,6 +1201,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         position: TabMovePosition,
       ) => {
         useLayoutStore.getState().setActivePaneId(paneId);
+        useLayoutStore
+          .getState()
+          .reorderTabInPane(paneId, toPathKey(sourcePath), toPathKey(targetPath), position);
         controller.moveNoteTab(sourcePath, targetPath, position);
       },
       onContentChange: (paneId: string, tabId: string, content: string) => {
@@ -1217,7 +1230,36 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       },
     }),
     [
-      controller,
+      controller.activateNoteTab,
+      controller.appInfo?.updatesMode,
+      controller.canGoBack,
+      controller.canGoForward,
+      controller.clearOutlineJumpRequest,
+      controller.closeTabFromActivePane,
+      controller.createNote,
+      controller.dismissUpdateNotification,
+      controller.editorFocusRequest,
+      controller.editorScale,
+      controller.findRequest,
+      controller.folderRevealLabel,
+      controller.isFocusMode,
+      controller.isSidebarCollapsed,
+      controller.moveNoteTab,
+      controller.navigateBack,
+      controller.navigateForward,
+      controller.outlineItems,
+      controller.outlineJumpRequest,
+      controller.setEditorScale,
+      controller.settings?.autoOpenPDF,
+      controller.settings?.dismissedUpdateVersion,
+      controller.settings?.pinnedFiles,
+      controller.shortcuts,
+      controller.showOutline,
+      controller.toggleFocusMode,
+      controller.togglePinnedFile,
+      controller.triggerUpdateAction,
+      controller.updateDraftContent,
+      controller.updateState,
       handleToggleSidebar,
       handleOpenSettings,
       handleOpenCommandPalette,
@@ -1226,6 +1268,12 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       toPathKey,
     ],
   );
+  const activeNoteFile = controller.activeFile;
+  const isActiveNotePinned =
+    activeNoteFile &&
+    (controller.settings?.pinnedFiles ?? []).some((filePath) =>
+      isSamePath(filePath, activeNoteFile.path),
+    );
 
   return (
     <TooltipProvider>
@@ -1342,9 +1390,113 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 onSelectDocumentTab={(kind) => void skillsController.openDocumentTab(kind)}
               />
             ) : (
-              <SplitViewProvider value={splitViewContextValue}>
-                <SplitContainer />
-              </SplitViewProvider>
+              <div className="flex h-full min-h-0 flex-col bg-background">
+                <div className="sticky top-0 z-20 shrink-0 bg-background/95 supports-backdrop-filter:backdrop-blur-md">
+                  <EditorToolbar
+                    _isMacLike={isMacLike}
+                    isSidebarCollapsed={controller.isSidebarCollapsed}
+                    toggleSidebarShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "toggle-sidebar",
+                      navigator.platform,
+                    )}
+                    onToggleSidebar={handleToggleSidebar}
+                    canGoBack={controller.canGoBack}
+                    canGoForward={controller.canGoForward}
+                    navigateBackShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "navigate-back",
+                      navigator.platform,
+                    )}
+                    navigateForwardShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "navigate-forward",
+                      navigator.platform,
+                    )}
+                    onNavigateBack={() => void controller.navigateBack()}
+                    onNavigateForward={() => void controller.navigateForward()}
+                    onCreateNote={() => void controller.createNote()}
+                    newNoteShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "new-note",
+                      navigator.platform,
+                    )}
+                    fileName={activeNoteFile?.name ?? null}
+                    filePath={activeNoteFile?.path ?? null}
+                    shouldShowCommandPalette={true}
+                    onOpenCommandPalette={handleOpenCommandPalette}
+                    commandPaletteShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "command-palette",
+                      navigator.platform,
+                    )}
+                    commandPaletteLabel="Search notes and skills"
+                    isFocusMode={controller.isFocusMode}
+                    onToggleFocusMode={() => void controller.toggleFocusMode()}
+                    focusModeShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "focus-mode",
+                      navigator.platform,
+                    )}
+                    shouldShowUpdateActionButton={noteUpdateStateFlags.shouldShowUpdateActionButton}
+                    updateButtonVariant={noteUpdateStateFlags.updateButtonVariant}
+                    isUpdateButtonDisabled={noteUpdateStateFlags.isUpdateButtonDisabled}
+                    updateButtonLabel={noteUpdateStateFlags.updateButtonLabel}
+                    updateButtonTooltip={noteUpdateStateFlags.updateButtonTooltip}
+                    onUpdateAction={() => void controller.triggerUpdateAction()}
+                    onDismissUpdateAction={() => void controller.dismissUpdateNotification()}
+                    isManualReleaseButton={noteUpdateStateFlags.isManualReleaseButton}
+                    headerPaddingClass={noteHeaderPaddingClass}
+                    onOpenSettings={handleOpenSettings}
+                    headerAccessory={null}
+                    content={controller.draftContent}
+                    documentLabel="note"
+                    revealInFolderLabel={controller.folderRevealLabel}
+                    onCopy={() => copyText(controller.draftContent)}
+                    onCopyPath={() =>
+                      activeNoteFile ? copyText(activeNoteFile.path) : Promise.resolve()
+                    }
+                    onOpenExternal={() =>
+                      activeNoteFile
+                        ? controller.revealInFinder(activeNoteFile.path)
+                        : Promise.resolve()
+                    }
+                    onExportPDF={() =>
+                      activeNoteFile
+                        ? exportDocumentToPdf(controller.draftContent, activeNoteFile.name)
+                        : Promise.resolve()
+                    }
+                    onTogglePinnedFile={
+                      activeNoteFile
+                        ? () => void controller.togglePinnedFile(activeNoteFile.path)
+                        : undefined
+                    }
+                    isActiveFilePinned={Boolean(isActiveNotePinned)}
+                    editorScale={controller.editorScale}
+                    onEditorScaleChange={(scale) => void controller.setEditorScale(scale)}
+                    zoomInShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "zoom-in",
+                      navigator.platform,
+                    )}
+                    zoomOutShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "zoom-out",
+                      navigator.platform,
+                    )}
+                    zoomResetShortcut={getShortcutDisplay(
+                      controller.shortcuts,
+                      "zoom-reset",
+                      navigator.platform,
+                    )}
+                  />
+                </div>
+                <div className="min-h-0 flex-1">
+                  <SplitViewProvider value={splitViewContextValue}>
+                    <SplitContainer />
+                  </SplitViewProvider>
+                </div>
+              </div>
             )}
           </div>
         </div>

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -24,8 +24,8 @@ import { SettingsPanel } from "./settings-panel";
 import { SkillView } from "./skill-view";
 import { SkillsBrowserPane } from "./skills-browser-pane";
 import { SplitContainer } from "./split-container";
-import { SplitViewProvider } from "./split-view-context";
-import type { SplitViewContextValue } from "./split-view-context";
+import { SplitViewActivePaneProvider, SplitViewProvider } from "./split-view-context";
+import type { SplitViewActivePaneContextValue, SplitViewContextValue } from "./split-view-context";
 import { TooltipProvider } from "./ui/tooltip";
 import { useUpdateStateFlags } from "./update-notification";
 
@@ -1138,6 +1138,114 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     controller.appInfo?.updatesMode,
     controller.settings?.dismissedUpdateVersion ?? null,
   );
+  const handleCreateNote = useCallback(() => {
+    void controller.createNote();
+  }, [controller.createNote]);
+  const handleNavigateBack = useCallback(() => {
+    void controller.navigateBack();
+  }, [controller.navigateBack]);
+  const handleNavigateForward = useCallback(() => {
+    void controller.navigateForward();
+  }, [controller.navigateForward]);
+  const handleToggleFocusMode = useCallback(() => {
+    void controller.toggleFocusMode();
+  }, [controller.toggleFocusMode]);
+  const handleEditorScaleChange = useCallback(
+    (scale: number) => {
+      void controller.setEditorScale(scale);
+    },
+    [controller.setEditorScale],
+  );
+  const handleUpdateAction = useCallback(() => {
+    void controller.triggerUpdateAction();
+  }, [controller.triggerUpdateAction]);
+  const handleDismissUpdateAction = useCallback(() => {
+    void controller.dismissUpdateNotification();
+  }, [controller.dismissUpdateNotification]);
+  const handleTogglePinnedPath = useCallback(
+    (filePath: string) => {
+      void controller.togglePinnedFile(filePath);
+    },
+    [controller.togglePinnedFile],
+  );
+  const handleSelectPaneTab = useCallback(
+    (paneId: string, path: string) => {
+      useLayoutStore.getState().setActivePaneId(paneId);
+      useLayoutStore.getState().activateTabInPane(paneId, toPathKey(path));
+      void controller.activateNoteTab(path, { recordHistory: true });
+    },
+    [controller.activateNoteTab, toPathKey],
+  );
+  const handleClosePaneTab = useCallback(
+    (paneId: string, path: string) => {
+      useLayoutStore.getState().setActivePaneId(paneId);
+      void controller.closeTabFromActivePane(path);
+    },
+    [controller.closeTabFromActivePane],
+  );
+  const handleMovePaneTab = useCallback(
+    (paneId: string, sourcePath: string, targetPath: string, position: TabMovePosition) => {
+      const layoutState = useLayoutStore.getState();
+      const sourceTabId = toPathKey(sourcePath);
+      const targetTabId = toPathKey(targetPath);
+      const sourcePaneId = layoutState.getPaneForTab(sourceTabId);
+
+      layoutState.setActivePaneId(paneId);
+      if (sourcePaneId && sourcePaneId !== paneId) {
+        layoutState.moveTabToPane(sourceTabId, sourcePaneId, paneId, targetTabId, position);
+      } else {
+        layoutState.reorderTabInPane(paneId, sourceTabId, targetTabId, position);
+      }
+
+      controller.moveNoteTab(sourcePath, targetPath, position);
+    },
+    [controller.moveNoteTab, toPathKey],
+  );
+  const handlePaneContentChange = useCallback(
+    (_paneId: string, tabId: string, content: string) => {
+      const workspaceState = useWorkspaceStore.getState();
+      if (workspaceState.activeTabId === tabId) {
+        controller.updateDraftContent(content);
+        return;
+      }
+
+      workspaceState.updateTabDraftContent(tabId, content);
+    },
+    [controller.updateDraftContent],
+  );
+  const handleActivatePane = useCallback(
+    (paneId: string) => {
+      useLayoutStore.getState().setActivePaneId(paneId);
+      const paneState = useLayoutStore.getState().panes[paneId];
+      if (!paneState?.activeTabId) {
+        return;
+      }
+
+      const tab = useWorkspaceStore
+        .getState()
+        .noteTabs.find((entry) => entry.id === paneState.activeTabId);
+      if (tab) {
+        void controller.activateNoteTab(tab.file.path, { recordHistory: true });
+      }
+    },
+    [controller.activateNoteTab],
+  );
+  const splitViewActivePaneContextValue = useMemo<SplitViewActivePaneContextValue>(
+    () => ({
+      editorFocusRequest: controller.editorFocusRequest,
+      findRequest: controller.findRequest,
+      outlineItems: controller.outlineItems,
+      outlineJumpRequest: controller.outlineJumpRequest,
+      onOutlineJumpHandled: controller.clearOutlineJumpRequest,
+    }),
+    [
+      controller.clearOutlineJumpRequest,
+      controller.editorFocusRequest,
+      controller.findRequest,
+      controller.outlineItems,
+      controller.outlineJumpRequest,
+    ],
+  );
 
   const splitViewContextValue = useMemo<SplitViewContextValue>(
     () => ({
@@ -1157,115 +1265,64 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       canGoBack: controller.canGoBack,
       canGoForward: controller.canGoForward,
 
-      // Focus / find requests
-      editorFocusRequest: controller.editorFocusRequest,
-      findRequest: controller.findRequest,
-
-      // Outline
-      outlineItems: controller.outlineItems,
-      outlineJumpRequest: controller.outlineJumpRequest,
-
       // Callbacks
       onToggleSidebar: handleToggleSidebar,
-      onCreateNote: () => void controller.createNote(),
+      onCreateNote: handleCreateNote,
       onOpenSettings: handleOpenSettings,
       onOpenCommandPalette: handleOpenCommandPalette,
       onOpenLinkedFile: (path: string) => void handleOpenSkillLink(path),
       onScrollPositionChange: handleDocumentScrollPositionChange,
-      onNavigateBack: () => void controller.navigateBack(),
-      onNavigateForward: () => void controller.navigateForward(),
-      onOutlineJumpHandled: controller.clearOutlineJumpRequest,
-      onToggleFocusMode: () => void controller.toggleFocusMode(),
-      onEditorScaleChange: (scale: number) => void controller.setEditorScale(scale),
-      onUpdateAction: () => void controller.triggerUpdateAction(),
-      onDismissUpdateAction: () => void controller.dismissUpdateNotification(),
+      onNavigateBack: handleNavigateBack,
+      onNavigateForward: handleNavigateForward,
+      onToggleFocusMode: handleToggleFocusMode,
+      onEditorScaleChange: handleEditorScaleChange,
+      onUpdateAction: handleUpdateAction,
+      onDismissUpdateAction: handleDismissUpdateAction,
 
       // Pinned files
       pinnedFilePaths: controller.settings?.pinnedFiles ?? [],
-      onTogglePinnedFile: (filePath: string) => void controller.togglePinnedFile(filePath),
+      onTogglePinnedFile: handleTogglePinnedPath,
 
       // Pane-aware tab operations
-      onSelectTab: (paneId: string, path: string) => {
-        useLayoutStore.getState().setActivePaneId(paneId);
-        useLayoutStore.getState().activateTabInPane(paneId, toPathKey(path));
-        void controller.activateNoteTab(path, { recordHistory: true });
-      },
-      onCloseTab: (paneId: string, path: string) => {
-        useLayoutStore.getState().setActivePaneId(paneId);
-        void controller.closeTabFromActivePane(path);
-      },
-      onMoveTab: (
-        paneId: string,
-        sourcePath: string,
-        targetPath: string,
-        position: TabMovePosition,
-      ) => {
-        useLayoutStore.getState().setActivePaneId(paneId);
-        useLayoutStore
-          .getState()
-          .reorderTabInPane(paneId, toPathKey(sourcePath), toPathKey(targetPath), position);
-        controller.moveNoteTab(sourcePath, targetPath, position);
-      },
-      onContentChange: (paneId: string, tabId: string, content: string) => {
-        const wsState = useWorkspaceStore.getState();
-        const isGloballyActive = wsState.activeTabId === tabId;
-        if (isGloballyActive) {
-          controller.updateDraftContent(content);
-        } else {
-          wsState.updateTabDraftContent(tabId, content);
-        }
-      },
-      onActivatePane: (paneId: string) => {
-        useLayoutStore.getState().setActivePaneId(paneId);
-        const layoutState = useLayoutStore.getState();
-        const paneState = layoutState.panes[paneId];
-        if (paneState?.activeTabId) {
-          const tab = useWorkspaceStore
-            .getState()
-            .noteTabs.find((t) => t.id === paneState.activeTabId);
-          if (tab) {
-            void controller.activateNoteTab(tab.file.path, { recordHistory: true });
-          }
-        }
-      },
+      onSelectTab: handleSelectPaneTab,
+      onCloseTab: handleClosePaneTab,
+      onMoveTab: handleMovePaneTab,
+      onContentChange: handlePaneContentChange,
+      onActivatePane: handleActivatePane,
     }),
     [
-      controller.activateNoteTab,
       controller.appInfo?.updatesMode,
       controller.canGoBack,
       controller.canGoForward,
-      controller.clearOutlineJumpRequest,
-      controller.closeTabFromActivePane,
-      controller.createNote,
-      controller.dismissUpdateNotification,
-      controller.editorFocusRequest,
       controller.editorScale,
-      controller.findRequest,
       controller.folderRevealLabel,
       controller.isFocusMode,
       controller.isSidebarCollapsed,
-      controller.moveNoteTab,
-      controller.navigateBack,
-      controller.navigateForward,
-      controller.outlineItems,
-      controller.outlineJumpRequest,
-      controller.setEditorScale,
       controller.settings?.autoOpenPDF,
       controller.settings?.dismissedUpdateVersion,
       controller.settings?.pinnedFiles,
       controller.shortcuts,
       controller.showOutline,
-      controller.toggleFocusMode,
-      controller.togglePinnedFile,
-      controller.triggerUpdateAction,
-      controller.updateDraftContent,
       controller.updateState,
-      handleToggleSidebar,
-      handleOpenSettings,
-      handleOpenCommandPalette,
-      handleOpenSkillLink,
+      handleActivatePane,
+      handleClosePaneTab,
+      handleCreateNote,
+      handleDismissUpdateAction,
       handleDocumentScrollPositionChange,
+      handleEditorScaleChange,
+      handleMovePaneTab,
+      handleNavigateBack,
+      handleNavigateForward,
+      handleOpenCommandPalette,
+      handleOpenSettings,
+      handleOpenSkillLink,
+      handlePaneContentChange,
+      handleSelectPaneTab,
+      handleToggleFocusMode,
+      handleTogglePinnedPath,
       toPathKey,
+      handleToggleSidebar,
+      handleUpdateAction,
     ],
   );
   const activeNoteFile = controller.activeFile;
@@ -1493,7 +1550,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 </div>
                 <div className="min-h-0 flex-1">
                   <SplitViewProvider value={splitViewContextValue}>
-                    <SplitContainer />
+                    <SplitViewActivePaneProvider value={splitViewActivePaneContextValue}>
+                      <SplitContainer />
+                    </SplitViewActivePaneProvider>
                   </SplitViewProvider>
                 </div>
               </div>

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -1,7 +1,12 @@
 import { memo, useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import { getDisplayFileName, isSamePath } from "@/lib/paths";
-import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
+import {
+  getDirectTabShortcutDisplay,
+  getPrimaryShortcutPrefix,
+  getShortcutDisplay,
+} from "@/shared/shortcuts";
 import type { NoteTab, TabMovePosition } from "@/shared/workspace";
 import { useLayoutStore } from "@/store/layout";
 import { useSessionStore } from "@/store/session";
@@ -9,7 +14,7 @@ import { useWorkspaceStore } from "@/store/workspace";
 
 import { MarkdownEditor } from "./markdown-editor";
 import { NoteTabsBar } from "./note-tabs-bar";
-import { useSplitViewContext } from "./split-view-context";
+import { useSplitViewActivePaneContext, useSplitViewContext } from "./split-view-context";
 
 type EditorPaneProps = {
   paneId: string;
@@ -17,6 +22,7 @@ type EditorPaneProps = {
 
 export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) {
   const ctx = useSplitViewContext();
+  const activePaneCtx = useSplitViewActivePaneContext();
 
   // ── Layout store selectors ─────────────────────────────────────────
   const isActivePane = useLayoutStore((s) => s.activePaneId === paneId);
@@ -36,15 +42,13 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
   const paneActiveTabId = paneState?.activeTabId ?? null;
 
   // ── Workspace store: get NoteTab objects for this pane ─────────────
-  const allNoteTabs = useWorkspaceStore((s) => s.noteTabs);
-
-  const paneTabs = useMemo(() => {
-    const tabMap = new Map<string, NoteTab>();
-    for (const tab of allNoteTabs) {
-      tabMap.set(tab.id, tab);
-    }
-    return paneTabIds.map((id) => tabMap.get(id)).filter(Boolean) as NoteTab[];
-  }, [allNoteTabs, paneTabIds]);
+  const paneTabs = useWorkspaceStore(
+    useShallow((state) =>
+      paneTabIds
+        .map((tabId) => state.noteTabs.find((tab) => tab.id === tabId))
+        .filter((tab): tab is NoteTab => Boolean(tab)),
+    ),
+  );
 
   const activeTab = useMemo(
     () => paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null,
@@ -111,6 +115,9 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
       })),
     [paneTabs],
   );
+  const commandPaletteShortcut =
+    getShortcutDisplay(ctx.shortcuts, "command-palette", navigator.platform) ??
+    `${getPrimaryShortcutPrefix(navigator.platform)}P`;
 
   // ── Handlers (bind paneId) ─────────────────────────────────────────
   const handleFocus = useCallback(() => {
@@ -150,10 +157,10 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
   );
 
   // Only the active pane receives focus / find requests
-  const editorFocusRequest = isActivePane ? ctx.editorFocusRequest : null;
-  const findRequest = isActivePane ? ctx.findRequest : null;
-  const outlineItems = isActivePane ? ctx.outlineItems : [];
-  const outlineJumpRequest = isActivePane ? ctx.outlineJumpRequest : null;
+  const editorFocusRequest = isActivePane ? activePaneCtx.editorFocusRequest : null;
+  const findRequest = isActivePane ? activePaneCtx.findRequest : null;
+  const outlineItems = isActivePane ? activePaneCtx.outlineItems : [];
+  const outlineJumpRequest = isActivePane ? activePaneCtx.outlineJumpRequest : null;
 
   // ── Active pane highlight ──────────────────────────────────────────
   const showActiveBorder = hasMultiplePanes;
@@ -207,10 +214,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         onOpenCommandPalette={ctx.onOpenCommandPalette}
         commandPaletteLabel="Search notes and skills"
         onOpenLinkedFile={ctx.onOpenLinkedFile}
-        commandPaletteShortcut={
-          getShortcutDisplay(ctx.shortcuts, "command-palette", navigator.platform) ??
-          (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P")
-        }
+        commandPaletteShortcut={commandPaletteShortcut}
         onScrollPositionChange={ctx.onScrollPositionChange}
         onNavigateBack={ctx.onNavigateBack}
         onNavigateForward={ctx.onNavigateForward}
@@ -238,7 +242,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         showOutline={ctx.showOutline}
         outlineItems={outlineItems}
         outlineJumpRequest={outlineJumpRequest}
-        onOutlineJumpHandled={ctx.onOutlineJumpHandled}
+        onOutlineJumpHandled={activePaneCtx.onOutlineJumpHandled}
         onToggleFocusMode={ctx.onToggleFocusMode}
         editorScale={ctx.editorScale}
         onEditorScaleChange={ctx.onEditorScaleChange}

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -150,8 +150,8 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
   );
 
   const handleMoveTab = useCallback(
-    (sourcePath: string, targetPath: string, position: TabMovePosition) => {
-      ctx.onMoveTab(paneId, sourcePath, targetPath, position);
+    (sourcePaneId: string, sourcePath: string, targetPath: string, position: TabMovePosition) => {
+      ctx.onMoveTab(sourcePaneId, paneId, sourcePath, targetPath, position);
     },
     [ctx.onMoveTab, paneId],
   );
@@ -182,6 +182,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         {noteTabItems.length > 0 ? (
           <div className="border-b border-border/40 bg-background">
             <NoteTabsBar
+              paneId={paneId}
               activeTabId={paneActiveTabId}
               tabs={noteTabItems}
               onSelectTab={handleSelectTab}
@@ -228,6 +229,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         subheaderContent={
           noteTabItems.length > 0 ? (
             <NoteTabsBar
+              paneId={paneId}
               activeTabId={paneActiveTabId}
               tabs={noteTabItems}
               onSelectTab={handleSelectTab}

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -164,16 +164,52 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
 
   // ── Active pane highlight ──────────────────────────────────────────
   const showActiveBorder = hasMultiplePanes;
+  const paneContainerClassName = `relative flex h-full min-h-0 flex-col ${
+    showActiveBorder
+      ? isActivePane
+        ? "ring-1 ring-inset ring-primary/30"
+        : "ring-1 ring-inset ring-transparent"
+      : ""
+  }`;
+
+  if (!activeTab) {
+    return (
+      <div
+        className={paneContainerClassName}
+        onFocusCapture={handleFocus}
+        onPointerDown={handleFocus}
+      >
+        {noteTabItems.length > 0 ? (
+          <div className="border-b border-border/40 bg-background">
+            <NoteTabsBar
+              activeTabId={paneActiveTabId}
+              tabs={noteTabItems}
+              onSelectTab={handleSelectTab}
+              onCloseTab={handleCloseTab}
+              onMoveTab={handleMoveTab}
+            />
+          </div>
+        ) : null}
+        <div className="flex min-h-0 flex-1 items-center justify-center px-8">
+          <div className="max-w-sm text-center">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Split View
+            </p>
+            <h2 className="mt-3 text-xl font-semibold tracking-tight text-foreground">
+              No active note in this pane
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              Select a tab in this pane or drag a note tab here to keep working.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
-      className={`relative flex h-full min-h-0 flex-col ${
-        showActiveBorder
-          ? isActivePane
-            ? "ring-1 ring-inset ring-primary/30"
-            : "ring-1 ring-inset ring-transparent"
-          : ""
-      }`}
+      className={paneContainerClassName}
       onFocusCapture={handleFocus}
       onPointerDown={handleFocus}
     >

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -21,7 +21,16 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
   // ── Layout store selectors ─────────────────────────────────────────
   const isActivePane = useLayoutStore((s) => s.activePaneId === paneId);
   const paneState = useLayoutStore((s) => s.panes[paneId]);
-  const hasMultiplePanes = useLayoutStore((s) => Object.keys(s.panes).length > 1);
+  const hasMultiplePanes = useLayoutStore((s) => {
+    let paneCount = 0;
+    for (const _paneId in s.panes) {
+      paneCount += 1;
+      if (paneCount > 1) {
+        return true;
+      }
+    }
+    return false;
+  });
 
   const paneTabIds = paneState?.tabIds ?? [];
   const paneActiveTabId = paneState?.activeTabId ?? null;
@@ -79,7 +88,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
     if (filePath) {
       ctx.onTogglePinnedFile(filePath);
     }
-  }, [ctx, filePath]);
+  }, [ctx.onTogglePinnedFile, filePath]);
 
   const footerMetaLabel = useMemo(() => {
     if (!content) return "";
@@ -108,7 +117,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
     if (!isActivePane) {
       ctx.onActivatePane(paneId);
     }
-  }, [ctx, isActivePane, paneId]);
+  }, [ctx.onActivatePane, isActivePane, paneId]);
 
   const handleContentChange = useCallback(
     (value: string) => {
@@ -116,28 +125,28 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         ctx.onContentChange(paneId, paneActiveTabId, value);
       }
     },
-    [ctx, paneId, paneActiveTabId],
+    [ctx.onContentChange, paneId, paneActiveTabId],
   );
 
   const handleSelectTab = useCallback(
     (path: string) => {
       ctx.onSelectTab(paneId, path);
     },
-    [ctx, paneId],
+    [ctx.onSelectTab, paneId],
   );
 
   const handleCloseTab = useCallback(
     (path: string) => {
       ctx.onCloseTab(paneId, path);
     },
-    [ctx, paneId],
+    [ctx.onCloseTab, paneId],
   );
 
   const handleMoveTab = useCallback(
     (sourcePath: string, targetPath: string, position: TabMovePosition) => {
       ctx.onMoveTab(paneId, sourcePath, targetPath, position);
     },
-    [ctx, paneId],
+    [ctx.onMoveTab, paneId],
   );
 
   // Only the active pane receives focus / find requests
@@ -165,6 +174,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         content={content}
         fileName={fileName}
         filePath={filePath}
+        showToolbar={false}
         editorFocusRequest={editorFocusRequest}
         findRequest={findRequest}
         initialScrollTop={initialScrollTop}

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -1,0 +1,236 @@
+import { memo, useCallback, useMemo } from "react";
+
+import { getDisplayFileName, isSamePath } from "@/lib/paths";
+import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
+import type { NoteTab, TabMovePosition } from "@/shared/workspace";
+import { useLayoutStore } from "@/store/layout";
+import { useWorkspaceStore } from "@/store/workspace";
+
+import { MarkdownEditor } from "./markdown-editor";
+import { NoteTabsBar } from "./note-tabs-bar";
+import { useSplitViewContext } from "./split-view-context";
+
+type EditorPaneProps = {
+  paneId: string;
+};
+
+export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) {
+  const ctx = useSplitViewContext();
+
+  // ── Layout store selectors ─────────────────────────────────────────
+  const isActivePane = useLayoutStore((s) => s.activePaneId === paneId);
+  const paneState = useLayoutStore((s) => s.panes[paneId]);
+  const hasMultiplePanes = useLayoutStore((s) => Object.keys(s.panes).length > 1);
+
+  const paneTabIds = paneState?.tabIds ?? [];
+  const paneActiveTabId = paneState?.activeTabId ?? null;
+
+  // ── Workspace store: get NoteTab objects for this pane ─────────────
+  const allNoteTabs = useWorkspaceStore((s) => s.noteTabs);
+
+  const paneTabs = useMemo(() => {
+    const tabMap = new Map<string, NoteTab>();
+    for (const tab of allNoteTabs) {
+      tabMap.set(tab.id, tab);
+    }
+    return paneTabIds.map((id) => tabMap.get(id)).filter(Boolean) as NoteTab[];
+  }, [allNoteTabs, paneTabIds]);
+
+  const activeTab = useMemo(
+    () => paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null,
+    [paneTabs, paneActiveTabId],
+  );
+
+  // ── Derived display values ─────────────────────────────────────────
+  const content = activeTab?.draftContent ?? "";
+  const fileName = activeTab?.file.name ?? null;
+  const filePath = activeTab?.file.path ?? null;
+  const isDirty = activeTab?.isDirty ?? false;
+  const isSaving = activeTab?.isSaving ?? false;
+
+  const saveStateLabel = useMemo(() => {
+    if (!activeTab) return "";
+    if (isSaving) return "Saving...";
+    if (isDirty) return "Unsaved";
+    return "Saved";
+  }, [activeTab, isDirty, isSaving]);
+
+  const wordCount = useMemo(() => {
+    if (!content) return 0;
+    return content.split(/\s+/).filter(Boolean).length;
+  }, [content]);
+
+  const readingTime = useMemo(() => Math.max(1, Math.ceil(wordCount / 200)), [wordCount]);
+
+  const isActiveFilePinned = useMemo(() => {
+    if (!filePath) return false;
+    return ctx.pinnedFilePaths.some((p) => isSamePath(p, filePath));
+  }, [ctx.pinnedFilePaths, filePath]);
+
+  const handleTogglePinnedFile = useCallback(() => {
+    if (filePath) {
+      ctx.onTogglePinnedFile(filePath);
+    }
+  }, [ctx, filePath]);
+
+  const footerMetaLabel = useMemo(() => {
+    if (!content) return "";
+    const bytes = new TextEncoder().encode(content).length;
+    if (bytes < 1024) return `${bytes} B`;
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }, [content]);
+
+  const noteTabItems = useMemo(
+    () =>
+      paneTabs.map((tab, index) => ({
+        id: tab.id,
+        label: getDisplayFileName(tab.file.name),
+        path: tab.file.path,
+        shortcutLabel: getDirectTabShortcutDisplay(
+          index,
+          paneTabs.length,
+          typeof navigator === "undefined" ? undefined : navigator.platform,
+        ),
+      })),
+    [paneTabs],
+  );
+
+  // ── Handlers (bind paneId) ─────────────────────────────────────────
+  const handleFocus = useCallback(() => {
+    if (!isActivePane) {
+      ctx.onActivatePane(paneId);
+    }
+  }, [ctx, isActivePane, paneId]);
+
+  const handleContentChange = useCallback(
+    (value: string) => {
+      if (paneActiveTabId) {
+        ctx.onContentChange(paneId, paneActiveTabId, value);
+      }
+    },
+    [ctx, paneId, paneActiveTabId],
+  );
+
+  const handleSelectTab = useCallback(
+    (path: string) => {
+      ctx.onSelectTab(paneId, path);
+    },
+    [ctx, paneId],
+  );
+
+  const handleCloseTab = useCallback(
+    (path: string) => {
+      ctx.onCloseTab(paneId, path);
+    },
+    [ctx, paneId],
+  );
+
+  const handleMoveTab = useCallback(
+    (sourcePath: string, targetPath: string, position: TabMovePosition) => {
+      ctx.onMoveTab(paneId, sourcePath, targetPath, position);
+    },
+    [ctx, paneId],
+  );
+
+  // Only the active pane receives focus / find requests
+  const editorFocusRequest = isActivePane ? ctx.editorFocusRequest : null;
+  const findRequest = isActivePane ? ctx.findRequest : null;
+  const outlineItems = isActivePane ? ctx.outlineItems : [];
+  const outlineJumpRequest = isActivePane ? ctx.outlineJumpRequest : null;
+
+  // ── Active pane highlight ──────────────────────────────────────────
+  const showActiveBorder = hasMultiplePanes;
+
+  return (
+    <div
+      className={`relative flex h-full min-h-0 flex-col ${
+        showActiveBorder
+          ? isActivePane
+            ? "ring-1 ring-inset ring-primary/30"
+            : "ring-1 ring-inset ring-transparent"
+          : ""
+      }`}
+      onFocusCapture={handleFocus}
+      onPointerDown={handleFocus}
+    >
+      <MarkdownEditor
+        content={content}
+        fileName={fileName}
+        filePath={filePath}
+        editorFocusRequest={editorFocusRequest}
+        findRequest={findRequest}
+        initialScrollTop={0}
+        saveStateLabel={saveStateLabel}
+        footerMetaLabel={footerMetaLabel}
+        wordCount={wordCount}
+        readingTime={readingTime}
+        subheaderContent={
+          noteTabItems.length > 0 ? (
+            <NoteTabsBar
+              activeTabId={paneActiveTabId}
+              tabs={noteTabItems}
+              onSelectTab={handleSelectTab}
+              onCloseTab={handleCloseTab}
+              onMoveTab={handleMoveTab}
+            />
+          ) : null
+        }
+        onChange={handleContentChange}
+        onToggleSidebar={ctx.onToggleSidebar}
+        isSidebarCollapsed={ctx.isSidebarCollapsed}
+        onCreateNote={ctx.onCreateNote}
+        toggleSidebarShortcut={getShortcutDisplay(
+          ctx.shortcuts,
+          "toggle-sidebar",
+          navigator.platform,
+        )}
+        newNoteShortcut={getShortcutDisplay(ctx.shortcuts, "new-note", navigator.platform)}
+        onOpenSettings={ctx.onOpenSettings}
+        onOpenCommandPalette={ctx.onOpenCommandPalette}
+        commandPaletteLabel="Search notes and skills"
+        onOpenLinkedFile={ctx.onOpenLinkedFile}
+        commandPaletteShortcut={
+          getShortcutDisplay(ctx.shortcuts, "command-palette", navigator.platform) ??
+          (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P")
+        }
+        onScrollPositionChange={ctx.onScrollPositionChange}
+        onNavigateBack={ctx.onNavigateBack}
+        onNavigateForward={ctx.onNavigateForward}
+        navigateBackShortcut={getShortcutDisplay(
+          ctx.shortcuts,
+          "navigate-back",
+          navigator.platform,
+        )}
+        navigateForwardShortcut={getShortcutDisplay(
+          ctx.shortcuts,
+          "navigate-forward",
+          navigator.platform,
+        )}
+        focusModeShortcut={getShortcutDisplay(ctx.shortcuts, "focus-mode", navigator.platform)}
+        zoomInShortcut={getShortcutDisplay(ctx.shortcuts, "zoom-in", navigator.platform)}
+        zoomOutShortcut={getShortcutDisplay(ctx.shortcuts, "zoom-out", navigator.platform)}
+        zoomResetShortcut={getShortcutDisplay(ctx.shortcuts, "zoom-reset", navigator.platform)}
+        canGoBack={ctx.canGoBack}
+        canGoForward={ctx.canGoForward}
+        autoOpenPDFSetting={ctx.autoOpenPDFSetting}
+        folderRevealLabel={ctx.folderRevealLabel}
+        isActiveFilePinned={isActiveFilePinned}
+        onTogglePinnedFile={filePath ? handleTogglePinnedFile : undefined}
+        isFocusMode={ctx.isFocusMode}
+        showOutline={ctx.showOutline}
+        outlineItems={outlineItems}
+        outlineJumpRequest={outlineJumpRequest}
+        onOutlineJumpHandled={ctx.onOutlineJumpHandled}
+        onToggleFocusMode={ctx.onToggleFocusMode}
+        editorScale={ctx.editorScale}
+        onEditorScaleChange={ctx.onEditorScaleChange}
+        scrollRestorationKey={filePath}
+        updateState={isActivePane ? ctx.updateState : null}
+        updatesMode={ctx.updatesMode}
+        dismissedUpdateVersion={ctx.dismissedUpdateVersion}
+        onUpdateAction={ctx.onUpdateAction}
+        onDismissUpdateAction={ctx.onDismissUpdateAction}
+      />
+    </div>
+  );
+});

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useLayoutEffect, useMemo, useState } from "react";
 
 import { getDisplayFileName, isSamePath } from "@/lib/paths";
 import { getDirectTabShortcutDisplay, getShortcutDisplay } from "@/shared/shortcuts";
 import type { NoteTab, TabMovePosition } from "@/shared/workspace";
 import { useLayoutStore } from "@/store/layout";
+import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
 
 import { MarkdownEditor } from "./markdown-editor";
@@ -66,6 +67,13 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
     if (!filePath) return false;
     return ctx.pinnedFilePaths.some((p) => isSamePath(p, filePath));
   }, [ctx.pinnedFilePaths, filePath]);
+
+  // ── Scroll position restoration ────────────────────────────────────
+  const [initialScrollTop, setInitialScrollTop] = useState(0);
+
+  useLayoutEffect(() => {
+    setInitialScrollTop(filePath ? useSessionStore.getState().getDocumentScroll(filePath) : 0);
+  }, [filePath]);
 
   const handleTogglePinnedFile = useCallback(() => {
     if (filePath) {
@@ -159,7 +167,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         filePath={filePath}
         editorFocusRequest={editorFocusRequest}
         findRequest={findRequest}
-        initialScrollTop={0}
+        initialScrollTop={initialScrollTop}
         saveStateLabel={saveStateLabel}
         footerMetaLabel={footerMetaLabel}
         wordCount={wordCount}

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -354,6 +354,7 @@ export const MarkdownEditor = ({
   scrollRestorationKey = null,
   editorFocusRequest,
   findRequest,
+  showToolbar = true,
   saveStateLabel,
   footerMetaLabel,
   wordCount,
@@ -1432,54 +1433,56 @@ export const MarkdownEditor = ({
 
   return (
     <section className="relative h-full min-h-0 flex flex-col bg-background">
-      <EditorToolbar
-        _isMacLike={isMacLike}
-        isSidebarCollapsed={isSidebarCollapsed}
-        toggleSidebarShortcut={toggleSidebarShortcut}
-        onToggleSidebar={onToggleSidebar}
-        canGoBack={canGoBack}
-        canGoForward={canGoForward}
-        navigateBackShortcut={navigateBackShortcut}
-        navigateForwardShortcut={navigateForwardShortcut}
-        onNavigateBack={onNavigateBack}
-        onNavigateForward={onNavigateForward}
-        onCreateNote={onCreateNote}
-        newNoteShortcut={newNoteShortcut}
-        fileName={fileName}
-        filePath={filePath}
-        shouldShowCommandPalette={shouldShowCommandPalette}
-        onOpenCommandPalette={onOpenCommandPalette}
-        commandPaletteShortcut={commandPaletteShortcut}
-        commandPaletteLabel={commandPaletteLabel}
-        isFocusMode={isFocusLayout}
-        onToggleFocusMode={onToggleFocusMode}
-        focusModeShortcut={focusModeShortcut}
-        shouldShowUpdateActionButton={updateStateFlags.shouldShowUpdateActionButton}
-        updateButtonVariant={updateStateFlags.updateButtonVariant}
-        isUpdateButtonDisabled={updateStateFlags.isUpdateButtonDisabled}
-        updateButtonLabel={updateStateFlags.updateButtonLabel}
-        updateButtonTooltip={updateStateFlags.updateButtonTooltip}
-        onUpdateAction={onUpdateAction}
-        onDismissUpdateAction={onDismissUpdateAction}
-        isManualReleaseButton={updateStateFlags.isManualReleaseButton}
-        headerPaddingClass={headerPaddingClass}
-        onOpenSettings={onOpenSettings}
-        headerAccessory={headerAccessory}
-        content={content}
-        documentLabel={normalizedDocumentLabel}
-        revealInFolderLabel={revealInFolderLabel}
-        onCopy={handleCopy}
-        onCopyPath={handleCopyPath}
-        onOpenExternal={handleOpenExternal}
-        onExportPDF={handleExportPDF}
-        onTogglePinnedFile={onTogglePinnedFile}
-        isActiveFilePinned={isActiveFilePinned}
-        editorScale={editorScale}
-        onEditorScaleChange={onEditorScaleChange}
-        zoomInShortcut={zoomInShortcut}
-        zoomOutShortcut={zoomOutShortcut}
-        zoomResetShortcut={zoomResetShortcut}
-      />
+      {showToolbar ? (
+        <EditorToolbar
+          _isMacLike={isMacLike}
+          isSidebarCollapsed={isSidebarCollapsed}
+          toggleSidebarShortcut={toggleSidebarShortcut}
+          onToggleSidebar={onToggleSidebar}
+          canGoBack={canGoBack}
+          canGoForward={canGoForward}
+          navigateBackShortcut={navigateBackShortcut}
+          navigateForwardShortcut={navigateForwardShortcut}
+          onNavigateBack={onNavigateBack}
+          onNavigateForward={onNavigateForward}
+          onCreateNote={onCreateNote}
+          newNoteShortcut={newNoteShortcut}
+          fileName={fileName}
+          filePath={filePath}
+          shouldShowCommandPalette={shouldShowCommandPalette}
+          onOpenCommandPalette={onOpenCommandPalette}
+          commandPaletteShortcut={commandPaletteShortcut}
+          commandPaletteLabel={commandPaletteLabel}
+          isFocusMode={isFocusLayout}
+          onToggleFocusMode={onToggleFocusMode}
+          focusModeShortcut={focusModeShortcut}
+          shouldShowUpdateActionButton={updateStateFlags.shouldShowUpdateActionButton}
+          updateButtonVariant={updateStateFlags.updateButtonVariant}
+          isUpdateButtonDisabled={updateStateFlags.isUpdateButtonDisabled}
+          updateButtonLabel={updateStateFlags.updateButtonLabel}
+          updateButtonTooltip={updateStateFlags.updateButtonTooltip}
+          onUpdateAction={onUpdateAction}
+          onDismissUpdateAction={onDismissUpdateAction}
+          isManualReleaseButton={updateStateFlags.isManualReleaseButton}
+          headerPaddingClass={headerPaddingClass}
+          onOpenSettings={onOpenSettings}
+          headerAccessory={headerAccessory}
+          content={content}
+          documentLabel={normalizedDocumentLabel}
+          revealInFolderLabel={revealInFolderLabel}
+          onCopy={handleCopy}
+          onCopyPath={handleCopyPath}
+          onOpenExternal={handleOpenExternal}
+          onExportPDF={handleExportPDF}
+          onTogglePinnedFile={onTogglePinnedFile}
+          isActiveFilePinned={isActiveFilePinned}
+          editorScale={editorScale}
+          onEditorScaleChange={onEditorScaleChange}
+          zoomInShortcut={zoomInShortcut}
+          zoomOutShortcut={zoomOutShortcut}
+          zoomResetShortcut={zoomResetShortcut}
+        />
+      ) : null}
       {subheaderContent ? (
         <div className="border-b border-border/30">{subheaderContent}</div>
       ) : null}

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -8,20 +8,32 @@ import type { TabMovePosition } from "@/shared/workspace";
 import { XIcon } from "./icons";
 
 const NOTE_TAB_DRAG_MIME = "application/x-glyph-note-tab";
-let globalDraggedTabPath: string | null = null;
+let globalDraggedTab: { paneId: string; path: string } | null = null;
 
-const readDraggedTabPath = (event: DragEvent<HTMLElement | HTMLDivElement>): string | null => {
-  if (globalDraggedTabPath) {
-    return globalDraggedTabPath;
+const readDraggedTab = (
+  event: DragEvent<HTMLElement | HTMLDivElement>,
+): { paneId: string | null; path: string } | null => {
+  if (globalDraggedTab) {
+    return globalDraggedTab;
   }
 
   const dragPayload = event.dataTransfer.getData(NOTE_TAB_DRAG_MIME);
   if (dragPayload) {
-    return dragPayload;
+    try {
+      const parsed = JSON.parse(dragPayload) as { paneId?: string; path?: string };
+      if (parsed.path) {
+        return {
+          paneId: parsed.paneId ?? null,
+          path: parsed.path,
+        };
+      }
+    } catch {
+      return { paneId: null, path: dragPayload };
+    }
   }
 
   const plainTextPayload = event.dataTransfer.getData("text/plain");
-  return plainTextPayload || null;
+  return plainTextPayload ? { paneId: null, path: plainTextPayload } : null;
 };
 
 export type NoteTabRailItem = {
@@ -32,14 +44,21 @@ export type NoteTabRailItem = {
 };
 
 type NoteTabsBarProps = {
+  paneId: string;
   activeTabId: string | null;
   onCloseTab: (path: string) => void;
-  onMoveTab: (sourcePath: string, targetPath: string, position: TabMovePosition) => void;
+  onMoveTab: (
+    sourcePaneId: string,
+    sourcePath: string,
+    targetPath: string,
+    position: TabMovePosition,
+  ) => void;
   onSelectTab: (path: string) => void;
   tabs: NoteTabRailItem[];
 };
 
 export function NoteTabsBar({
+  paneId,
   activeTabId,
   onCloseTab,
   onMoveTab,
@@ -101,14 +120,15 @@ export function NoteTabsBar({
   }, [activeTabId, tabOrderKey]);
 
   const clearDragState = useCallback(() => {
-    globalDraggedTabPath = null;
+    globalDraggedTab = null;
     draggedTabPathRef.current = null;
     setDraggedTabPath(null);
     setDropTarget(null);
   }, []);
 
   const handleTabDragOver = useCallback((event: DragEvent<HTMLElement>, tabPath: string) => {
-    const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
+    const currentDraggedTab = readDraggedTab(event);
+    const currentDraggedTabPath = currentDraggedTab?.path ?? draggedTabPathRef.current;
     if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tabPath)) {
       return;
     }
@@ -127,7 +147,7 @@ export function NoteTabsBar({
   }, []);
 
   const handleContainerDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
-    const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
+    const currentDraggedTabPath = readDraggedTab(event)?.path ?? draggedTabPathRef.current;
     if (!currentDraggedTabPath) {
       return;
     }
@@ -151,8 +171,10 @@ export function NoteTabsBar({
 
   const handleContainerDrop = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
-      if (!currentDraggedTabPath) {
+      const currentDraggedTab = readDraggedTab(event);
+      const currentDraggedTabPath = currentDraggedTab?.path ?? draggedTabPathRef.current;
+      const sourcePaneId = currentDraggedTab?.paneId;
+      if (!currentDraggedTabPath || !sourcePaneId) {
         return;
       }
 
@@ -167,7 +189,7 @@ export function NoteTabsBar({
       const lastTab = tabs.at(-1);
       if (lastTab && !isSamePath(lastTab.path, currentDraggedTabPath)) {
         event.preventDefault();
-        onMoveTab(currentDraggedTabPath, lastTab.path, "after");
+        onMoveTab(sourcePaneId, currentDraggedTabPath, lastTab.path, "after");
       }
 
       clearDragState();
@@ -238,16 +260,25 @@ export function NoteTabsBar({
                   onDragStart={(event) => {
                     event.dataTransfer.effectAllowed = "move";
                     event.dataTransfer.setData("text/plain", tab.path);
-                    event.dataTransfer.setData(NOTE_TAB_DRAG_MIME, tab.path);
-                    globalDraggedTabPath = tab.path;
+                    event.dataTransfer.setData(
+                      NOTE_TAB_DRAG_MIME,
+                      JSON.stringify({ paneId, path: tab.path }),
+                    );
+                    globalDraggedTab = { paneId, path: tab.path };
                     draggedTabPathRef.current = tab.path;
                     setDraggedTabPath(tab.path);
                   }}
                   onDragOver={(event) => handleTabDragOver(event, tab.path)}
                   onDrop={(event) => {
+                    const currentDraggedTab = readDraggedTab(event);
                     const currentDraggedTabPath =
-                      draggedTabPathRef.current ?? readDraggedTabPath(event);
-                    if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tab.path)) {
+                      currentDraggedTab?.path ?? draggedTabPathRef.current;
+                    const sourcePaneId = currentDraggedTab?.paneId;
+                    if (
+                      !currentDraggedTabPath ||
+                      !sourcePaneId ||
+                      isSamePath(currentDraggedTabPath, tab.path)
+                    ) {
                       clearDragState();
                       return;
                     }
@@ -255,7 +286,7 @@ export function NoteTabsBar({
                     event.preventDefault();
                     event.stopPropagation();
                     const position = dropTarget?.path === tab.path ? dropTarget.position : "after";
-                    onMoveTab(currentDraggedTabPath, tab.path, position);
+                    onMoveTab(sourcePaneId, currentDraggedTabPath, tab.path, position);
                     clearDragState();
                   }}
                   onClick={() => onSelectTab(tab.path)}

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -7,6 +7,18 @@ import type { TabMovePosition } from "@/shared/workspace";
 
 import { XIcon } from "./icons";
 
+const NOTE_TAB_DRAG_MIME = "application/x-glyph-note-tab";
+
+const readDraggedTabPath = (event: DragEvent<HTMLElement | HTMLDivElement>): string | null => {
+  const dragPayload = event.dataTransfer.getData(NOTE_TAB_DRAG_MIME);
+  if (dragPayload) {
+    return dragPayload;
+  }
+
+  const plainTextPayload = event.dataTransfer.getData("text/plain");
+  return plainTextPayload || null;
+};
+
 export type NoteTabRailItem = {
   id: string;
   label: string;
@@ -90,12 +102,14 @@ export function NoteTabsBar({
   }, []);
 
   const handleTabDragOver = useCallback((event: DragEvent<HTMLElement>, tabPath: string) => {
-    const currentDraggedTabPath = draggedTabPathRef.current;
+    const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
     if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tabPath)) {
       return;
     }
 
     event.preventDefault();
+    draggedTabPathRef.current = currentDraggedTabPath;
+    setDraggedTabPath((current) => current ?? currentDraggedTabPath);
     const bounds = event.currentTarget.getBoundingClientRect();
     const position: TabMovePosition =
       event.clientX < bounds.left + bounds.width / 2 ? "before" : "after";
@@ -107,11 +121,14 @@ export function NoteTabsBar({
   }, []);
 
   const handleContainerDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
-    if (!draggedTabPathRef.current) {
+    const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
+    if (!currentDraggedTabPath) {
       return;
     }
 
     event.preventDefault();
+    draggedTabPathRef.current = currentDraggedTabPath;
+    setDraggedTabPath((current) => current ?? currentDraggedTabPath);
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
       return;
@@ -128,7 +145,7 @@ export function NoteTabsBar({
 
   const handleContainerDrop = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      const currentDraggedTabPath = draggedTabPathRef.current;
+      const currentDraggedTabPath = draggedTabPathRef.current ?? readDraggedTabPath(event);
       if (!currentDraggedTabPath) {
         return;
       }
@@ -215,12 +232,14 @@ export function NoteTabsBar({
                   onDragStart={(event) => {
                     event.dataTransfer.effectAllowed = "move";
                     event.dataTransfer.setData("text/plain", tab.path);
+                    event.dataTransfer.setData(NOTE_TAB_DRAG_MIME, tab.path);
                     draggedTabPathRef.current = tab.path;
                     setDraggedTabPath(tab.path);
                   }}
                   onDragOver={(event) => handleTabDragOver(event, tab.path)}
                   onDrop={(event) => {
-                    const currentDraggedTabPath = draggedTabPathRef.current;
+                    const currentDraggedTabPath =
+                      draggedTabPathRef.current ?? readDraggedTabPath(event);
                     if (!currentDraggedTabPath || isSamePath(currentDraggedTabPath, tab.path)) {
                       clearDragState();
                       return;

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -214,7 +214,7 @@ export function NoteTabsBar({
                   }}
                   type="button"
                   role="tab"
-                  draggable={tabs.length > 1}
+                  draggable
                   aria-selected={isActive}
                   title={tab.path}
                   onDragEnd={clearDragState}

--- a/apps/desktop/src/components/note-tabs-bar.tsx
+++ b/apps/desktop/src/components/note-tabs-bar.tsx
@@ -8,8 +8,13 @@ import type { TabMovePosition } from "@/shared/workspace";
 import { XIcon } from "./icons";
 
 const NOTE_TAB_DRAG_MIME = "application/x-glyph-note-tab";
+let globalDraggedTabPath: string | null = null;
 
 const readDraggedTabPath = (event: DragEvent<HTMLElement | HTMLDivElement>): string | null => {
+  if (globalDraggedTabPath) {
+    return globalDraggedTabPath;
+  }
+
   const dragPayload = event.dataTransfer.getData(NOTE_TAB_DRAG_MIME);
   if (dragPayload) {
     return dragPayload;
@@ -96,6 +101,7 @@ export function NoteTabsBar({
   }, [activeTabId, tabOrderKey]);
 
   const clearDragState = useCallback(() => {
+    globalDraggedTabPath = null;
     draggedTabPathRef.current = null;
     setDraggedTabPath(null);
     setDropTarget(null);
@@ -233,6 +239,7 @@ export function NoteTabsBar({
                     event.dataTransfer.effectAllowed = "move";
                     event.dataTransfer.setData("text/plain", tab.path);
                     event.dataTransfer.setData(NOTE_TAB_DRAG_MIME, tab.path);
+                    globalDraggedTabPath = tab.path;
                     draggedTabPathRef.current = tab.path;
                     setDraggedTabPath(tab.path);
                   }}

--- a/apps/desktop/src/components/note-view.tsx
+++ b/apps/desktop/src/components/note-view.tsx
@@ -147,11 +147,14 @@ export function NoteView({
       subheaderContent={
         noteTabItems.length > 0 ? (
           <NoteTabsBar
+            paneId="pane-0"
             activeTabId={activeTabId}
             tabs={noteTabItems}
             onSelectTab={onSelectTab}
             onCloseTab={onCloseTab}
-            onMoveTab={onMoveTab}
+            onMoveTab={(_sourcePaneId, sourcePath, targetPath, position) =>
+              onMoveTab(sourcePath, targetPath, position)
+            }
           />
         ) : null
       }

--- a/apps/desktop/src/components/split-container.tsx
+++ b/apps/desktop/src/components/split-container.tsx
@@ -1,0 +1,59 @@
+import { memo } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+
+import { useLayoutStore } from "@/store/layout";
+import type { LayoutNode } from "@/shared/workspace";
+
+import { EditorPane } from "./editor-pane";
+
+// ─── Resize handle ───────────────────────────────────────────────────
+
+function ResizeHandle({ direction }: { direction: "horizontal" | "vertical" }) {
+  const isVertical = direction === "vertical";
+
+  return (
+    <Separator
+      className={`group relative flex items-center justify-center ${
+        isVertical ? "h-px" : "w-px"
+      } bg-border/60 transition-colors duration-100 hover:bg-primary/40 active:bg-primary/60`}
+    >
+      <div
+        className={`absolute z-10 ${
+          isVertical ? "h-1 w-full cursor-row-resize" : "h-full w-1 cursor-col-resize"
+        }`}
+      />
+    </Separator>
+  );
+}
+
+// ─── Recursive layout renderer ───────────────────────────────────────
+
+const LayoutNodeRenderer = memo(function LayoutNodeRenderer({ node }: { node: LayoutNode }) {
+  if (node.type === "pane") {
+    return <EditorPane paneId={node.id} />;
+  }
+
+  return (
+    <Group orientation={node.direction}>
+      <Panel defaultSize={50} minSize={15}>
+        <LayoutNodeRenderer node={node.children[0]} />
+      </Panel>
+      <ResizeHandle direction={node.direction} />
+      <Panel defaultSize={50} minSize={15}>
+        <LayoutNodeRenderer node={node.children[1]} />
+      </Panel>
+    </Group>
+  );
+});
+
+// ─── Public component ────────────────────────────────────────────────
+
+export function SplitContainer() {
+  const root = useLayoutStore((state) => state.root);
+
+  return (
+    <div className="h-full min-h-0 min-w-0">
+      <LayoutNodeRenderer node={root} />
+    </div>
+  );
+}

--- a/apps/desktop/src/components/split-container.tsx
+++ b/apps/desktop/src/components/split-container.tsx
@@ -23,7 +23,7 @@ function ResizeHandle({ direction }: { direction: "horizontal" | "vertical" }) {
       } bg-border/55 transition-colors duration-100 hover:bg-border/80 active:bg-border`}
     >
       <div
-        className={`absolute z-10 cursor-${isVertical ? "row" : "col"}-resize ${
+        className={`absolute z-10 cursor-grab active:cursor-grabbing ${
           HANDLE_HIT_TARGET_CLASS[direction]
         }`}
       />

--- a/apps/desktop/src/components/split-container.tsx
+++ b/apps/desktop/src/components/split-container.tsx
@@ -8,20 +8,34 @@ import { EditorPane } from "./editor-pane";
 
 // ─── Resize handle ───────────────────────────────────────────────────
 
+const HANDLE_HIT_TARGET_CLASS = {
+  horizontal: "h-full w-2",
+  vertical: "h-2 w-full",
+} as const;
+
 function ResizeHandle({ direction }: { direction: "horizontal" | "vertical" }) {
   const isVertical = direction === "vertical";
 
   return (
     <Separator
       className={`group relative flex items-center justify-center ${
-        isVertical ? "h-px" : "w-px"
-      } bg-border/60 transition-colors duration-100 hover:bg-primary/40 active:bg-primary/60`}
+        isVertical ? "h-px w-full" : "h-full w-px"
+      } bg-border/55 transition-colors duration-100 hover:bg-border/80 active:bg-border`}
     >
       <div
-        className={`absolute z-10 ${
-          isVertical ? "h-1 w-full cursor-row-resize" : "h-full w-1 cursor-col-resize"
+        className={`absolute z-10 cursor-${isVertical ? "row" : "col"}-resize ${
+          HANDLE_HIT_TARGET_CLASS[direction]
         }`}
       />
+      <div
+        className={`pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/40 transition-opacity duration-100 group-hover:opacity-100 group-active:opacity-100 ${
+          isVertical ? "h-1 w-7" : "h-7 w-1"
+        } opacity-0`}
+      >
+        <div
+          className={`absolute inset-0 rounded-full bg-muted-foreground/30 transition-transform duration-100 group-active:scale-105`}
+        />
+      </div>
     </Separator>
   );
 }
@@ -52,7 +66,7 @@ export function SplitContainer() {
   const root = useLayoutStore((state) => state.root);
 
   return (
-    <div className="h-full min-h-0 min-w-0">
+    <div className="h-full min-h-0 min-w-0 overflow-hidden">
       <LayoutNodeRenderer node={root} />
     </div>
   );

--- a/apps/desktop/src/components/split-view-context.tsx
+++ b/apps/desktop/src/components/split-view-context.tsx
@@ -54,7 +54,8 @@ export type SplitViewContextValue = {
   onSelectTab: (paneId: string, path: string) => void;
   onCloseTab: (paneId: string, path: string) => void;
   onMoveTab: (
-    paneId: string,
+    sourcePaneId: string,
+    targetPaneId: string,
     sourcePath: string,
     targetPath: string,
     position: TabMovePosition,

--- a/apps/desktop/src/components/split-view-context.tsx
+++ b/apps/desktop/src/components/split-view-context.tsx
@@ -41,8 +41,10 @@ export type SplitViewContextValue = {
   onUpdateAction: () => void;
   onDismissUpdateAction: () => void;
 
-  // NoteView-only note actions are intentionally omitted here until split view
-  // grows pane-aware versions of those workflows.
+  // TODO(split-view): add pane-aware note actions here before split view
+  // reuses NoteView behaviors directly. The next callbacks to add are
+  // onDeleteNote(paneId, path) and onOpenNewWindow(paneId, path), and callers
+  // should migrate from note-view.tsx once those flows are pane-aware.
 
   // ── Pinned files ──
   pinnedFilePaths: string[];

--- a/apps/desktop/src/components/split-view-context.tsx
+++ b/apps/desktop/src/components/split-view-context.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext } from "react";
+
+import type { AppInfo, ShortcutSetting, TabMovePosition, UpdateState } from "@/shared/workspace";
+import type { EditorFindRequest, EditorFocusRequest } from "@/types/markdown-editor";
+import type { OutlineItem } from "@/types/navigation";
+
+/**
+ * Shared controller state passed through the split layout tree so that
+ * individual pane components don't need the full controller prop-drilled
+ * from DesktopApp. Everything here is "global" (not pane-specific).
+ */
+export type SplitViewContextValue = {
+  // ── Appearance / settings ──
+  shortcuts: ShortcutSetting[];
+  isSidebarCollapsed: boolean;
+  isFocusMode: boolean;
+  showOutline: boolean;
+  editorScale: number;
+  autoOpenPDFSetting: boolean;
+  folderRevealLabel: string;
+  updateState: UpdateState | null;
+  updatesMode: AppInfo["updatesMode"] | undefined;
+  dismissedUpdateVersion: string | null;
+
+  // ── Navigation ──
+  canGoBack: boolean;
+  canGoForward: boolean;
+
+  // ── Focus / find requests (only apply to the active pane) ──
+  editorFocusRequest: EditorFocusRequest | null;
+  findRequest: EditorFindRequest | null;
+
+  // ── Outline ──
+  outlineItems: OutlineItem[];
+  outlineJumpRequest: { id: string; nonce: number } | null;
+
+  // ── Callbacks ──
+  onToggleSidebar: () => void;
+  onCreateNote: () => void;
+  onOpenSettings: () => void;
+  onOpenCommandPalette: () => void;
+  onOpenLinkedFile: (path: string) => void;
+  onScrollPositionChange: (targetPath: string | null, scrollTop: number) => void;
+  onNavigateBack: () => void;
+  onNavigateForward: () => void;
+  onOutlineJumpHandled: () => void;
+  onToggleFocusMode: () => void;
+  onEditorScaleChange: (scale: number) => void;
+  onUpdateAction: () => void;
+  onDismissUpdateAction: () => void;
+
+  // ── Pinned files ──
+  pinnedFilePaths: string[];
+  onTogglePinnedFile: (filePath: string) => void;
+
+  // ── Pane-aware tab operations (these go through layout store) ──
+  onSelectTab: (paneId: string, path: string) => void;
+  onCloseTab: (paneId: string, path: string) => void;
+  onMoveTab: (
+    paneId: string,
+    sourcePath: string,
+    targetPath: string,
+    position: TabMovePosition,
+  ) => void;
+  onContentChange: (paneId: string, tabId: string, content: string) => void;
+  onActivatePane: (paneId: string) => void;
+};
+
+const SplitViewContext = createContext<SplitViewContextValue | null>(null);
+
+export const SplitViewProvider = SplitViewContext.Provider;
+
+export function useSplitViewContext(): SplitViewContextValue {
+  const context = useContext(SplitViewContext);
+  if (!context) {
+    throw new Error("useSplitViewContext must be used within a SplitViewProvider");
+  }
+  return context;
+}

--- a/apps/desktop/src/components/split-view-context.tsx
+++ b/apps/desktop/src/components/split-view-context.tsx
@@ -7,7 +7,8 @@ import type { OutlineItem } from "@/types/navigation";
 /**
  * Shared controller state passed through the split layout tree so that
  * individual pane components don't need the full controller prop-drilled
- * from DesktopApp. Everything here is "global" (not pane-specific).
+ * from DesktopApp. Keep this context stable and avoid putting high-churn
+ * editor state here so inactive panes don't rerender on every keystroke.
  */
 export type SplitViewContextValue = {
   // ── Appearance / settings ──
@@ -26,14 +27,6 @@ export type SplitViewContextValue = {
   canGoBack: boolean;
   canGoForward: boolean;
 
-  // ── Focus / find requests (only apply to the active pane) ──
-  editorFocusRequest: EditorFocusRequest | null;
-  findRequest: EditorFindRequest | null;
-
-  // ── Outline ──
-  outlineItems: OutlineItem[];
-  outlineJumpRequest: { id: string; nonce: number } | null;
-
   // ── Callbacks ──
   onToggleSidebar: () => void;
   onCreateNote: () => void;
@@ -43,7 +36,6 @@ export type SplitViewContextValue = {
   onScrollPositionChange: (targetPath: string | null, scrollTop: number) => void;
   onNavigateBack: () => void;
   onNavigateForward: () => void;
-  onOutlineJumpHandled: () => void;
   onToggleFocusMode: () => void;
   onEditorScaleChange: (scale: number) => void;
   onUpdateAction: () => void;
@@ -69,14 +61,34 @@ export type SplitViewContextValue = {
   onActivatePane: (paneId: string) => void;
 };
 
+export type SplitViewActivePaneContextValue = {
+  editorFocusRequest: EditorFocusRequest | null;
+  findRequest: EditorFindRequest | null;
+  outlineItems: OutlineItem[];
+  outlineJumpRequest: { id: string; nonce: number } | null;
+  onOutlineJumpHandled: () => void;
+};
+
 const SplitViewContext = createContext<SplitViewContextValue | null>(null);
+const SplitViewActivePaneContext = createContext<SplitViewActivePaneContextValue | null>(null);
 
 export const SplitViewProvider = SplitViewContext.Provider;
+export const SplitViewActivePaneProvider = SplitViewActivePaneContext.Provider;
 
 export function useSplitViewContext(): SplitViewContextValue {
   const context = useContext(SplitViewContext);
   if (!context) {
     throw new Error("useSplitViewContext must be used within a SplitViewProvider");
+  }
+  return context;
+}
+
+export function useSplitViewActivePaneContext(): SplitViewActivePaneContextValue {
+  const context = useContext(SplitViewActivePaneContext);
+  if (!context) {
+    throw new Error(
+      "useSplitViewActivePaneContext must be used within a SplitViewActivePaneProvider",
+    );
   }
   return context;
 }

--- a/apps/desktop/src/components/split-view-context.tsx
+++ b/apps/desktop/src/components/split-view-context.tsx
@@ -49,6 +49,9 @@ export type SplitViewContextValue = {
   onUpdateAction: () => void;
   onDismissUpdateAction: () => void;
 
+  // NoteView-only note actions are intentionally omitted here until split view
+  // grows pane-aware versions of those workflows.
+
   // ── Pinned files ──
   pinnedFilePaths: string[];
   onTogglePinnedFile: (filePath: string) => void;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -8,7 +8,7 @@ import {
   getDirectTabTargetIndex,
   getShortcutDisplay,
 } from "@/shared/shortcuts";
-import type { DirectoryNode, FileDocument, TabMovePosition } from "@/shared/workspace";
+import type { DirectoryNode, FileDocument, LayoutNode, TabMovePosition } from "@/shared/workspace";
 import { useLayoutStore } from "@/store/layout";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
@@ -143,6 +143,7 @@ export const useDesktopAppController = (
     removeHistoryPath,
   } = useWorkspaceStore();
   const setNoteSession = useSessionStore((state) => state.setNoteSession);
+  const setLayoutSession = useSessionStore((state) => state.setLayoutSession);
 
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
@@ -2051,10 +2052,61 @@ export const useDesktopAppController = (
       setExpandedFolderPaths(Array.from(nextExpandedFolders));
       setHasHydratedSidebar(true);
 
-      // Initialize layout store with current tabs
+      // Initialize layout store with current tabs — restore persisted layout if available
       const bootTabs = useWorkspaceStore.getState().noteTabs;
       const bootActiveTabId = useWorkspaceStore.getState().activeTabId;
-      if (bootTabs.length > 0) {
+      const bootTabIds = new Set(bootTabs.map((t) => t.id));
+      const savedLayout = useSessionStore.getState().getLayoutSession();
+
+      if (savedLayout && Object.keys(savedLayout.panes).length > 1) {
+        // Validate: only keep panes whose tabs still exist in the workspace
+        const validPanes: Record<string, { tabIds: string[]; activeTabId: string | null }> = {};
+        for (const [paneId, pane] of Object.entries(savedLayout.panes)) {
+          const validTabIds = pane.tabIds.filter((id) => bootTabIds.has(id));
+          if (validTabIds.length > 0) {
+            validPanes[paneId] = {
+              tabIds: validTabIds,
+              activeTabId:
+                pane.activeTabId && validTabIds.includes(pane.activeTabId)
+                  ? pane.activeTabId
+                  : validTabIds[0],
+            };
+          }
+        }
+
+        if (Object.keys(validPanes).length > 1) {
+          // Prune the layout tree to only include panes that survived validation
+          const validPaneIds = new Set(Object.keys(validPanes));
+          const pruneTree = (node: LayoutNode): LayoutNode | null => {
+            if (node.type === "pane") {
+              return validPaneIds.has(node.id) ? node : null;
+            }
+            const left = pruneTree(node.children[0]);
+            const right = pruneTree(node.children[1]);
+            if (left && right) {
+              return { ...node, children: [left, right] };
+            }
+            return left ?? right;
+          };
+
+          const prunedRoot = pruneTree(savedLayout.root);
+          if (prunedRoot) {
+            useLayoutStore
+              .getState()
+              .restoreLayout(prunedRoot, savedLayout.activePaneId, validPanes);
+          } else if (bootTabs.length > 0) {
+            useLayoutStore.getState().initializePane(
+              bootTabs.map((t) => t.id),
+              bootActiveTabId,
+            );
+          }
+        } else if (bootTabs.length > 0) {
+          useLayoutStore.getState().initializePane(
+            bootTabs.map((t) => t.id),
+            bootActiveTabId,
+          );
+        }
+      } else if (bootTabs.length > 0) {
         useLayoutStore.getState().initializePane(
           bootTabs.map((t) => t.id),
           bootActiveTabId,
@@ -2169,6 +2221,42 @@ export const useDesktopAppController = (
     return () => window.clearTimeout(timer);
   }, [activeFile?.path, draftContent, getActiveTab, isDirty, isSaving, persistNoteDraft]);
 
+  // Auto-save non-active dirty tabs (e.g. tabs in background panes)
+  useEffect(() => {
+    const dirtyBackgroundTabs = noteTabs.filter(
+      (tab) => tab.isDirty && !tab.isSaving && tab.id !== activeTabId,
+    );
+
+    if (dirtyBackgroundTabs.length === 0) {
+      return;
+    }
+
+    const timer = window.setTimeout(async () => {
+      // Re-check in case state changed during the delay
+      const currentTabs = useWorkspaceStore.getState().noteTabs;
+      const currentActiveTabId = useWorkspaceStore.getState().activeTabId;
+      const tabsToSave = currentTabs.filter(
+        (tab) => tab.isDirty && !tab.isSaving && tab.id !== currentActiveTabId,
+      );
+
+      for (const tab of tabsToSave) {
+        await persistNoteDraft(
+          {
+            draftContent: tab.draftContent,
+            file: tab.file,
+            isDirty: tab.isDirty,
+          },
+          {
+            isActive: false,
+            restoreFocus: false,
+          },
+        );
+      }
+    }, 1200);
+
+    return () => window.clearTimeout(timer);
+  }, [activeTabId, noteTabs, persistNoteDraft]);
+
   // Session sync
   useLayoutEffect(() => {
     if (!sessionReady || !hasBooted) {
@@ -2181,6 +2269,19 @@ export const useDesktopAppController = (
       activeFile?.path ?? null,
     );
   }, [activeFile?.path, hasBooted, noteTabs, rootPath, sessionReady, setNoteSession]);
+
+  // Layout session sync — persist layout tree structure across restarts
+  const layoutRoot = useLayoutStore((s) => s.root);
+  const layoutActivePaneId = useLayoutStore((s) => s.activePaneId);
+  const layoutPanes = useLayoutStore((s) => s.panes);
+
+  useLayoutEffect(() => {
+    if (!sessionReady || !hasBooted) {
+      return;
+    }
+
+    setLayoutSession(layoutRoot, layoutActivePaneId, layoutPanes);
+  }, [hasBooted, layoutActivePaneId, layoutPanes, layoutRoot, sessionReady, setLayoutSession]);
 
   const requestOutlineJump = useCallback((id: string) => {
     setOutlineJumpRequest({

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
 import type { BreadcrumbItem, OutlineItem } from "@/types/navigation";
 
@@ -144,9 +153,17 @@ export const useDesktopAppController = (
   } = useWorkspaceStore();
   const setNoteSession = useSessionStore((state) => state.setNoteSession);
   const setLayoutSession = useSessionStore((state) => state.setLayoutSession);
+  const isSidebarCollapsed = useSessionStore((state) => state.isSidebarCollapsed);
+  const setSidebarCollapsed = useSessionStore((state) => state.setSidebarCollapsed);
+  const paneCount = useLayoutStore((state) => {
+    let count = 0;
+    for (const _paneId in state.panes) {
+      count += 1;
+    }
+    return count;
+  });
 
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [isWorkspaceMode, setIsWorkspaceMode] = useState(true);
   const [sidebarNodes, setSidebarNodes] = useState<DirectoryNode[]>([]);
   const [hasHydratedSidebar, setHasHydratedSidebar] = useState(false);
@@ -241,6 +258,14 @@ export const useDesktopAppController = (
   const isActiveFilePinned = activeFile
     ? (settings?.pinnedFiles ?? []).some((filePath) => isSamePath(filePath, activeFile.path))
     : false;
+  const setIsSidebarCollapsed = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (value) => {
+      setSidebarCollapsed(
+        typeof value === "function" ? value(useSessionStore.getState().isSidebarCollapsed) : value,
+      );
+    },
+    [setSidebarCollapsed],
+  );
 
   const requestEditorFocus = useCallback((mode: "start" | "end" | "preserve") => {
     window.requestAnimationFrame(() => {
@@ -401,10 +426,10 @@ export const useDesktopAppController = (
       await ensureFileVisible(file.path);
       const currentRootPath = useWorkspaceStore.getState().rootPath;
       const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(file.path);
+      const nextTabId = toPathKey(file.path);
+      useLayoutStore.getState().removeTabFromAllPanes(nextTabId);
       setActiveFile(file);
-      useLayoutStore
-        .getState()
-        .addTabToPane(useLayoutStore.getState().activePaneId, toPathKey(file.path));
+      useLayoutStore.getState().addTabToPane(useLayoutStore.getState().activePaneId, nextTabId);
       setIsWorkspaceMode(isFileInsideWorkspace(file.path, currentRootPath));
       setSidebarNodes((prev) => upsertSidebarFile(prev, file));
       if (options?.recordHistory) {
@@ -528,7 +553,25 @@ export const useDesktopAppController = (
           return;
         }
       }
+
+      const activeTabId = toPathKey(filePath);
       closeOtherTabs(filePath);
+      const layoutState = useLayoutStore.getState();
+      const nextPanes = Object.fromEntries(
+        Object.entries(layoutState.panes).map(([paneKey, pane]) => {
+          const nextTabIds = pane.tabIds.filter((tabId) => tabId === activeTabId);
+          return [
+            paneKey,
+            {
+              tabIds: nextTabIds,
+              activeTabId: nextTabIds[0] ?? null,
+            },
+          ];
+        }),
+      );
+      useLayoutStore
+        .getState()
+        .restoreLayout(layoutState.root, layoutState.activePaneId, nextPanes);
     },
     [activeFile?.path, closeOtherTabs, persistNoteDraft],
   );
@@ -617,31 +660,67 @@ export const useDesktopAppController = (
     useLayoutStore.getState().splitPane("vertical");
   }, []);
 
-  const closeActivePane = useCallback(() => {
+  const closeActivePane = useCallback(async () => {
     const layoutState = useLayoutStore.getState();
-    // Don't close the last pane
-    if (Object.keys(layoutState.panes).length <= 1) return;
+    if (paneCount <= 1) {
+      return;
+    }
 
     const closingPaneId = layoutState.activePaneId;
     const closingPaneState = layoutState.panes[closingPaneId];
+    if (!closingPaneState) {
+      return;
+    }
+
+    const sharedTabIds = new Set<string>();
+    for (const [paneId, pane] of Object.entries(layoutState.panes)) {
+      if (paneId === closingPaneId) {
+        continue;
+      }
+
+      for (const tabId of pane.tabIds) {
+        sharedTabIds.add(tabId);
+      }
+    }
+
+    const tabPathsToClose: string[] = [];
+    for (const tabId of closingPaneState.tabIds) {
+      if (sharedTabIds.has(tabId)) {
+        continue;
+      }
+
+      const tab = useWorkspaceStore.getState().noteTabs.find((entry) => entry.id === tabId);
+      if (!tab) {
+        continue;
+      }
+
+      let nextPathToClose = tab.file.path;
+      if (tab.isDirty) {
+        const savedPath = await persistNoteDraft(
+          {
+            draftContent: tab.draftContent,
+            file: tab.file,
+            isDirty: tab.isDirty,
+          },
+          {
+            isActive: isSamePath(activeFile?.path, tab.file.path),
+            restoreFocus: false,
+          },
+        );
+        if (!savedPath) {
+          return;
+        }
+
+        nextPathToClose = savedPath;
+      }
+
+      tabPathsToClose.push(nextPathToClose);
+    }
 
     useLayoutStore.getState().closePane(closingPaneId);
 
-    // Clean up tabs that are no longer in any pane
-    if (closingPaneState) {
-      const updatedLayout = useLayoutStore.getState();
-      for (const tabId of closingPaneState.tabIds) {
-        const stillExists = Object.values(updatedLayout.panes).some((ps) =>
-          ps.tabIds.includes(tabId),
-        );
-        if (!stillExists) {
-          // Find the tab by ID and close it from workspace
-          const tab = useWorkspaceStore.getState().noteTabs.find((t) => t.id === tabId);
-          if (tab) {
-            closeTab(tab.file.path);
-          }
-        }
-      }
+    for (const tabPath of tabPathsToClose) {
+      closeTab(tabPath);
     }
 
     // Sync workspace active tab to new active pane
@@ -656,7 +735,7 @@ export const useDesktopAppController = (
         requestEditorFocus("preserve");
       }
     }
-  }, [activateTab, closeTab, requestEditorFocus]);
+  }, [activeFile?.path, activateTab, closeTab, paneCount, persistNoteDraft, requestEditorFocus]);
 
   const focusNextPane = useCallback(() => {
     useLayoutStore.getState().focusNextPane();
@@ -1593,8 +1672,8 @@ export const useDesktopAppController = (
               section: "View",
               kind: "command" as const,
               onSelect: () => {
-                splitRight();
                 setIsPaletteOpen(false);
+                splitRight();
               },
             },
             {
@@ -1605,13 +1684,13 @@ export const useDesktopAppController = (
               section: "View",
               kind: "command" as const,
               onSelect: () => {
-                splitDown();
                 setIsPaletteOpen(false);
+                splitDown();
               },
             },
           ]
         : []),
-      ...(Object.keys(useLayoutStore.getState().panes).length > 1
+      ...(paneCount > 1
         ? [
             {
               id: "close-pane",
@@ -1621,8 +1700,8 @@ export const useDesktopAppController = (
               section: "View",
               kind: "command" as const,
               onSelect: () => {
-                closeActivePane();
                 setIsPaletteOpen(false);
+                void closeActivePane();
               },
             },
             {
@@ -1633,8 +1712,8 @@ export const useDesktopAppController = (
               section: "View",
               kind: "command" as const,
               onSelect: () => {
-                focusNextPane();
                 setIsPaletteOpen(false);
+                focusNextPane();
               },
             },
             {
@@ -1645,8 +1724,8 @@ export const useDesktopAppController = (
               section: "View",
               kind: "command" as const,
               onSelect: () => {
-                focusPreviousPane();
                 setIsPaletteOpen(false);
+                focusPreviousPane();
               },
             },
           ]
@@ -1760,6 +1839,7 @@ export const useDesktopAppController = (
       showOutline,
       splitRight,
       splitDown,
+      paneCount,
       closeActivePane,
       closeTabFromActivePane,
       focusNextPane,
@@ -2406,7 +2486,7 @@ export const useDesktopAppController = (
       }
 
       if (command === "close-pane") {
-        closeActivePane();
+        await closeActivePane();
         return;
       }
 

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -473,10 +473,14 @@ export const useDesktopAppController = (
 
       const currentRootPath = useWorkspaceStore.getState().rootPath;
       const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(filePath);
+      const nextTabId = toPathKey(filePath);
+      const layoutState = useLayoutStore.getState();
+      const owningPaneId = layoutState.getPaneForTab(nextTabId);
       activateTab(filePath);
-      useLayoutStore
-        .getState()
-        .activateTabInPane(useLayoutStore.getState().activePaneId, toPathKey(filePath));
+      if (owningPaneId) {
+        layoutState.setActivePaneId(owningPaneId);
+        layoutState.activateTabInPane(owningPaneId, nextTabId);
+      }
       setIsWorkspaceMode(isFileInsideWorkspace(filePath, currentRootPath));
       if (options?.recordHistory) {
         pushHistory(filePath);
@@ -558,20 +562,33 @@ export const useDesktopAppController = (
       closeOtherTabs(filePath);
       const layoutState = useLayoutStore.getState();
       const nextPanes = Object.fromEntries(
-        Object.entries(layoutState.panes).map(([paneKey, pane]) => {
-          const nextTabIds = pane.tabIds.filter((tabId) => tabId === activeTabId);
-          return [
-            paneKey,
-            {
-              tabIds: nextTabIds,
-              activeTabId: nextTabIds[0] ?? null,
-            },
-          ];
-        }),
+        Object.entries(layoutState.panes)
+          .map(([paneKey, pane]) => {
+            const nextTabIds = pane.tabIds.filter((tabId) => tabId === activeTabId);
+            if (nextTabIds.length === 0) {
+              return null;
+            }
+
+            return [
+              paneKey,
+              {
+                tabIds: nextTabIds,
+                activeTabId: nextTabIds[0] ?? null,
+              },
+            ] as const;
+          })
+          .filter(Boolean) as Array<
+          readonly [string, { tabIds: string[]; activeTabId: string | null }]
+        >,
       );
-      useLayoutStore
-        .getState()
-        .restoreLayout(layoutState.root, layoutState.activePaneId, nextPanes);
+      const nextActivePaneId = nextPanes[layoutState.activePaneId]
+        ? layoutState.activePaneId
+        : Object.keys(nextPanes)[0];
+      if (!nextActivePaneId) {
+        useLayoutStore.getState().resetLayout();
+        return;
+      }
+      useLayoutStore.getState().restoreLayout(layoutState.root, nextActivePaneId, nextPanes);
     },
     [activeFile?.path, closeOtherTabs, persistNoteDraft],
   );

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -630,8 +630,13 @@ export const useDesktopAppController = (
         closeTab(nextFilePath);
       }
 
+      if (updatedLayout.panes[activePaneId]?.tabIds.length === 0 && paneCount > 1) {
+        updatedLayout.closePane(activePaneId);
+      }
+
       // Sync workspace active tab to the pane's new active tab
-      const currentPaneState = updatedLayout.panes[activePaneId];
+      const nextLayoutState = useLayoutStore.getState();
+      const currentPaneState = nextLayoutState.panes[nextLayoutState.activePaneId];
       if (currentPaneState?.activeTabId) {
         const nextTab = useWorkspaceStore
           .getState()
@@ -647,7 +652,15 @@ export const useDesktopAppController = (
         }
       }
     },
-    [activeFile?.path, activateTab, closeTab, getTabByPath, persistNoteDraft, requestEditorFocus],
+    [
+      activeFile?.path,
+      activateTab,
+      closeTab,
+      getTabByPath,
+      paneCount,
+      persistNoteDraft,
+      requestEditorFocus,
+    ],
   );
 
   const splitRight = useCallback(() => {

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -587,17 +587,19 @@ export const useDesktopAppController = (
 
   const closeTabFromActivePane = useCallback(
     async (filePath: string) => {
-      const tabId = toPathKey(filePath);
       const layoutState = useLayoutStore.getState();
-      const paneState = layoutState.panes[layoutState.activePaneId];
-      if (!paneState || !paneState.tabIds.includes(tabId)) {
+      const activePaneId = layoutState.activePaneId;
+      const paneState = layoutState.panes[activePaneId];
+      let nextFilePath = filePath;
+      let nextTabId = toPathKey(nextFilePath);
+      if (!paneState || !paneState.tabIds.includes(nextTabId)) {
         return;
       }
 
       // Save dirty tab first
-      const targetTab = getTabByPath(filePath);
+      const targetTab = getTabByPath(nextFilePath);
       if (targetTab?.isDirty) {
-        const isClosingActiveTab = isSamePath(activeFile?.path, filePath);
+        const isClosingActiveTab = isSamePath(activeFile?.path, nextFilePath);
         const savedPath = await persistNoteDraft(
           {
             draftContent: targetTab.draftContent,
@@ -610,24 +612,26 @@ export const useDesktopAppController = (
           },
         );
         if (!savedPath) return;
+        nextFilePath = savedPath;
+        nextTabId = toPathKey(savedPath);
       }
 
       // Remove from layout pane
-      useLayoutStore.getState().removeTabFromPane(layoutState.activePaneId, tabId);
+      useLayoutStore.getState().removeTabFromPane(activePaneId, nextTabId);
 
       // Check if tab still exists in another pane
       const updatedLayout = useLayoutStore.getState();
       const tabStillInOtherPane = Object.entries(updatedLayout.panes).some(
-        ([paneId, ps]) => paneId !== layoutState.activePaneId && ps.tabIds.includes(tabId),
+        ([paneId, ps]) => paneId !== activePaneId && ps.tabIds.includes(nextTabId),
       );
 
       if (!tabStillInOtherPane) {
         // Tab not in any other pane — close from workspace store too
-        closeTab(filePath);
+        closeTab(nextFilePath);
       }
 
       // Sync workspace active tab to the pane's new active tab
-      const currentPaneState = updatedLayout.panes[layoutState.activePaneId];
+      const currentPaneState = updatedLayout.panes[activePaneId];
       if (currentPaneState?.activeTabId) {
         const nextTab = useWorkspaceStore
           .getState()
@@ -1086,12 +1090,19 @@ export const useDesktopAppController = (
       try {
         await glyph.deleteFolder(folderPath);
         setSidebarNodes((prev) => removeSidebarPath(prev, folderPath));
+        const removedLayoutTabIds = useWorkspaceStore
+          .getState()
+          .noteTabs.filter((tab) => isFileInsideWorkspace(tab.file.path, folderPath))
+          .map((tab) => tab.id);
         Array.from(
           new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, folderPath))),
         ).forEach((entry) => {
           removeHistoryPath(entry);
         });
         removeTabsInFolder(folderPath);
+        for (const tabId of removedLayoutTabIds) {
+          useLayoutStore.getState().removeTabFromAllPanes(tabId);
+        }
 
         if (rootPath && isSamePath(rootPath, folderPath)) {
           setWorkspace({ rootPath: "", tree: [], activeFile: null });
@@ -1210,12 +1221,25 @@ export const useDesktopAppController = (
       try {
         const { oldPath, newPath } = await glyph.renameFolder(folderPath, newName);
         setSidebarNodes((prev) => renameSidebarFolder(prev, oldPath, newPath, newName));
+        const layoutTabRemaps = useWorkspaceStore
+          .getState()
+          .noteTabs.filter((tab) => isFileInsideWorkspace(tab.file.path, oldPath))
+          .map(
+            (tab) =>
+              [
+                toPathKey(tab.file.path),
+                toPathKey(getRenamedFolderFilePath(oldPath, newPath, tab.file.path)),
+              ] as const,
+          );
         Array.from(
           new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, oldPath))),
         ).forEach((entry) => {
           replaceHistoryPath(entry, getRenamedFolderFilePath(oldPath, newPath, entry));
         });
         remapTabsForFolderRename(oldPath, newPath);
+        for (const [oldTabId, nextTabId] of layoutTabRemaps) {
+          useLayoutStore.getState().replaceTabId(oldTabId, nextTabId);
+        }
 
         // If the renamed folder was the workspace root, reopen to restart the watcher
         if (rootPath && isSamePath(rootPath, oldPath)) {
@@ -2171,9 +2195,10 @@ export const useDesktopAppController = (
 
           const prunedRoot = pruneTree(savedLayout.root);
           if (prunedRoot) {
-            useLayoutStore
-              .getState()
-              .restoreLayout(prunedRoot, savedLayout.activePaneId, validPanes);
+            const nextActivePaneId = validPanes[savedLayout.activePaneId]
+              ? savedLayout.activePaneId
+              : Object.keys(validPanes)[0];
+            useLayoutStore.getState().restoreLayout(prunedRoot, nextActivePaneId, validPanes);
           } else if (bootTabs.length > 0) {
             useLayoutStore.getState().initializePane(
               bootTabs.map((t) => t.id),

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -9,6 +9,7 @@ import {
   getShortcutDisplay,
 } from "@/shared/shortcuts";
 import type { DirectoryNode, FileDocument, TabMovePosition } from "@/shared/workspace";
+import { useLayoutStore } from "@/store/layout";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
 import { applyTheme } from "@/theme/themes";
@@ -337,6 +338,7 @@ export const useDesktopAppController = (
           replaceTabPath(previousPath, nextFile);
           replaceHistoryPath(previousPath, nextFile.path);
           await syncTrackedPaths(previousPath, nextFile.path);
+          useLayoutStore.getState().replaceTabId(toPathKey(previousPath), toPathKey(nextFile.path));
           currentPath = nextFile.path;
 
           if (options?.restoreFocus) {
@@ -399,6 +401,9 @@ export const useDesktopAppController = (
       const currentRootPath = useWorkspaceStore.getState().rootPath;
       const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(file.path);
       setActiveFile(file);
+      useLayoutStore
+        .getState()
+        .addTabToPane(useLayoutStore.getState().activePaneId, toPathKey(file.path));
       setIsWorkspaceMode(isFileInsideWorkspace(file.path, currentRootPath));
       setSidebarNodes((prev) => upsertSidebarFile(prev, file));
       if (options?.recordHistory) {
@@ -443,6 +448,9 @@ export const useDesktopAppController = (
       const currentRootPath = useWorkspaceStore.getState().rootPath;
       const shouldPreserveFocus = useSessionStore.getState().hasDocumentScroll(filePath);
       activateTab(filePath);
+      useLayoutStore
+        .getState()
+        .activateTabInPane(useLayoutStore.getState().activePaneId, toPathKey(filePath));
       setIsWorkspaceMode(isFileInsideWorkspace(filePath, currentRootPath));
       if (options?.recordHistory) {
         pushHistory(filePath);
@@ -531,43 +539,206 @@ export const useDesktopAppController = (
     [moveTab],
   );
 
+  // ── Split view methods ───────────────────────────────────────────
+
+  const closeTabFromActivePane = useCallback(
+    async (filePath: string) => {
+      const tabId = toPathKey(filePath);
+      const layoutState = useLayoutStore.getState();
+      const paneState = layoutState.panes[layoutState.activePaneId];
+      if (!paneState || !paneState.tabIds.includes(tabId)) {
+        return;
+      }
+
+      // Save dirty tab first
+      const targetTab = getTabByPath(filePath);
+      if (targetTab?.isDirty) {
+        const isClosingActiveTab = isSamePath(activeFile?.path, filePath);
+        const savedPath = await persistNoteDraft(
+          {
+            draftContent: targetTab.draftContent,
+            file: targetTab.file,
+            isDirty: targetTab.isDirty,
+          },
+          {
+            isActive: isClosingActiveTab,
+            restoreFocus: isClosingActiveTab,
+          },
+        );
+        if (!savedPath) return;
+      }
+
+      // Remove from layout pane
+      useLayoutStore.getState().removeTabFromPane(layoutState.activePaneId, tabId);
+
+      // Check if tab still exists in another pane
+      const updatedLayout = useLayoutStore.getState();
+      const tabStillInOtherPane = Object.entries(updatedLayout.panes).some(
+        ([paneId, ps]) => paneId !== layoutState.activePaneId && ps.tabIds.includes(tabId),
+      );
+
+      if (!tabStillInOtherPane) {
+        // Tab not in any other pane — close from workspace store too
+        closeTab(filePath);
+      }
+
+      // Sync workspace active tab to the pane's new active tab
+      const currentPaneState = updatedLayout.panes[layoutState.activePaneId];
+      if (currentPaneState?.activeTabId) {
+        const nextTab = useWorkspaceStore
+          .getState()
+          .noteTabs.find((t) => t.id === currentPaneState.activeTabId);
+        if (nextTab) {
+          activateTab(nextTab.file.path);
+          const currentRootPath = useWorkspaceStore.getState().rootPath;
+          setIsWorkspaceMode(isFileInsideWorkspace(nextTab.file.path, currentRootPath));
+          const shouldPreserveFocus = useSessionStore
+            .getState()
+            .hasDocumentScroll(nextTab.file.path);
+          requestEditorFocus(shouldPreserveFocus ? "preserve" : "end");
+        }
+      }
+    },
+    [activeFile?.path, activateTab, closeTab, getTabByPath, persistNoteDraft, requestEditorFocus],
+  );
+
+  const splitRight = useCallback(() => {
+    const layoutState = useLayoutStore.getState();
+    const paneState = layoutState.panes[layoutState.activePaneId];
+    if (!paneState?.activeTabId) return;
+    useLayoutStore.getState().splitPane("horizontal");
+  }, []);
+
+  const splitDown = useCallback(() => {
+    const layoutState = useLayoutStore.getState();
+    const paneState = layoutState.panes[layoutState.activePaneId];
+    if (!paneState?.activeTabId) return;
+    useLayoutStore.getState().splitPane("vertical");
+  }, []);
+
+  const closeActivePane = useCallback(() => {
+    const layoutState = useLayoutStore.getState();
+    // Don't close the last pane
+    if (Object.keys(layoutState.panes).length <= 1) return;
+
+    const closingPaneId = layoutState.activePaneId;
+    const closingPaneState = layoutState.panes[closingPaneId];
+
+    useLayoutStore.getState().closePane(closingPaneId);
+
+    // Clean up tabs that are no longer in any pane
+    if (closingPaneState) {
+      const updatedLayout = useLayoutStore.getState();
+      for (const tabId of closingPaneState.tabIds) {
+        const stillExists = Object.values(updatedLayout.panes).some((ps) =>
+          ps.tabIds.includes(tabId),
+        );
+        if (!stillExists) {
+          // Find the tab by ID and close it from workspace
+          const tab = useWorkspaceStore.getState().noteTabs.find((t) => t.id === tabId);
+          if (tab) {
+            closeTab(tab.file.path);
+          }
+        }
+      }
+    }
+
+    // Sync workspace active tab to new active pane
+    const updatedLayout = useLayoutStore.getState();
+    const newPaneState = updatedLayout.panes[updatedLayout.activePaneId];
+    if (newPaneState?.activeTabId) {
+      const nextTab = useWorkspaceStore
+        .getState()
+        .noteTabs.find((t) => t.id === newPaneState.activeTabId);
+      if (nextTab) {
+        activateTab(nextTab.file.path);
+        requestEditorFocus("preserve");
+      }
+    }
+  }, [activateTab, closeTab, requestEditorFocus]);
+
+  const focusNextPane = useCallback(() => {
+    useLayoutStore.getState().focusNextPane();
+    const updatedLayout = useLayoutStore.getState();
+    const paneState = updatedLayout.panes[updatedLayout.activePaneId];
+    if (paneState?.activeTabId) {
+      const nextTab = useWorkspaceStore
+        .getState()
+        .noteTabs.find((t) => t.id === paneState.activeTabId);
+      if (nextTab) {
+        activateTab(nextTab.file.path);
+        requestEditorFocus("preserve");
+      }
+    }
+  }, [activateTab, requestEditorFocus]);
+
+  const focusPreviousPane = useCallback(() => {
+    useLayoutStore.getState().focusPreviousPane();
+    const updatedLayout = useLayoutStore.getState();
+    const paneState = updatedLayout.panes[updatedLayout.activePaneId];
+    if (paneState?.activeTabId) {
+      const nextTab = useWorkspaceStore
+        .getState()
+        .noteTabs.find((t) => t.id === paneState.activeTabId);
+      if (nextTab) {
+        activateTab(nextTab.file.path);
+        requestEditorFocus("preserve");
+      }
+    }
+  }, [activateTab, requestEditorFocus]);
+
   const activateTabByIndex = useCallback(
     async (index: number) => {
-      const targetIndex = getDirectTabTargetIndex(index, noteTabs.length);
+      const layoutState = useLayoutStore.getState();
+      const paneState = layoutState.panes[layoutState.activePaneId];
+      if (!paneState) return;
+
+      const paneTabs = paneState.tabIds
+        .map((id) => useWorkspaceStore.getState().noteTabs.find((t) => t.id === id))
+        .filter(Boolean);
+      const targetIndex = getDirectTabTargetIndex(index, paneTabs.length);
       if (targetIndex === null) {
         return;
       }
 
-      const targetTab = noteTabs[targetIndex];
+      const targetTab = paneTabs[targetIndex];
       if (!targetTab) {
         return;
       }
 
       await activateNoteTab(targetTab.file.path, { recordHistory: true });
     },
-    [activateNoteTab, noteTabs],
+    [activateNoteTab],
   );
 
   const activateAdjacentNoteTab = useCallback(
     async (direction: -1 | 1) => {
-      if (noteTabs.length <= 1 || !activeTabId) {
+      const layoutState = useLayoutStore.getState();
+      const paneState = layoutState.panes[layoutState.activePaneId];
+      if (!paneState || paneState.tabIds.length <= 1 || !paneState.activeTabId) {
         return;
       }
 
-      const currentIndex = noteTabs.findIndex((tab) => tab.id === activeTabId);
+      const currentIndex = paneState.tabIds.indexOf(paneState.activeTabId);
       if (currentIndex < 0) {
         return;
       }
 
-      const targetIndex = (currentIndex + direction + noteTabs.length) % noteTabs.length;
-      const targetTab = noteTabs[targetIndex];
+      const targetIndex =
+        (currentIndex + direction + paneState.tabIds.length) % paneState.tabIds.length;
+      const targetTabId = paneState.tabIds[targetIndex];
+      if (!targetTabId) {
+        return;
+      }
+
+      const targetTab = useWorkspaceStore.getState().noteTabs.find((t) => t.id === targetTabId);
       if (!targetTab) {
         return;
       }
 
       await activateNoteTab(targetTab.file.path, { recordHistory: true });
     },
-    [activateNoteTab, activeTabId, noteTabs],
+    [activateNoteTab],
   );
 
   const openFile = useCallback(
@@ -623,6 +794,9 @@ export const useDesktopAppController = (
     setIsPaletteOpen(false);
     const file = await glyph.createFile(baseDir, `Untitled-${Date.now()}.md`);
     setActiveFile(file);
+    useLayoutStore
+      .getState()
+      .addTabToPane(useLayoutStore.getState().activePaneId, toPathKey(file.path));
     setIsWorkspaceMode(true);
 
     // Find which top-level workspace directory node owns the new file.
@@ -811,6 +985,7 @@ export const useDesktopAppController = (
         setSidebarNodes((prev) => removeSidebarPath(prev, filePath));
         removeHistoryPath(filePath);
         await syncTrackedPaths(filePath);
+        useLayoutStore.getState().removeTabFromAllPanes(toPathKey(filePath));
         const nextActivePath = closeTab(filePath);
         if (nextActivePath) {
           const currentRootPath = useWorkspaceStore.getState().rootPath;
@@ -895,6 +1070,7 @@ export const useDesktopAppController = (
           pinnedFiles: nextPinnedFiles,
         });
         removeHistoryPath(targetPath);
+        useLayoutStore.getState().removeTabFromAllPanes(toPathKey(targetPath));
         const nextActivePath = closeTab(targetPath);
         if (nextActivePath) {
           const currentRootPath = useWorkspaceStore.getState().rootPath;
@@ -936,6 +1112,7 @@ export const useDesktopAppController = (
         await syncTrackedPaths(filePath, renamedFile.path);
         if (getTabByPath(filePath)) {
           replaceTabPath(filePath, renamedFile);
+          useLayoutStore.getState().replaceTabId(toPathKey(filePath), toPathKey(renamedFile.path));
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to rename file");
@@ -1379,7 +1556,7 @@ export const useDesktopAppController = (
               onSelect: () => {
                 const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
                 if (currentActiveTab) {
-                  void closeNoteTab(currentActiveTab.file.path);
+                  void closeTabFromActivePane(currentActiveTab.file.path);
                 }
                 setIsPaletteOpen(false);
               },
@@ -1400,6 +1577,74 @@ export const useDesktopAppController = (
                 if (currentActiveTab) {
                   void closeOtherNoteTabs(currentActiveTab.file.path);
                 }
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
+      ...(activeFile
+        ? [
+            {
+              id: "split-right",
+              title: "Split Right",
+              subtitle: "Open a split pane to the right",
+              shortcut: getShortcutDisplay(shortcuts, "split-right", appInfo?.platform),
+              section: "View",
+              kind: "command" as const,
+              onSelect: () => {
+                splitRight();
+                setIsPaletteOpen(false);
+              },
+            },
+            {
+              id: "split-down",
+              title: "Split Down",
+              subtitle: "Open a split pane below",
+              shortcut: getShortcutDisplay(shortcuts, "split-down", appInfo?.platform),
+              section: "View",
+              kind: "command" as const,
+              onSelect: () => {
+                splitDown();
+                setIsPaletteOpen(false);
+              },
+            },
+          ]
+        : []),
+      ...(Object.keys(useLayoutStore.getState().panes).length > 1
+        ? [
+            {
+              id: "close-pane",
+              title: "Close Pane",
+              subtitle: "Close the active split pane",
+              shortcut: getShortcutDisplay(shortcuts, "close-pane", appInfo?.platform),
+              section: "View",
+              kind: "command" as const,
+              onSelect: () => {
+                closeActivePane();
+                setIsPaletteOpen(false);
+              },
+            },
+            {
+              id: "focus-next-pane",
+              title: "Focus Next Pane",
+              subtitle: "Move focus to the next split pane",
+              shortcut: getShortcutDisplay(shortcuts, "focus-next-pane", appInfo?.platform),
+              section: "View",
+              kind: "command" as const,
+              onSelect: () => {
+                focusNextPane();
+                setIsPaletteOpen(false);
+              },
+            },
+            {
+              id: "focus-previous-pane",
+              title: "Focus Previous Pane",
+              subtitle: "Move focus to the previous split pane",
+              shortcut: getShortcutDisplay(shortcuts, "focus-previous-pane", appInfo?.platform),
+              section: "View",
+              kind: "command" as const,
+              onSelect: () => {
+                focusPreviousPane();
                 setIsPaletteOpen(false);
               },
             },
@@ -1512,6 +1757,12 @@ export const useDesktopAppController = (
       saveSettings,
       shortcuts,
       showOutline,
+      splitRight,
+      splitDown,
+      closeActivePane,
+      closeTabFromActivePane,
+      focusNextPane,
+      focusPreviousPane,
       triggerUpdateAction,
       syncOpenedFile,
       syncWorkspace,
@@ -1571,7 +1822,7 @@ export const useDesktopAppController = (
         return;
       }
 
-      await closeNoteTab(currentActiveTab.file.path);
+      await closeTabFromActivePane(currentActiveTab.file.path);
     },
     closeOtherTabs: async () => {
       const currentActiveTab = useWorkspaceStore.getState().getActiveTab();
@@ -1595,6 +1846,11 @@ export const useDesktopAppController = (
     navigateForward,
     requestFindInNote,
     triggerUpdateAction,
+    splitRight,
+    splitDown,
+    closeActivePane,
+    focusNextPane,
+    focusPreviousPane,
     isPaletteOpen,
     isSettingsOpen,
     setIsPaletteOpen,
@@ -1794,6 +2050,17 @@ export const useDesktopAppController = (
       setSidebarNodes(nextSidebarNodes);
       setExpandedFolderPaths(Array.from(nextExpandedFolders));
       setHasHydratedSidebar(true);
+
+      // Initialize layout store with current tabs
+      const bootTabs = useWorkspaceStore.getState().noteTabs;
+      const bootActiveTabId = useWorkspaceStore.getState().activeTabId;
+      if (bootTabs.length > 0) {
+        useLayoutStore.getState().initializePane(
+          bootTabs.map((t) => t.id),
+          bootActiveTabId,
+        );
+      }
+
       requestEditorFocus(bootFocusMode);
       setHasBooted(true);
     };
@@ -2023,7 +2290,32 @@ export const useDesktopAppController = (
           return;
         }
 
-        await closeNoteTab(currentActiveTab.file.path);
+        await closeTabFromActivePane(currentActiveTab.file.path);
+        return;
+      }
+
+      if (command === "split-right") {
+        splitRight();
+        return;
+      }
+
+      if (command === "split-down") {
+        splitDown();
+        return;
+      }
+
+      if (command === "close-pane") {
+        closeActivePane();
+        return;
+      }
+
+      if (command === "focus-next-pane") {
+        focusNextPane();
+        return;
+      }
+
+      if (command === "focus-previous-pane") {
+        focusPreviousPane();
         return;
       }
 
@@ -2075,13 +2367,18 @@ export const useDesktopAppController = (
     });
   }, [
     activeFile,
-    closeNoteTab,
+    closeTabFromActivePane,
     activateAdjacentNoteTab,
     createNote,
     draftContent,
     getActiveTab,
     persistNoteDraft,
     setError,
+    splitRight,
+    splitDown,
+    closeActivePane,
+    focusNextPane,
+    focusPreviousPane,
     syncOpenedFile,
     syncWorkspace,
     glyph,
@@ -2107,6 +2404,12 @@ export const useDesktopAppController = (
     clearOutlineJumpRequest,
     closeNoteTab,
     closeOtherNoteTabs,
+    closeTabFromActivePane,
+    splitRight,
+    splitDown,
+    closeActivePane,
+    focusNextPane,
+    focusPreviousPane,
     createNote,
     createFolder,
     draftContent,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -23,6 +23,11 @@ type UseKeyboardShortcutsOptions = {
   navigateForward: () => Promise<void>;
   requestFindInNote: () => void;
   triggerUpdateAction: () => Promise<void>;
+  splitRight: () => void;
+  splitDown: () => void;
+  closeActivePane: () => void;
+  focusNextPane: () => void;
+  focusPreviousPane: () => void;
   isPaletteOpen: boolean;
   isSettingsOpen: boolean;
   setIsPaletteOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -53,6 +58,11 @@ export function useKeyboardShortcuts({
   navigateForward,
   requestFindInNote,
   triggerUpdateAction,
+  splitRight,
+  splitDown,
+  closeActivePane,
+  focusNextPane,
+  focusPreviousPane,
   isPaletteOpen,
   isSettingsOpen,
   setIsPaletteOpen,
@@ -155,6 +165,11 @@ export function useKeyboardShortcuts({
         "zoom-in",
         "zoom-out",
         "zoom-reset",
+        "split-right",
+        "split-down",
+        "close-pane",
+        "focus-next-pane",
+        "focus-previous-pane",
       ]);
       const globalShortcut = shortcuts.find(
         (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys, platform),
@@ -206,6 +221,21 @@ export function useKeyboardShortcuts({
             break;
           case "zoom-reset":
             void setEditorScale(100);
+            break;
+          case "split-right":
+            splitRight();
+            break;
+          case "split-down":
+            splitDown();
+            break;
+          case "close-pane":
+            closeActivePane();
+            break;
+          case "focus-next-pane":
+            focusNextPane();
+            break;
+          case "focus-previous-pane":
+            focusPreviousPane();
             break;
         }
         return;
@@ -287,6 +317,11 @@ export function useKeyboardShortcuts({
     navigateForward,
     requestFindInNote,
     triggerUpdateAction,
+    splitRight,
+    splitDown,
+    closeActivePane,
+    focusNextPane,
+    focusPreviousPane,
     isPaletteOpen,
     isSettingsOpen,
     setIsPaletteOpen,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -25,7 +25,7 @@ type UseKeyboardShortcutsOptions = {
   triggerUpdateAction: () => Promise<void>;
   splitRight: () => void;
   splitDown: () => void;
-  closeActivePane: () => void;
+  closeActivePane: () => Promise<void> | void;
   focusNextPane: () => void;
   focusPreviousPane: () => void;
   isPaletteOpen: boolean;
@@ -229,7 +229,7 @@ export function useKeyboardShortcuts({
             splitDown();
             break;
           case "close-pane":
-            closeActivePane();
+            void closeActivePane();
             break;
           case "focus-next-pane":
             focusNextPane();

--- a/apps/desktop/src/hooks/use-settings-controller.ts
+++ b/apps/desktop/src/hooks/use-settings-controller.ts
@@ -37,10 +37,9 @@ export function useSettingsController({ glyph }: UseSettingsControllerOptions) {
     [saveSettings],
   );
 
-  const shortcuts = useMemo(
-    () => mergeShortcutSettings(settings?.shortcuts),
-    [settings?.shortcuts],
-  );
+  const shortcuts = useMemo(() => {
+    return mergeShortcutSettings(settings?.shortcuts ?? null);
+  }, [settings?.shortcuts]);
 
   useEffect(() => {
     if (!settings) {

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -39,6 +39,7 @@ type ParsedShortcut = {
 
 export type ShortcutEventLike = {
   key: string;
+  code?: string;
   metaKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;
@@ -262,7 +263,38 @@ const NORMALIZED_KEY_ALIASES: Record<string, string> = {
   tab: "tab",
   backspace: "backspace",
   delete: "delete",
+  "\\": "backslash",
+  backslash: "backslash",
 };
+
+const NORMALIZED_CODE_ALIASES: Record<string, string> = {
+  arrowup: "arrowup",
+  arrowdown: "arrowdown",
+  arrowleft: "arrowleft",
+  arrowright: "arrowright",
+  backslash: "backslash",
+  bracketleft: "[",
+  bracketright: "]",
+  comma: ",",
+  period: ".",
+  slash: "/",
+  equal: "=",
+  minus: "-",
+  digit0: "0",
+  digit1: "1",
+  digit2: "2",
+  digit3: "3",
+  digit4: "4",
+  digit5: "5",
+  digit6: "6",
+  digit7: "7",
+  digit8: "8",
+  digit9: "9",
+};
+
+for (const letter of "abcdefghijklmnopqrstuvwxyz") {
+  NORMALIZED_CODE_ALIASES[`key${letter}`] = letter;
+}
 
 const DISPLAY_KEY_ALIASES: Record<string, string> = {
   arrowup: "↑",
@@ -275,6 +307,7 @@ const DISPLAY_KEY_ALIASES: Record<string, string> = {
   tab: "Tab",
   backspace: "Backspace",
   delete: "Delete",
+  backslash: "\\",
 };
 
 const ELECTRON_KEY_ALIASES: Record<string, string> = {
@@ -340,6 +373,19 @@ function normalizeShortcutKeyToken(token: string): string | null {
   }
 
   return lower;
+}
+
+function normalizeShortcutCodeToken(token?: string): string | null {
+  const trimmed = token?.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (NORMALIZED_CODE_ALIASES[trimmed]) {
+    return normalizeShortcutKeyToken(NORMALIZED_CODE_ALIASES[trimmed]);
+  }
+
+  return null;
 }
 
 function formatShortcutKey(key: string): string {
@@ -475,10 +521,11 @@ export function matchShortcut(
   }
 
   const eventKey = normalizeShortcutKeyToken(event.key);
+  const eventCodeKey = normalizeShortcutCodeToken(event.code);
   const primaryPressed = isPrimaryModifierPressed(event, platform);
 
   return (
-    eventKey === parsed.key &&
+    (eventKey === parsed.key || eventCodeKey === parsed.key) &&
     primaryPressed === parsed.primary &&
     event.altKey === parsed.alt &&
     event.shiftKey === parsed.shift

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -18,7 +18,12 @@ export type ShortcutId =
   | "focus-mode"
   | "zoom-in"
   | "zoom-out"
-  | "zoom-reset";
+  | "zoom-reset"
+  | "split-right"
+  | "split-down"
+  | "close-pane"
+  | "focus-next-pane"
+  | "focus-previous-pane";
 
 export type ShortcutDefinition = ShortcutSetting & {
   id: ShortcutId;
@@ -130,6 +135,32 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "zoom-in", label: "Zoom In", keys: `${MODIFIER_TOKENS.cmdOrCtrl} =` },
   { id: "zoom-out", label: "Zoom Out", keys: `${MODIFIER_TOKENS.cmdOrCtrl} -` },
   { id: "zoom-reset", label: "Reset Zoom", keys: `${MODIFIER_TOKENS.cmdOrCtrl} 0` },
+  // ── Split view ───────────────────────────────────────────────
+  {
+    id: "split-right",
+    label: "Split Right",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} \\`,
+  },
+  {
+    id: "split-down",
+    label: "Split Down",
+    keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} \\`,
+  },
+  {
+    id: "close-pane",
+    label: "Close Pane",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} W`,
+  },
+  {
+    id: "focus-next-pane",
+    label: "Focus Next Pane",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} ]`,
+  },
+  {
+    id: "focus-previous-pane",
+    label: "Focus Previous Pane",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} [`,
+  },
 ];
 
 export function getPrimaryShortcutPrefix(platform?: string): string {

--- a/apps/desktop/src/shared/workspace.ts
+++ b/apps/desktop/src/shared/workspace.ts
@@ -161,9 +161,37 @@ export type AppCommand =
   | "focus-mode"
   | "zoom-in"
   | "zoom-out"
-  | "zoom-reset";
+  | "zoom-reset"
+  | "split-right"
+  | "split-down"
+  | "close-pane"
+  | "focus-next-pane"
+  | "focus-previous-pane";
 
 export type ExternalFileTarget = {
   path: string;
   isDirectory: boolean;
+};
+
+// ─── Split View Layout ──────────────────────────────────────────────
+
+export type SplitDirection = "horizontal" | "vertical";
+
+export type PaneNode = {
+  type: "pane";
+  id: string;
+};
+
+export type SplitNode = {
+  type: "split";
+  id: string;
+  direction: SplitDirection;
+  children: [LayoutNode, LayoutNode];
+};
+
+export type LayoutNode = PaneNode | SplitNode;
+
+export type PaneState = {
+  tabIds: string[];
+  activeTabId: string | null;
 };

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -327,43 +327,33 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   removeTabFromPane: (paneId, tabId) => {
-    let result: string | null = null;
+    const pane = get().panes[paneId];
+    if (!pane) {
+      return null;
+    }
 
-    set((state) => {
-      const pane = state.panes[paneId];
-      if (!pane) {
-        return state;
-      }
+    const tabIndex = pane.tabIds.indexOf(tabId);
+    if (tabIndex < 0) {
+      return pane.activeTabId;
+    }
 
-      const tabIndex = pane.tabIds.indexOf(tabId);
-      if (tabIndex < 0) {
-        result = pane.activeTabId;
-        return state;
-      }
+    const nextTabIds = pane.tabIds.filter((id) => id !== tabId);
+    const nextActiveTabId =
+      pane.activeTabId === tabId
+        ? (pane.tabIds[tabIndex - 1] ?? pane.tabIds[tabIndex + 1] ?? null)
+        : pane.activeTabId;
 
-      const nextTabIds = pane.tabIds.filter((id) => id !== tabId);
-      let nextActiveTabId = pane.activeTabId;
-
-      if (pane.activeTabId === tabId) {
-        // Pick adjacent tab
-        const prevTab = pane.tabIds[tabIndex - 1] ?? null;
-        const nextTab = pane.tabIds[tabIndex + 1] ?? null;
-        nextActiveTabId = prevTab ?? nextTab ?? null;
-      }
-
-      result = nextActiveTabId;
-      return {
-        panes: {
-          ...state.panes,
-          [paneId]: {
-            tabIds: nextTabIds,
-            activeTabId: nextActiveTabId,
-          },
+    set((state) => ({
+      panes: {
+        ...state.panes,
+        [paneId]: {
+          tabIds: nextTabIds,
+          activeTabId: nextActiveTabId,
         },
-      };
-    });
+      },
+    }));
 
-    return result;
+    return nextActiveTabId;
   },
 
   activateTabInPane: (paneId, tabId) => {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -149,7 +149,13 @@ type LayoutState = {
     targetTabId: string,
     position: TabMovePosition,
   ) => void;
-  moveTabToPane: (tabId: string, fromPaneId: string, toPaneId: string) => void;
+  moveTabToPane: (
+    tabId: string,
+    fromPaneId: string,
+    toPaneId: string,
+    targetTabId?: string | null,
+    position?: TabMovePosition,
+  ) => void;
   replaceTabId: (oldTabId: string, newTabId: string) => void;
   removeTabFromAllPanes: (tabId: string) => void;
 
@@ -407,7 +413,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     });
   },
 
-  moveTabToPane: (tabId, fromPaneId, toPaneId) => {
+  moveTabToPane: (tabId, fromPaneId, toPaneId, targetTabId, position = "after") => {
     set((state) => {
       const fromPane = state.panes[fromPaneId];
       const toPane = state.panes[toPaneId];
@@ -423,10 +429,19 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
         nextFromActiveTabId = fromPane.tabIds[idx - 1] ?? fromPane.tabIds[idx + 1] ?? null;
       }
 
-      // Add to target pane (avoid duplicates)
-      const nextToTabIds = toPane.tabIds.includes(tabId)
-        ? toPane.tabIds
-        : [...toPane.tabIds, tabId];
+      const targetIdsWithoutTab = toPane.tabIds.filter((id) => id !== tabId);
+      const targetIndex = targetTabId ? targetIdsWithoutTab.indexOf(targetTabId) : -1;
+      const insertAt =
+        targetIndex < 0
+          ? targetIdsWithoutTab.length
+          : position === "before"
+            ? targetIndex
+            : targetIndex + 1;
+      const nextToTabIds = [
+        ...targetIdsWithoutTab.slice(0, insertAt),
+        tabId,
+        ...targetIdsWithoutTab.slice(insertAt),
+      ];
 
       return {
         panes: {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -117,6 +117,20 @@ const collectPaneIdsInOrder = (node: LayoutNode): string[] => {
   return [...collectPaneIdsInOrder(node.children[0]), ...collectPaneIdsInOrder(node.children[1])];
 };
 
+const pruneLayoutTree = (node: LayoutNode, validPaneIds: Set<string>): LayoutNode | null => {
+  if (node.type === "pane") {
+    return validPaneIds.has(node.id) ? node : null;
+  }
+
+  const left = pruneLayoutTree(node.children[0], validPaneIds);
+  const right = pruneLayoutTree(node.children[1], validPaneIds);
+  if (left && right) {
+    return { ...node, children: [left, right] };
+  }
+
+  return left ?? right;
+};
+
 // ─── Store ───────────────────────────────────────────────────────────
 
 type LayoutState = {
@@ -534,7 +548,14 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   restoreLayout: (root, activePaneId, panes) => {
-    const restoredPaneIds = new Set(collectPaneIdsInOrder(root));
+    const validPaneIds = new Set(Object.keys(panes));
+    const prunedRoot = pruneLayoutTree(root, validPaneIds);
+    if (!prunedRoot) {
+      get().resetLayout();
+      return;
+    }
+
+    const restoredPaneIds = new Set(collectPaneIdsInOrder(prunedRoot));
     const restoredPanes = Object.fromEntries(
       Object.entries(panes).filter(([paneId]) => restoredPaneIds.has(paneId)),
     );
@@ -552,13 +573,15 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       const num = match ? Number(match[1]) : 0;
       return Math.max(num, countSplits(node.children[0]), countSplits(node.children[1]));
     };
-    splitCounter = countSplits(root);
+    splitCounter = countSplits(prunedRoot);
 
     // Validate activePaneId exists in the restored tree and pane map
-    const validActivePaneId = restoredPanes[activePaneId] ? activePaneId : getFirstPaneId(root);
+    const validActivePaneId = restoredPanes[activePaneId]
+      ? activePaneId
+      : getFirstPaneId(prunedRoot);
 
     set({
-      root,
+      root: prunedRoot,
       activePaneId: validActivePaneId,
       panes: restoredPanes,
     });

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -534,8 +534,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   restoreLayout: (root, activePaneId, panes) => {
+    const restoredPaneIds = new Set(collectPaneIdsInOrder(root));
+    const restoredPanes = Object.fromEntries(
+      Object.entries(panes).filter(([paneId]) => restoredPaneIds.has(paneId)),
+    );
+
     // Reset counters to avoid ID collisions with restored IDs
-    const maxPaneNum = Object.keys(panes).reduce((max, id) => {
+    const maxPaneNum = Object.keys(restoredPanes).reduce((max, id) => {
       const match = id.match(/^pane-(\d+)$/);
       return match ? Math.max(max, Number(match[1])) : max;
     }, 0);
@@ -549,13 +554,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     };
     splitCounter = countSplits(root);
 
-    // Validate activePaneId exists in panes
-    const validActivePaneId = panes[activePaneId] ? activePaneId : getFirstPaneId(root);
+    // Validate activePaneId exists in the restored tree and pane map
+    const validActivePaneId = restoredPanes[activePaneId] ? activePaneId : getFirstPaneId(root);
 
     set({
       root,
       activePaneId: validActivePaneId,
-      panes,
+      panes: restoredPanes,
     });
   },
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -155,6 +155,7 @@ type LayoutState = {
 
   // ── Bulk initialisation (boot / session restore) ──
   initializePane: (tabIds: string[], activeTabId: string | null) => void;
+  restoreLayout: (root: LayoutNode, activePaneId: string, panes: Record<string, PaneState>) => void;
   resetLayout: () => void;
 };
 
@@ -508,6 +509,32 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
         },
       },
     }));
+  },
+
+  restoreLayout: (root, activePaneId, panes) => {
+    // Reset counters to avoid ID collisions with restored IDs
+    const maxPaneNum = Object.keys(panes).reduce((max, id) => {
+      const match = id.match(/^pane-(\d+)$/);
+      return match ? Math.max(max, Number(match[1])) : max;
+    }, 0);
+    paneCounter = maxPaneNum;
+
+    const countSplits = (node: LayoutNode): number => {
+      if (node.type === "pane") return 0;
+      const match = node.id.match(/^split-(\d+)$/);
+      const num = match ? Number(match[1]) : 0;
+      return Math.max(num, countSplits(node.children[0]), countSplits(node.children[1]));
+    };
+    splitCounter = countSplits(root);
+
+    // Validate activePaneId exists in panes
+    const validActivePaneId = panes[activePaneId] ? activePaneId : getFirstPaneId(root);
+
+    set({
+      root,
+      activePaneId: validActivePaneId,
+      panes,
+    });
   },
 
   resetLayout: () => {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -1,0 +1,522 @@
+import { create } from "zustand";
+
+import type {
+  LayoutNode,
+  PaneNode,
+  PaneState,
+  SplitDirection,
+  SplitNode,
+  TabMovePosition,
+} from "../shared/workspace";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+let paneCounter = 0;
+let splitCounter = 0;
+
+const createPaneId = (): string => `pane-${++paneCounter}`;
+const createSplitId = (): string => `split-${++splitCounter}`;
+
+const DEFAULT_PANE_ID = "pane-0";
+
+const createDefaultPaneState = (): PaneState => ({
+  tabIds: [],
+  activeTabId: null,
+});
+
+/**
+ * Find the parent split of a given pane ID and which child index it is.
+ */
+const findParent = (
+  node: LayoutNode,
+  targetId: string,
+): { parent: SplitNode; childIndex: 0 | 1 } | null => {
+  if (node.type === "pane") {
+    return null;
+  }
+
+  for (const idx of [0, 1] as const) {
+    const child = node.children[idx];
+    if (child.type === "pane" && child.id === targetId) {
+      return { parent: node, childIndex: idx };
+    }
+    if (child.type === "split" && child.id === targetId) {
+      return { parent: node, childIndex: idx };
+    }
+    const found = findParent(child, targetId);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Replace a node in the layout tree by ID. Returns a new tree.
+ */
+const replaceNode = (root: LayoutNode, targetId: string, replacement: LayoutNode): LayoutNode => {
+  if (root.type === "pane") {
+    return root.id === targetId ? replacement : root;
+  }
+
+  if (root.id === targetId) {
+    return replacement;
+  }
+
+  return {
+    ...root,
+    children: [
+      replaceNode(root.children[0], targetId, replacement),
+      replaceNode(root.children[1], targetId, replacement),
+    ],
+  };
+};
+
+/**
+ * Remove a pane from the tree. The sibling takes its parent's place.
+ * Returns null if the pane is the root (can't remove the last pane).
+ */
+const removePaneFromTree = (root: LayoutNode, paneId: string): LayoutNode | null => {
+  if (root.type === "pane") {
+    return root.id === paneId ? null : root;
+  }
+
+  const parentInfo = findParent(root, paneId);
+  if (!parentInfo) {
+    return root;
+  }
+
+  const { parent, childIndex } = parentInfo;
+  const siblingIndex = childIndex === 0 ? 1 : 0;
+  const sibling = parent.children[siblingIndex];
+
+  // Replace the parent split with the sibling
+  return replaceNode(root, parent.id, sibling);
+};
+
+/**
+ * Get the first pane ID in tree order (depth-first, left-first).
+ */
+const getFirstPaneId = (node: LayoutNode): string => {
+  if (node.type === "pane") {
+    return node.id;
+  }
+
+  return getFirstPaneId(node.children[0]);
+};
+
+/**
+ * Collect pane IDs in display order (left-to-right / top-to-bottom).
+ */
+const collectPaneIdsInOrder = (node: LayoutNode): string[] => {
+  if (node.type === "pane") {
+    return [node.id];
+  }
+
+  return [...collectPaneIdsInOrder(node.children[0]), ...collectPaneIdsInOrder(node.children[1])];
+};
+
+// ─── Store ───────────────────────────────────────────────────────────
+
+type LayoutState = {
+  root: LayoutNode;
+  activePaneId: string;
+  panes: Record<string, PaneState>;
+
+  // ── Queries ──
+  getActivePaneState: () => PaneState;
+  getPane: (paneId: string) => PaneState;
+  getAllTabIds: () => string[];
+  getPaneForTab: (tabId: string) => string | null;
+  getPaneCount: () => number;
+  getOrderedPaneIds: () => string[];
+
+  // ── Layout mutations ──
+  splitPane: (direction: SplitDirection, tabIdToCopy?: string | null) => string;
+  closePane: (paneId: string) => void;
+  setActivePaneId: (paneId: string) => void;
+  focusNextPane: () => void;
+  focusPreviousPane: () => void;
+
+  // ── Tab-in-pane mutations ──
+  addTabToPane: (paneId: string, tabId: string) => void;
+  removeTabFromPane: (paneId: string, tabId: string) => string | null;
+  activateTabInPane: (paneId: string, tabId: string) => void;
+  reorderTabInPane: (
+    paneId: string,
+    sourceTabId: string,
+    targetTabId: string,
+    position: TabMovePosition,
+  ) => void;
+  moveTabToPane: (tabId: string, fromPaneId: string, toPaneId: string) => void;
+  replaceTabId: (oldTabId: string, newTabId: string) => void;
+  removeTabFromAllPanes: (tabId: string) => void;
+
+  // ── Bulk initialisation (boot / session restore) ──
+  initializePane: (tabIds: string[], activeTabId: string | null) => void;
+  resetLayout: () => void;
+};
+
+export const useLayoutStore = create<LayoutState>((set, get) => ({
+  root: { type: "pane", id: DEFAULT_PANE_ID } as LayoutNode,
+  activePaneId: DEFAULT_PANE_ID,
+  panes: { [DEFAULT_PANE_ID]: createDefaultPaneState() },
+
+  // ── Queries ────────────────────────────────────────────────────────
+
+  getActivePaneState: () => {
+    const state = get();
+    return state.panes[state.activePaneId] ?? createDefaultPaneState();
+  },
+
+  getPane: (paneId) => {
+    return get().panes[paneId] ?? createDefaultPaneState();
+  },
+
+  getAllTabIds: () => {
+    const seen = new Set<string>();
+    for (const pane of Object.values(get().panes)) {
+      for (const tabId of pane.tabIds) {
+        seen.add(tabId);
+      }
+    }
+    return [...seen];
+  },
+
+  getPaneForTab: (tabId) => {
+    for (const [paneId, pane] of Object.entries(get().panes)) {
+      if (pane.tabIds.includes(tabId)) {
+        return paneId;
+      }
+    }
+    return null;
+  },
+
+  getPaneCount: () => Object.keys(get().panes).length,
+
+  getOrderedPaneIds: () => collectPaneIdsInOrder(get().root),
+
+  // ── Layout mutations ───────────────────────────────────────────────
+
+  splitPane: (direction, tabIdToCopy) => {
+    const state = get();
+    const sourcePaneId = state.activePaneId;
+    const sourcePane = state.panes[sourcePaneId];
+    if (!sourcePane) {
+      return sourcePaneId;
+    }
+
+    const newPaneId = createPaneId();
+    const splitId = createSplitId();
+
+    // The new pane gets a copy of the active tab (or specified tab)
+    const tabToCopy = tabIdToCopy ?? sourcePane.activeTabId;
+    const newPaneState: PaneState = {
+      tabIds: tabToCopy ? [tabToCopy] : [],
+      activeTabId: tabToCopy ?? null,
+    };
+
+    // Wrap the source pane and new pane in a split
+    const sourcePaneNode: PaneNode = { type: "pane", id: sourcePaneId };
+    const newPaneNode: PaneNode = { type: "pane", id: newPaneId };
+    const splitNode: SplitNode = {
+      type: "split",
+      id: splitId,
+      direction,
+      children: [sourcePaneNode, newPaneNode],
+    };
+
+    const nextRoot = replaceNode(state.root, sourcePaneId, splitNode);
+
+    set({
+      root: nextRoot,
+      activePaneId: newPaneId,
+      panes: {
+        ...state.panes,
+        [newPaneId]: newPaneState,
+      },
+    });
+
+    return newPaneId;
+  },
+
+  closePane: (paneId) => {
+    set((state) => {
+      const paneIds = Object.keys(state.panes);
+
+      // Can't close the last pane
+      if (paneIds.length <= 1) {
+        return state;
+      }
+
+      const nextRoot = removePaneFromTree(state.root, paneId);
+      if (!nextRoot) {
+        return state;
+      }
+
+      const { [paneId]: _removed, ...remainingPanes } = state.panes;
+      const nextActivePaneId =
+        state.activePaneId === paneId ? getFirstPaneId(nextRoot) : state.activePaneId;
+
+      return {
+        root: nextRoot,
+        panes: remainingPanes,
+        activePaneId: nextActivePaneId,
+      };
+    });
+  },
+
+  setActivePaneId: (paneId) => {
+    set((state) => {
+      if (state.panes[paneId]) {
+        return { activePaneId: paneId };
+      }
+      return state;
+    });
+  },
+
+  focusNextPane: () => {
+    set((state) => {
+      const ordered = collectPaneIdsInOrder(state.root);
+      const currentIndex = ordered.indexOf(state.activePaneId);
+      const nextIndex = (currentIndex + 1) % ordered.length;
+      return { activePaneId: ordered[nextIndex] };
+    });
+  },
+
+  focusPreviousPane: () => {
+    set((state) => {
+      const ordered = collectPaneIdsInOrder(state.root);
+      const currentIndex = ordered.indexOf(state.activePaneId);
+      const prevIndex = (currentIndex - 1 + ordered.length) % ordered.length;
+      return { activePaneId: ordered[prevIndex] };
+    });
+  },
+
+  // ── Tab-in-pane mutations ──────────────────────────────────────────
+
+  addTabToPane: (paneId, tabId) => {
+    set((state) => {
+      const pane = state.panes[paneId];
+      if (!pane) {
+        return state;
+      }
+
+      // Don't add duplicates
+      if (pane.tabIds.includes(tabId)) {
+        return {
+          panes: {
+            ...state.panes,
+            [paneId]: { ...pane, activeTabId: tabId },
+          },
+        };
+      }
+
+      return {
+        panes: {
+          ...state.panes,
+          [paneId]: {
+            tabIds: [...pane.tabIds, tabId],
+            activeTabId: tabId,
+          },
+        },
+      };
+    });
+  },
+
+  removeTabFromPane: (paneId, tabId) => {
+    let result: string | null = null;
+
+    set((state) => {
+      const pane = state.panes[paneId];
+      if (!pane) {
+        return state;
+      }
+
+      const tabIndex = pane.tabIds.indexOf(tabId);
+      if (tabIndex < 0) {
+        result = pane.activeTabId;
+        return state;
+      }
+
+      const nextTabIds = pane.tabIds.filter((id) => id !== tabId);
+      let nextActiveTabId = pane.activeTabId;
+
+      if (pane.activeTabId === tabId) {
+        // Pick adjacent tab
+        const prevTab = pane.tabIds[tabIndex - 1] ?? null;
+        const nextTab = pane.tabIds[tabIndex + 1] ?? null;
+        nextActiveTabId = prevTab ?? nextTab ?? null;
+      }
+
+      result = nextActiveTabId;
+      return {
+        panes: {
+          ...state.panes,
+          [paneId]: {
+            tabIds: nextTabIds,
+            activeTabId: nextActiveTabId,
+          },
+        },
+      };
+    });
+
+    return result;
+  },
+
+  activateTabInPane: (paneId, tabId) => {
+    set((state) => {
+      const pane = state.panes[paneId];
+      if (!pane || !pane.tabIds.includes(tabId)) {
+        return state;
+      }
+
+      return {
+        panes: {
+          ...state.panes,
+          [paneId]: { ...pane, activeTabId: tabId },
+        },
+      };
+    });
+  },
+
+  reorderTabInPane: (paneId, sourceTabId, targetTabId, position) => {
+    set((state) => {
+      const pane = state.panes[paneId];
+      if (!pane) {
+        return state;
+      }
+
+      const sourceIndex = pane.tabIds.indexOf(sourceTabId);
+      const targetIndex = pane.tabIds.indexOf(targetTabId);
+      if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+        return state;
+      }
+
+      const remaining = pane.tabIds.filter((id) => id !== sourceTabId);
+      const newTargetIndex = remaining.indexOf(targetTabId);
+      if (newTargetIndex < 0) {
+        return state;
+      }
+
+      const insertAt = position === "before" ? newTargetIndex : newTargetIndex + 1;
+      const nextTabIds = [
+        ...remaining.slice(0, insertAt),
+        sourceTabId,
+        ...remaining.slice(insertAt),
+      ];
+
+      return {
+        panes: {
+          ...state.panes,
+          [paneId]: { ...pane, tabIds: nextTabIds },
+        },
+      };
+    });
+  },
+
+  moveTabToPane: (tabId, fromPaneId, toPaneId) => {
+    set((state) => {
+      const fromPane = state.panes[fromPaneId];
+      const toPane = state.panes[toPaneId];
+      if (!fromPane || !toPane) {
+        return state;
+      }
+
+      // Remove from source pane
+      const nextFromTabIds = fromPane.tabIds.filter((id) => id !== tabId);
+      let nextFromActiveTabId = fromPane.activeTabId;
+      if (fromPane.activeTabId === tabId) {
+        const idx = fromPane.tabIds.indexOf(tabId);
+        nextFromActiveTabId = fromPane.tabIds[idx - 1] ?? fromPane.tabIds[idx + 1] ?? null;
+      }
+
+      // Add to target pane (avoid duplicates)
+      const nextToTabIds = toPane.tabIds.includes(tabId)
+        ? toPane.tabIds
+        : [...toPane.tabIds, tabId];
+
+      return {
+        panes: {
+          ...state.panes,
+          [fromPaneId]: { tabIds: nextFromTabIds, activeTabId: nextFromActiveTabId },
+          [toPaneId]: { tabIds: nextToTabIds, activeTabId: tabId },
+        },
+        activePaneId: toPaneId,
+      };
+    });
+  },
+
+  // ── Cross-pane tab mutations ───────────────────────────────────────
+
+  replaceTabId: (oldTabId, newTabId) => {
+    if (oldTabId === newTabId) return;
+    set((state) => {
+      let changed = false;
+      const nextPanes: Record<string, PaneState> = {};
+      for (const [paneId, pane] of Object.entries(state.panes)) {
+        const hasOld = pane.tabIds.includes(oldTabId) || pane.activeTabId === oldTabId;
+        if (!hasOld) {
+          nextPanes[paneId] = pane;
+          continue;
+        }
+        changed = true;
+        nextPanes[paneId] = {
+          tabIds: pane.tabIds.map((id) => (id === oldTabId ? newTabId : id)),
+          activeTabId: pane.activeTabId === oldTabId ? newTabId : pane.activeTabId,
+        };
+      }
+      return changed ? { panes: nextPanes } : state;
+    });
+  },
+
+  removeTabFromAllPanes: (tabId) => {
+    set((state) => {
+      const nextPanes: Record<string, PaneState> = {};
+      let changed = false;
+      for (const [paneId, pane] of Object.entries(state.panes)) {
+        if (!pane.tabIds.includes(tabId)) {
+          nextPanes[paneId] = pane;
+          continue;
+        }
+        changed = true;
+        const nextTabIds = pane.tabIds.filter((id) => id !== tabId);
+        let nextActiveTabId = pane.activeTabId;
+        if (pane.activeTabId === tabId) {
+          const idx = pane.tabIds.indexOf(tabId);
+          nextActiveTabId = pane.tabIds[idx - 1] ?? pane.tabIds[idx + 1] ?? null;
+        }
+        nextPanes[paneId] = {
+          tabIds: nextTabIds,
+          activeTabId: nextActiveTabId,
+        };
+      }
+      return changed ? { panes: nextPanes } : state;
+    });
+  },
+
+  // ── Bulk initialisation ────────────────────────────────────────────
+
+  initializePane: (tabIds, activeTabId) => {
+    set((state) => ({
+      panes: {
+        ...state.panes,
+        [state.activePaneId]: {
+          tabIds,
+          activeTabId,
+        },
+      },
+    }));
+  },
+
+  resetLayout: () => {
+    paneCounter = 0;
+    splitCounter = 0;
+    set({
+      root: { type: "pane", id: DEFAULT_PANE_ID },
+      activePaneId: DEFAULT_PANE_ID,
+      panes: { [DEFAULT_PANE_ID]: createDefaultPaneState() },
+    });
+  },
+}));

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -443,6 +443,23 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
         ...targetIdsWithoutTab.slice(insertAt),
       ];
 
+      if (nextFromTabIds.length === 0 && Object.keys(state.panes).length > 1) {
+        const nextRoot = removePaneFromTree(state.root, fromPaneId);
+        if (!nextRoot) {
+          return state;
+        }
+
+        const { [fromPaneId]: _removed, ...remainingPanes } = state.panes;
+        return {
+          root: nextRoot,
+          panes: {
+            ...remainingPanes,
+            [toPaneId]: { tabIds: nextToTabIds, activeTabId: tabId },
+          },
+          activePaneId: toPaneId,
+        };
+      }
+
       return {
         panes: {
           ...state.panes,

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -18,6 +18,7 @@ type ScrollEntry = {
 type SessionState = {
   hasHydrated: boolean;
   viewerMode: ViewerMode;
+  isSidebarCollapsed: boolean;
   isNotesExpanded: boolean;
   isSkillsExpanded: boolean;
   selectedSkillCollectionId: string | null;
@@ -33,6 +34,7 @@ type SessionState = {
   layoutPanes: Record<string, PaneState> | null;
   setHasHydrated: (value: boolean) => void;
   setViewerMode: (mode: ViewerMode) => void;
+  setSidebarCollapsed: (value: boolean) => void;
   setNotesExpanded: (value: boolean) => void;
   setSkillsExpanded: (value: boolean) => void;
   setSelectedSkillCollectionId: (value: string | null) => void;
@@ -101,6 +103,7 @@ export const useSessionStore = create<SessionState>()(
     (set, get) => ({
       hasHydrated: false,
       viewerMode: "note",
+      isSidebarCollapsed: false,
       isNotesExpanded: true,
       isSkillsExpanded: false,
       selectedSkillCollectionId: null,
@@ -119,6 +122,9 @@ export const useSessionStore = create<SessionState>()(
       },
       setViewerMode: (viewerMode) => {
         set({ viewerMode });
+      },
+      setSidebarCollapsed: (isSidebarCollapsed) => {
+        set({ isSidebarCollapsed });
       },
       setNotesExpanded: (isNotesExpanded) => {
         set({ isNotesExpanded });
@@ -236,6 +242,7 @@ export const useSessionStore = create<SessionState>()(
       storage: createJSONStorage(() => window.localStorage),
       partialize: (state) => ({
         viewerMode: state.viewerMode,
+        isSidebarCollapsed: state.isSidebarCollapsed,
         isNotesExpanded: state.isNotesExpanded,
         isSkillsExpanded: state.isSkillsExpanded,
         selectedSkillCollectionId: state.selectedSkillCollectionId,

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 import { normalizePath } from "@/lib/paths";
 import type { SkillDocumentKind } from "@/shared/skills";
+import type { LayoutNode, PaneState } from "@/shared/workspace";
 
 const SESSION_STORAGE_KEY = "glyph.editor-session";
 const MAX_SCROLL_ENTRIES = 160;
@@ -27,6 +28,9 @@ type SessionState = {
   skillDocumentKind: SkillDocumentKind;
   skillDocumentKindsById: Record<string, SkillDocumentKind>;
   scrollPositions: Record<string, ScrollEntry>;
+  layoutRoot: LayoutNode | null;
+  layoutActivePaneId: string | null;
+  layoutPanes: Record<string, PaneState> | null;
   setHasHydrated: (value: boolean) => void;
   setViewerMode: (mode: ViewerMode) => void;
   setNotesExpanded: (value: boolean) => void;
@@ -44,6 +48,16 @@ type SessionState = {
   setDocumentScroll: (targetPath: string | null, top: number) => void;
   getDocumentScroll: (targetPath: string | null | undefined) => number;
   hasDocumentScroll: (targetPath: string | null | undefined) => boolean;
+  setLayoutSession: (
+    root: LayoutNode,
+    activePaneId: string,
+    panes: Record<string, PaneState>,
+  ) => void;
+  getLayoutSession: () => {
+    root: LayoutNode;
+    activePaneId: string;
+    panes: Record<string, PaneState>;
+  } | null;
 };
 
 const toScrollKey = (targetPath: string) => normalizePath(targetPath).toLowerCase();
@@ -97,6 +111,9 @@ export const useSessionStore = create<SessionState>()(
       skillDocumentKind: "skill",
       skillDocumentKindsById: {},
       scrollPositions: {},
+      layoutRoot: null,
+      layoutActivePaneId: null,
+      layoutPanes: null,
       setHasHydrated: (value) => {
         set({ hasHydrated: value });
       },
@@ -195,6 +212,24 @@ export const useSessionStore = create<SessionState>()(
 
         return Object.hasOwn(get().scrollPositions, toScrollKey(targetPath));
       },
+      setLayoutSession: (root, activePaneId, panes) => {
+        set({
+          layoutRoot: root,
+          layoutActivePaneId: activePaneId,
+          layoutPanes: panes,
+        });
+      },
+      getLayoutSession: () => {
+        const state = get();
+        if (!state.layoutRoot || !state.layoutActivePaneId || !state.layoutPanes) {
+          return null;
+        }
+        return {
+          root: state.layoutRoot,
+          activePaneId: state.layoutActivePaneId,
+          panes: state.layoutPanes,
+        };
+      },
     }),
     {
       name: SESSION_STORAGE_KEY,
@@ -211,6 +246,9 @@ export const useSessionStore = create<SessionState>()(
         skillDocumentKind: state.skillDocumentKind,
         skillDocumentKindsById: state.skillDocumentKindsById,
         scrollPositions: state.scrollPositions,
+        layoutRoot: state.layoutRoot,
+        layoutActivePaneId: state.layoutActivePaneId,
+        layoutPanes: state.layoutPanes,
       }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);

--- a/apps/desktop/src/store/workspace.ts
+++ b/apps/desktop/src/store/workspace.ts
@@ -102,6 +102,7 @@ type WorkspaceState = {
   attachActiveFile: (file: FileDocument) => void;
   updateActiveFile: (file: FileDocument) => void;
   updateDraftContent: (content: string) => void;
+  updateTabDraftContent: (tabId: string, content: string) => void;
   markSaved: (file: FileDocument) => void;
   markTabSaved: (filePath: string, file: FileDocument) => void;
   setSaving: (isSaving: boolean) => void;
@@ -287,6 +288,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         draftContent,
         isDirty: true,
       };
+    }),
+  updateTabDraftContent: (tabId, content) =>
+    set((state) => {
+      const tab = state.noteTabs.find((t) => t.id === tabId);
+      if (!tab) {
+        return state;
+      }
+
+      const noteTabs = state.noteTabs.map((t) =>
+        t.id === tabId ? { ...t, draftContent: content, isDirty: true } : t,
+      );
+
+      // If this is the active tab, also update top-level derived state
+      if (state.activeTabId === tabId) {
+        return { noteTabs, draftContent: content, isDirty: true };
+      }
+
+      return { noteTabs };
     }),
   markSaved: (activeFile) =>
     set((state) => {

--- a/apps/desktop/src/types/markdown-editor.ts
+++ b/apps/desktop/src/types/markdown-editor.ts
@@ -21,6 +21,7 @@ export type MarkdownEditorProps = {
   scrollRestorationKey?: string | null;
   editorFocusRequest?: EditorFocusRequest | null;
   findRequest?: EditorFindRequest | null;
+  showToolbar?: boolean;
   workspaceRootPath?: string | null;
   saveStateLabel: string;
   footerMetaLabel?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       pdfkit:
         specifier: ^0.17.2
         version: 0.17.2
+      react-resizable-panels:
+        specifier: ^4.10.0
+        version: 4.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -1831,6 +1834,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -3739,6 +3743,12 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-resizable-panels@4.10.0:
+    resolution: {integrity: sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -8094,6 +8104,11 @@ snapshots:
       react: 19.2.4
 
   react-refresh@0.17.0: {}
+
+  react-resizable-panels@4.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 


### PR DESCRIPTION
## Summary

Implements production-ready split view for the desktop editor so notes can be opened side by side with stable keyboard-first pane management.

## What shipped

- Recursive split layout with horizontal and vertical panes
- One global fixed top toolbar instead of per-pane navbars
- Pane keyboard shortcuts that work even while the editor is focused
- Per-pane tab rails with cross-pane drag/drop and in-pane reorder
- Layout/session persistence, sidebar collapse persistence, and pane/tab restore fixes
- Lighter resize handles with a grab cursor and cleaner hover affordance
- Faster split-view rendering by separating stable split context from active-pane editor state
- Review-comment fixes for folder rename/delete layout sync and safer layout restore

## Performance and maintainability

- Reduced inactive-pane rerenders by moving high-churn editor state out of the main split context
- Kept pane actions behind stable callbacks and store-driven mutations
- Improved drag/drop plumbing so cross-pane moves use explicit drag payloads instead of local-only refs
- Preserved renderer-only UI work in React and store layers without adding unsafe Electron coupling

## Verification

- `pnpm typecheck:desktop`
- `pnpm --filter @glyph/desktop lint`
- `pnpm --filter @glyph/desktop build && pnpm --filter @glyph/desktop exec playwright test -c playwright.config.ts`

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-pane editing with resizable splits, per-pane tab management, and pane-aware keyboard shortcuts (split, close pane, focus next/previous)
  * Background auto-save for dirty tabs in inactive panes
  * Layout/session persistence across restarts
  * Option to show/hide the editor toolbar
  * Improved tab drag-and-drop behavior

* **Chores**
  * Desktop app version updated to 0.7.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
