### PR TITLE
refactor(desktop): extract SidebarActionMenu component and simplify tab shortcuts

### DIFF
--- a/apps/desktop/src/components/sidebar-action-menu.tsx
+++ b/apps/desktop/src/components/sidebar-action-menu.tsx
@@ -65,7 +65,7 @@ export function SidebarActionMenu({
             className={`h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm ${
               item.variant === "destructive"
                 ? "hover:bg-destructive/10 hover:text-destructive"
-                : "hover:bg-accent"
+                : "hover:bg-accent dark:hover:bg-white/10"
             }`}
             onClick={(event) => {
               event.stopPropagation();

--- a/apps/desktop/src/components/sidebar-action-menu.tsx
+++ b/apps/desktop/src/components/sidebar-action-menu.tsx
@@ -1,0 +1,156 @@
+import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { PencilIcon, TrashIcon, XIcon } from "@/components/icons";
+import { FileManagerLogo } from "@/components/file-manager-logo";
+
+export type SidebarActionMenuCoords = {
+  top: number;
+  left: number;
+};
+
+type SidebarActionMenuItem = {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  variant?: "default" | "destructive";
+};
+
+type SidebarActionMenuProps = {
+  open: boolean;
+  coords: SidebarActionMenuCoords | null;
+  onClose: () => void;
+  onCloseFocusRef?: React.RefObject<HTMLButtonElement | null>;
+  items: SidebarActionMenuItem[];
+  ariaLabel: string;
+};
+
+export function SidebarActionMenu({
+  open,
+  coords,
+  onClose,
+  onCloseFocusRef,
+  items,
+  ariaLabel,
+}: SidebarActionMenuProps) {
+  if (!open || !coords) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <button
+        aria-label={ariaLabel}
+        className="fixed inset-0 z-40 cursor-default bg-transparent outline-none"
+        onClick={(event) => {
+          event.stopPropagation();
+          onClose();
+          window.requestAnimationFrame(() => {
+            onCloseFocusRef?.current?.focus();
+          });
+        }}
+        type="button"
+        tabIndex={-1}
+      />
+      <div
+        className="fixed z-50 w-[142px] rounded-md border border-border bg-popover py-1 shadow-lg"
+        style={{ top: coords.top, left: coords.left }}
+      >
+        {items.map((item) => (
+          <Button
+            key={item.label}
+            variant="ghost"
+            size="sm"
+            className={`h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm ${
+              item.variant === "destructive"
+                ? "hover:bg-destructive/10 hover:text-destructive"
+                : "hover:bg-accent"
+            }`}
+            onClick={(event) => {
+              event.stopPropagation();
+              item.onClick();
+              onClose();
+            }}
+            type="button"
+          >
+            {item.icon}
+            {item.label}
+          </Button>
+        ))}
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+export function buildFileMenuItems(options: {
+  displayFileName: string;
+  onRename: () => void;
+  onRevealInFinder: () => void;
+  onRemove: () => void;
+  onDelete: () => void;
+  revealLabel: string;
+}): SidebarActionMenuItem[] {
+  return [
+    {
+      label: "Rename",
+      icon: <PencilIcon size={14} className="opacity-70" />,
+      onClick: options.onRename,
+    },
+    {
+      label: options.revealLabel,
+      icon: <FileManagerLogo label={options.revealLabel} size={14} className="opacity-70" />,
+      onClick: options.onRevealInFinder,
+    },
+    {
+      label: "Remove",
+      icon: <XIcon size={14} className="opacity-70" />,
+      onClick: options.onRemove,
+    },
+    {
+      label: "Delete",
+      icon: <TrashIcon size={14} className="opacity-70" />,
+      onClick: options.onDelete,
+      variant: "destructive",
+    },
+  ];
+}
+
+export function buildFolderMenuItems(options: {
+  folderName: string;
+  onRename: () => void;
+  onRevealInFinder: () => void;
+  onRemove: () => void;
+  onDelete?: () => void;
+  revealLabel: string;
+}): SidebarActionMenuItem[] {
+  const items: SidebarActionMenuItem[] = [
+    {
+      label: "Rename",
+      icon: <PencilIcon size={14} className="opacity-70" />,
+      onClick: options.onRename,
+    },
+    {
+      label: options.revealLabel,
+      icon: <FileManagerLogo label={options.revealLabel} size={14} className="opacity-70" />,
+      onClick: options.onRevealInFinder,
+    },
+    {
+      label: "Remove",
+      icon: <XIcon size={14} className="opacity-70" />,
+      onClick: options.onRemove,
+    },
+  ];
+
+  if (options.onDelete) {
+    items.push({
+      label: "Delete",
+      icon: <TrashIcon size={14} className="opacity-70" />,
+      onClick: options.onDelete,
+      variant: "destructive",
+    });
+  }
+
+  return items;
+}

--- a/apps/desktop/src/components/sidebar-action-menu.tsx
+++ b/apps/desktop/src/components/sidebar-action-menu.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 
 import { Button } from "@/components/ui/button";
 import { PencilIcon, TrashIcon, XIcon } from "@/components/icons";
@@ -21,7 +21,7 @@ type SidebarActionMenuProps = {
   open: boolean;
   coords: SidebarActionMenuCoords | null;
   onClose: () => void;
-  onCloseFocusRef?: React.RefObject<HTMLButtonElement | null>;
+  onCloseFocusRef?: RefObject<HTMLButtonElement | null>;
   items: SidebarActionMenuItem[];
   ariaLabel: string;
 };

--- a/apps/desktop/src/components/sidebar-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar-tree-node.tsx
@@ -1,29 +1,19 @@
-import { createPortal } from "react-dom";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { DragEvent, MouseEvent, ReactNode } from "react";
+import type { DragEvent, MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getDisplayFileName, isSamePath } from "@/lib/paths";
 
-import { FileManagerLogo } from "./file-manager-logo";
 import {
-  ChevronRightIcon,
-  FileIcon,
-  FolderIcon,
-  MoreVerticalIcon,
-  PinIcon,
-  PencilIcon,
-  TrashIcon,
-  XIcon,
-} from "./icons";
-import type {
-  DragPosition,
-  SidebarRemoveTarget,
-  SidebarTreeNodeMenuCoords,
-  SidebarTreeNodeProps,
-} from "../types/sidebar";
+  SidebarActionMenu,
+  buildFileMenuItems,
+  buildFolderMenuItems,
+  type SidebarActionMenuCoords,
+} from "./sidebar-action-menu";
+import { ChevronRightIcon, FileIcon, FolderIcon, MoreVerticalIcon, PinIcon } from "./icons";
+import type { DragPosition, SidebarRemoveTarget, SidebarTreeNodeProps } from "../types/sidebar";
 
 let globalDraggedSidebarPath: string | null = null;
 
@@ -53,7 +43,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const [dropPosition, setDropPosition] = useState<DragPosition | null>(null);
-  const [menuCoords, setMenuCoords] = useState<SidebarTreeNodeMenuCoords | null>(null);
+  const [menuCoords, setMenuCoords] = useState<SidebarActionMenuCoords | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
   const displayFileName = useMemo(() => getDisplayFileName(node.name), [node.name]);
@@ -62,11 +52,6 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   const pinnedPathList = pinnedPaths ?? [];
   const isPinned = pinnedPathList.some((path) => isSamePath(path, node.path));
   const isActive = isSamePath(activePath, node.path);
-  const focusMenuButton = useCallback(() => {
-    window.requestAnimationFrame(() => {
-      menuButtonRef.current?.focus();
-    });
-  }, []);
 
   const containerClassName = useMemo(() => {
     if (dropPosition === "before") {
@@ -236,34 +221,44 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
       }
     : {};
 
-  const renderMenu = (content: ReactNode, ariaLabel: string) => {
-    if (!showMenu || !menuCoords) {
-      return null;
-    }
+  const fileMenuItems = buildFileMenuItems({
+    displayFileName,
+    onRename: () => {
+      setRenameValue(displayFileName);
+      setIsRenaming(true);
+    },
+    onRevealInFinder: () => {
+      onRevealInFinder(node.path);
+    },
+    onRemove: () => {
+      onRequestRemoveFile?.({ path: node.path, name: node.name });
+    },
+    onDelete: () => {
+      onRequestDelete({ path: node.path, name: node.name });
+    },
+    revealLabel: revealLabel ?? "Reveal in Finder",
+  });
 
-    return createPortal(
-      <>
-        <button
-          aria-label={ariaLabel}
-          className="fixed inset-0 z-40 cursor-default bg-transparent outline-none"
-          onClick={(event) => {
-            event.stopPropagation();
-            setShowMenu(false);
-            focusMenuButton();
-          }}
-          type="button"
-          tabIndex={-1}
-        />
-        <div
-          className="fixed z-50 w-[142px] rounded-md border border-border bg-popover py-1 shadow-lg"
-          style={{ top: menuCoords.top, left: menuCoords.left }}
-        >
-          {content}
-        </div>
-      </>,
-      document.body,
-    );
-  };
+  const folderMenuItems = buildFolderMenuItems({
+    folderName: node.name,
+    onRename: () => {
+      setRenameValue(node.name);
+      setIsRenaming(true);
+    },
+    onRevealInFinder: () => {
+      onRevealInFinder(node.path);
+    },
+    onRemove: () => {
+      const folder: SidebarRemoveTarget = { path: node.path, name: node.name };
+      onRequestRemoveFolder(folder);
+    },
+    onDelete: onRequestDeleteFolder
+      ? () => {
+          onRequestDeleteFolder({ path: node.path, name: node.name });
+        }
+      : undefined,
+    revealLabel: revealLabel ?? "Reveal in Finder",
+  });
 
   if (node.type === "directory") {
     return (
@@ -387,75 +382,14 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
           </div>
         ) : null}
 
-        {renderMenu(
-          <>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-              onClick={(event) => {
-                event.stopPropagation();
-                setRenameValue(node.name);
-                setIsRenaming(true);
-                setShowMenu(false);
-              }}
-              type="button"
-            >
-              <PencilIcon size={14} className="opacity-70" />
-              Rename
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-              onClick={(event) => {
-                event.stopPropagation();
-                onRevealInFinder(node.path);
-                setShowMenu(false);
-                focusMenuButton();
-              }}
-              type="button"
-            >
-              <FileManagerLogo label={revealLabel} size={14} className="opacity-70" />
-              {revealLabel}
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-              onClick={(event) => {
-                event.stopPropagation();
-                const folder: SidebarRemoveTarget = {
-                  path: node.path,
-                  name: node.name,
-                };
-                onRequestRemoveFolder(folder);
-                setShowMenu(false);
-              }}
-              type="button"
-            >
-              <XIcon size={14} className="opacity-70" />
-              Remove
-            </Button>
-            {onRequestDeleteFolder ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-destructive/10 hover:text-destructive"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRequestDeleteFolder({ path: node.path, name: node.name });
-                  setShowMenu(false);
-                }}
-                type="button"
-              >
-                <TrashIcon size={14} className="opacity-70" />
-                Delete
-              </Button>
-            ) : null}
-          </>,
-          "Close folder menu",
-        )}
+        <SidebarActionMenu
+          open={showMenu && node.type === "directory"}
+          coords={menuCoords}
+          onClose={() => setShowMenu(false)}
+          onCloseFocusRef={menuButtonRef}
+          items={folderMenuItems}
+          ariaLabel="Close folder menu"
+        />
       </div>
     );
   }
@@ -560,69 +494,14 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         ) : null}
       </div>
 
-      {renderMenu(
-        <>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-            onClick={(event) => {
-              event.stopPropagation();
-              setRenameValue(displayFileName);
-              setIsRenaming(true);
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <PencilIcon size={14} className="opacity-70" />
-            Rename
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRevealInFinder(node.path);
-              setShowMenu(false);
-              focusMenuButton();
-            }}
-            type="button"
-          >
-            <FileManagerLogo label={revealLabel} size={14} className="opacity-70" />
-            {revealLabel}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-white/10 dark:hover:bg-white/10"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRequestRemoveFile?.({ path: node.path, name: node.name });
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <XIcon size={14} className="opacity-70" />
-            Remove
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-destructive/10 hover:text-destructive"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRequestDelete({ path: node.path, name: node.name });
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <TrashIcon size={14} className="opacity-70" />
-            Delete
-          </Button>
-        </>,
-        "Close note menu",
-      )}
+      <SidebarActionMenu
+        open={showMenu && node.type === "file"}
+        coords={menuCoords}
+        onClose={() => setShowMenu(false)}
+        onCloseFocusRef={menuButtonRef}
+        items={fileMenuItems}
+        ariaLabel="Close note menu"
+      />
     </div>
   );
 });

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -1,4 +1,3 @@
-import { createPortal } from "react-dom";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, MouseEvent } from "react";
 
@@ -27,15 +26,11 @@ import type {
 import { LogoComponent } from "./logo-component";
 import { SkillSourceLogo } from "./skill-source-logo";
 import {
-  ChevronRightIcon,
-  MoreVerticalIcon,
-  PencilIcon,
-  PinIcon,
-  PlusIcon,
-  TrashIcon,
-  XIcon,
-  FolderPlusIcon,
-} from "./icons";
+  SidebarActionMenu,
+  buildFileMenuItems,
+  type SidebarActionMenuCoords,
+} from "./sidebar-action-menu";
+import { ChevronRightIcon, MoreVerticalIcon, PinIcon, PlusIcon, FolderPlusIcon } from "./icons";
 import { SidebarTreeNode } from "./sidebar-tree-node";
 
 const normalizePathKey = (path: string) => normalizePath(path).toLowerCase();
@@ -48,6 +43,8 @@ type SidebarShortcutRowProps = {
   onDeleteFile: (filePath: string) => void;
   onRequestRemoveFile?: (file: SidebarRemoveTarget) => void;
   onRenameFile: (filePath: string, newName: string) => void;
+  onRevealInFinder?: (filePath: string) => void;
+  revealLabel?: string;
 };
 
 const SidebarShortcutRow = memo(function SidebarShortcutRow({
@@ -58,9 +55,11 @@ const SidebarShortcutRow = memo(function SidebarShortcutRow({
   onDeleteFile,
   onRequestRemoveFile,
   onRenameFile,
+  onRevealInFinder,
+  revealLabel = "Reveal in Finder",
 }: SidebarShortcutRowProps) {
   const [showMenu, setShowMenu] = useState(false);
-  const [menuCoords, setMenuCoords] = useState<{ top: number; left: number } | null>(null);
+  const [menuCoords, setMenuCoords] = useState<SidebarActionMenuCoords | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -71,17 +70,6 @@ const SidebarShortcutRow = memo(function SidebarShortcutRow({
     const fileName = segments.pop() ?? item.title;
     return getDisplayFileName(fileName);
   }, [item.path, item.title]);
-
-  const focusMenuButton = useCallback(() => {
-    window.requestAnimationFrame(() => {
-      if (menuButtonRef.current?.isConnected) {
-        menuButtonRef.current.focus();
-        return;
-      }
-
-      document.querySelector<HTMLElement>("[data-glyph-editor='true']")?.focus();
-    });
-  }, []);
 
   const focusEditorSurface = useCallback(() => {
     window.requestAnimationFrame(() => {
@@ -117,84 +105,31 @@ const SidebarShortcutRow = memo(function SidebarShortcutRow({
   const openMenu = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
 
-    if (!showMenu) {
-      const rect = event.currentTarget.getBoundingClientRect();
+    if (!showMenu && menuButtonRef.current) {
+      const rect = menuButtonRef.current.getBoundingClientRect();
       setMenuCoords({ top: rect.bottom + 4, left: rect.right + 4 });
     }
 
     setShowMenu((value) => !value);
   };
 
-  const renderMenu = () => {
-    if (!showMenu || !menuCoords) {
-      return null;
-    }
-
-    return createPortal(
-      <>
-        <button
-          aria-label="Close note actions"
-          className="fixed inset-0 z-40 cursor-default bg-transparent outline-none"
-          onClick={(event) => {
-            event.stopPropagation();
-            setShowMenu(false);
-            focusMenuButton();
-          }}
-          type="button"
-          tabIndex={-1}
-        />
-        <div
-          className="fixed z-50 w-[142px] rounded-md border border-border bg-white dark:bg-popover py-1 shadow-lg"
-          style={{ top: menuCoords.top, left: menuCoords.left }}
-        >
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm"
-            onClick={(event) => {
-              event.stopPropagation();
-              setRenameValue(displayFileName);
-              setIsRenaming(true);
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <PencilIcon size={14} className="opacity-70" />
-            Rename
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRequestRemoveFile?.({ path: item.path, name: item.title });
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <XIcon size={14} className="opacity-70" />
-            Remove
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-sm hover:bg-destructive/10 hover:text-destructive"
-            onClick={(event) => {
-              event.stopPropagation();
-              onDeleteFile(item.path);
-              setShowMenu(false);
-            }}
-            type="button"
-          >
-            <TrashIcon size={14} className="opacity-70" />
-            Delete
-          </Button>
-        </div>
-      </>,
-      document.body,
-    );
-  };
+  const menuItems = buildFileMenuItems({
+    displayFileName,
+    onRename: () => {
+      setRenameValue(displayFileName);
+      setIsRenaming(true);
+    },
+    onRevealInFinder: () => {
+      onRevealInFinder?.(item.path);
+    },
+    onRemove: () => {
+      onRequestRemoveFile?.({ path: item.path, name: item.title });
+    },
+    onDelete: () => {
+      onDeleteFile(item.path);
+    },
+    revealLabel: revealLabel ?? "Reveal in Finder",
+  });
 
   return (
     <div
@@ -277,7 +212,14 @@ const SidebarShortcutRow = memo(function SidebarShortcutRow({
           </div>
         ) : null}
       </div>
-      {renderMenu()}
+      <SidebarActionMenu
+        open={showMenu}
+        coords={menuCoords}
+        onClose={() => setShowMenu(false)}
+        onCloseFocusRef={menuButtonRef}
+        items={menuItems}
+        ariaLabel="Close note actions"
+      />
     </div>
   );
 });
@@ -290,6 +232,8 @@ type SidebarShortcutListProps = {
   onDeleteFile: (filePath: string) => void;
   onRequestRemoveFile?: (file: SidebarRemoveTarget) => void;
   onRenameFile: (filePath: string, newName: string) => void;
+  onRevealInFinder?: (filePath: string) => void;
+  revealLabel?: string;
 };
 
 const SidebarShortcutList = memo(function SidebarShortcutList({
@@ -300,6 +244,8 @@ const SidebarShortcutList = memo(function SidebarShortcutList({
   onDeleteFile,
   onRequestRemoveFile,
   onRenameFile,
+  onRevealInFinder,
+  revealLabel,
 }: SidebarShortcutListProps) {
   if (items.length === 0) {
     return null;
@@ -317,6 +263,8 @@ const SidebarShortcutList = memo(function SidebarShortcutList({
           onDeleteFile={onDeleteFile}
           onRequestRemoveFile={onRequestRemoveFile}
           onRenameFile={onRenameFile}
+          onRevealInFinder={onRevealInFinder}
+          revealLabel={revealLabel}
         />
       ))}
     </div>
@@ -582,6 +530,8 @@ export const Sidebar = ({
                       setNodeToDelete({ path: filePath, name });
                     }}
                     onRenameFile={onRenameFile}
+                    onRevealInFinder={onRevealInFinder}
+                    revealLabel={revealLabel}
                   />
                 </div>
               ) : null}

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -2147,8 +2147,6 @@ export const useDesktopAppController = (
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,
-    navigateBack,
-    navigateForward,
     requestFindInNote,
     triggerUpdateAction,
     splitRight,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -19,8 +19,6 @@ type UseKeyboardShortcutsOptions = {
   syncOpenedFile: (file: FileDocument, options?: { recordHistory?: boolean }) => Promise<void>;
   syncWorkspace: (workspace: WorkspaceSnapshot) => void;
   setIsWorkspaceMode: React.Dispatch<React.SetStateAction<boolean>>;
-  navigateBack: () => Promise<void>;
-  navigateForward: () => Promise<void>;
   requestFindInNote: () => void;
   triggerUpdateAction: () => Promise<void>;
   splitRight: () => void;
@@ -54,8 +52,6 @@ export function useKeyboardShortcuts({
   syncOpenedFile,
   syncWorkspace,
   setIsWorkspaceMode,
-  navigateBack,
-  navigateForward,
   requestFindInNote,
   triggerUpdateAction,
   splitRight,
@@ -112,13 +108,19 @@ export function useKeyboardShortcuts({
         return;
       }
 
+      const isPreviousTabBracket =
+        primaryPressed && !event.altKey && !event.shiftKey && event.key === "[";
+      const isNextTabBracket =
+        primaryPressed && !event.altKey && !event.shiftKey && event.key === "]";
       const isPreviousBracketShortcut =
         primaryPressed &&
         !event.altKey &&
+        event.shiftKey &&
         matchShortcut(event, `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} [`, platform);
       const isNextBracketShortcut =
         primaryPressed &&
         !event.altKey &&
+        event.shiftKey &&
         matchShortcut(event, `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} ]`, platform);
       const isPreviousCtrlTabShortcut =
         !hasConfiguredShortcutMatch &&
@@ -137,13 +139,19 @@ export function useKeyboardShortcuts({
         !event.repeat &&
         event.key === "Tab";
 
-      if (!hasConfiguredShortcutMatch && (isPreviousBracketShortcut || isPreviousCtrlTabShortcut)) {
+      if (
+        !hasConfiguredShortcutMatch &&
+        (isPreviousTabBracket || isPreviousBracketShortcut || isPreviousCtrlTabShortcut)
+      ) {
         event.preventDefault();
         void activatePreviousTab();
         return;
       }
 
-      if (!hasConfiguredShortcutMatch && (isNextBracketShortcut || isNextCtrlTabShortcut)) {
+      if (
+        !hasConfiguredShortcutMatch &&
+        (isNextTabBracket || isNextBracketShortcut || isNextCtrlTabShortcut)
+      ) {
         event.preventDefault();
         void activateNextTab();
         return;
@@ -154,8 +162,6 @@ export function useKeyboardShortcuts({
         "command-palette",
         "find-in-note",
         "settings",
-        "navigate-back",
-        "navigate-forward",
         "focus-mode",
         "check-updates",
         "new-note",
@@ -188,12 +194,6 @@ export function useKeyboardShortcuts({
             break;
           case "settings":
             setIsSettingsOpen((value) => !value);
-            break;
-          case "navigate-back":
-            void navigateBack();
-            break;
-          case "navigate-forward":
-            void navigateForward();
             break;
           case "focus-mode":
             void toggleFocusMode();
@@ -313,8 +313,6 @@ export function useKeyboardShortcuts({
     syncOpenedFile,
     syncWorkspace,
     setIsWorkspaceMode,
-    navigateBack,
-    navigateForward,
     requestFindInNote,
     triggerUpdateAction,
     splitRight,

--- a/apps/desktop/src/shared/shortcuts.ts
+++ b/apps/desktop/src/shared/shortcuts.ts
@@ -126,8 +126,6 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "save", label: "Save", keys: `${MODIFIER_TOKENS.cmdOrCtrl} S` },
   { id: "settings", label: "Settings", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ,` },
   { id: "toggle-sidebar", label: "Toggle Sidebar", keys: `${MODIFIER_TOKENS.cmdOrCtrl} \\` },
-  { id: "navigate-back", label: "Navigate Back", keys: `${MODIFIER_TOKENS.cmdOrCtrl} [` },
-  { id: "navigate-forward", label: "Navigate Forward", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ]` },
   {
     id: "focus-mode",
     label: "Toggle Focus Mode",
@@ -219,7 +217,7 @@ export function getAdjacentTabShortcutDisplay(
   platform?: string,
 ): string {
   if (isMacPlatform(platform)) {
-    return direction === "next" ? "⇧⌘]" : "⇧⌘[";
+    return direction === "next" ? "⌘]" : "⌘[";
   }
 
   return direction === "next" ? "Ctrl+Tab" : "Ctrl+Shift+Tab";
@@ -230,13 +228,14 @@ export function matchAdjacentTabShortcut(
   direction: "next" | "previous",
   platform?: string,
 ): boolean {
-  return matchShortcut(
-    event,
-    isMacPlatform(platform)
-      ? `⇧ ⌘ ${direction === "next" ? "]" : "["}`
-      : `${direction === "next" ? "⌘ Tab" : "⇧ ⌘ Tab"}`,
-    platform,
-  );
+  if (isMacPlatform(platform)) {
+    const key = direction === "next" ? "]" : "[";
+    return (
+      matchShortcut(event, `⌘ ${key}`, platform) || matchShortcut(event, `⇧ ⌘ ${key}`, platform)
+    );
+  }
+
+  return matchShortcut(event, direction === "next" ? "⌘ Tab" : "⇧ ⌘ Tab", platform);
 }
 
 const MODIFIER_TOKENS_SET = new Set(Object.values(MODIFIER_TOKENS));

--- a/apps/desktop/src/types/sidebar.ts
+++ b/apps/desktop/src/types/sidebar.ts
@@ -53,11 +53,6 @@ export type SidebarProps = {
   onCreateFolder?: () => void;
 };
 
-export type SidebarTreeNodeMenuCoords = {
-  top: number;
-  left: number;
-};
-
 export type SidebarDeleteTarget = {
   path: string;
   name: string;


### PR DESCRIPTION
## Summary

- **Extract shared `SidebarActionMenu` component** from duplicated portal menu implementations in `sidebar-tree-node.tsx` and `sidebar.tsx`. The duplicated `renderMenu()` / `createPortal()` patterns are replaced by a single reusable component with declarative `items` config.
- **Add `buildFileMenuItems` / `buildFolderMenuItems` helpers** that construct the menu item arrays, removing inline JSX from both consumers.
- **Remove `navigate-back` / `navigate-forward` shortcuts** — these conflicted with `Cmd+[` / `Cmd+]` tab switching and are no longer needed.
- **Simplify tab switching**: `Cmd+[` and `Cmd+]` now switch tabs directly (no Shift required). `Shift+Cmd+[` / `Shift+Cmd+]` still work as a fallback. The old `Shift+Cmd+[` / `Shift+Cmd+]` requirement was unnecessarily complex.
- **Remove unused `SidebarTreeNodeMenuCoords` type** (replaced by `SidebarActionMenuCoords` in the new component).
- **Clean up `focusMenuButton` callbacks** — focus restoration on menu close is now handled by `onCloseFocusRef` in the shared component.
- **Fix indentation regression** in `use-keyboard-shortcuts.ts` switch statement.

## Files Changed

- `apps/desktop/src/components/sidebar-action-menu.tsx` — new shared menu component + item builders
- `apps/desktop/src/components/sidebar-tree-node.tsx` — replace `renderMenu`/`createPortal` with `SidebarActionMenu`
- `apps/desktop/src/components/sidebar.tsx` — replace `renderMenu`/`createPortal` with `SidebarActionMenu`; add `onRevealInFinder`/`revealLabel` props to shortcut row/list
- `apps/desktop/src/hooks/use-keyboard-shortcuts.ts` — remove navigate-back/forward handlers; add direct `Cmd+[`/`Cmd+]` tab switching
- `apps/desktop/src/hooks/use-desktop-app-controller.ts` — remove unused navigate deps
- `apps/desktop/src/shared/shortcuts.ts` — remove navigate-back/forward defaults; simplify `getAdjacentTabShortcutDisplay` and `matchAdjacentTabShortcut`
- `apps/desktop/src/types/sidebar.ts` — remove unused `SidebarTreeNodeMenuCoords` type

## Testing

- TypeScript type checking passes
- Lint passes with no warnings or errors
- Format check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified keyboard shortcuts for tab navigation: use **⌘[** and **⌘]** without the Shift modifier.
  * Removed dedicated keyboard shortcuts for back and forward navigation.
  * Standardized context menus across sidebar files and folders with consistent rename, remove, delete, and reveal options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->