### PR TITLE
feat(desktop): polish tasks board and frontmatter editing

### DIFF
--- a/apps/desktop/electron/tasks-service.ts
+++ b/apps/desktop/electron/tasks-service.ts
@@ -34,6 +34,25 @@ const clampIndex = (index: unknown, length: number) =>
     ? Math.max(0, Math.min(Math.trunc(index), length))
     : length;
 
+const MIN_COLUMN_WIDTH = 260;
+const MAX_COLUMN_WIDTH = 560;
+
+const normalizeColumnWidth = (width: unknown) => {
+  if (typeof width !== "number" || !Number.isFinite(width)) {
+    return null;
+  }
+
+  return Math.max(MIN_COLUMN_WIDTH, Math.min(Math.trunc(width), MAX_COLUMN_WIDTH));
+};
+
+const getLocalDateLabel = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 const parseMetaComment = (line: string, prefix: string): Record<string, string> | null => {
   const match = line.match(new RegExp(`<!--\\s*${prefix}:\\s*(.*?)\\s*-->`));
   if (!match) return null;
@@ -112,7 +131,8 @@ const serializeArchivedEntry = (entry: ArchivedTaskEntry): string => {
 };
 
 const serializeColumn = (column: TaskColumn): string => {
-  const meta = `<!-- column-meta: id=${column.id} color=${column.color} collapsed=${column.collapsed} isDone=${column.isDone} created=${column.createdAt} updated=${column.updatedAt} -->`;
+  const widthMeta = column.width ? ` width=${column.width}` : "";
+  const meta = `<!-- column-meta: id=${column.id} color=${column.color} collapsed=${column.collapsed} isDone=${column.isDone}${widthMeta} created=${column.createdAt} updated=${column.updatedAt} -->`;
   return `## ${column.title}\n${meta}`;
 };
 
@@ -127,6 +147,7 @@ const createDefaultBoard = (): { columns: TaskColumn[]; tasks: WorkspaceTask[] }
     columns: DEFAULT_TASK_COLUMNS.map((column) => ({
       ...column,
       collapsed: false,
+      width: null,
       taskIds: [],
       createdAt: now,
       updatedAt: now,
@@ -222,6 +243,7 @@ const parseBoardMarkdown = (
         title,
         color: isTaskColumnColor(meta.color) ? meta.color : "slate",
         collapsed: meta.collapsed === "true",
+        width: normalizeColumnWidth(Number(meta.width)),
         isDone,
         taskIds: [],
         createdAt: meta.created ? Number(meta.created) : now,
@@ -410,6 +432,7 @@ export function createTasksService() {
       return mutationError("missing-column", "Task list no longer exists.");
     }
 
+    const sourceColumn = getColumn(task.columnId);
     for (const column of columns) {
       column.taskIds = column.taskIds.filter((taskId) => taskId !== task.id);
     }
@@ -417,6 +440,9 @@ export function createTasksService() {
     targetColumn.taskIds.splice(targetIndex, 0, task.id);
     task.columnId = targetColumn.id;
     task.updatedAt = Date.now();
+    if (targetColumn.isDone && !sourceColumn?.isDone) {
+      task.dueDate = getLocalDateLabel();
+    }
     targetColumn.updatedAt = task.updatedAt;
     await save();
     return { ok: true, task, snapshot };
@@ -517,6 +543,7 @@ export function createTasksService() {
       title,
       color: isTaskColumnColor(input.color) ? input.color : "blue",
       collapsed: false,
+      width: null,
       isDone: typeof input.isDone === "boolean" ? input.isDone : false,
       taskIds: [],
       createdAt: now,
@@ -543,6 +570,9 @@ export function createTasksService() {
     }
     if (typeof input.collapsed === "boolean") {
       column.collapsed = input.collapsed;
+    }
+    if (input.width !== undefined) {
+      column.width = normalizeColumnWidth(input.width);
     }
     if (typeof input.isDone === "boolean") {
       column.isDone = input.isDone;

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
+import { parseMarkdownFrontmatter, serializeMarkdownFrontmatter } from "@/core/frontmatter";
 import { getDisplayFileName, isSamePath } from "@/core/paths";
 import {
   getDirectTabShortcutDisplay,
@@ -12,6 +13,7 @@ import { useLayoutStore } from "@/store/layout";
 import { useSessionStore } from "@/store/session";
 import { useWorkspaceStore } from "@/store/workspace";
 
+import { FrontmatterBlock } from "./frontmatter-block";
 import { MarkdownEditor } from "./markdown-editor";
 import { NoteTabsBar } from "./note-tabs-bar";
 import { useSplitViewActivePaneContext, useSplitViewContext } from "./split-view-context";
@@ -70,10 +72,11 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
     return "Saved";
   }, [activeTab, isDirty, isSaving]);
 
+  const parsedContent = useMemo(() => parseMarkdownFrontmatter(content), [content]);
   const wordCount = useMemo(() => {
-    if (!content) return 0;
-    return content.split(/\s+/).filter(Boolean).length;
-  }, [content]);
+    if (!parsedContent.body) return 0;
+    return parsedContent.body.split(/\s+/).filter(Boolean).length;
+  }, [parsedContent.body]);
 
   const readingTime = useMemo(() => Math.max(1, Math.ceil(wordCount / 200)), [wordCount]);
 
@@ -130,10 +133,33 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
   const handleContentChange = useCallback(
     (value: string) => {
       if (paneActiveTabId) {
-        ctx.onContentChange(paneId, paneActiveTabId, value);
+        ctx.onContentChange(
+          paneId,
+          paneActiveTabId,
+          serializeMarkdownFrontmatter({
+            frontmatterText: parsedContent.frontmatterText,
+            body: value,
+          }),
+        );
       }
     },
-    [ctx.onContentChange, paneId, paneActiveTabId],
+    [ctx.onContentChange, paneId, paneActiveTabId, parsedContent.frontmatterText],
+  );
+
+  const handleFrontmatterChange = useCallback(
+    (frontmatterText: string) => {
+      if (paneActiveTabId) {
+        ctx.onContentChange(
+          paneId,
+          paneActiveTabId,
+          serializeMarkdownFrontmatter({
+            frontmatterText,
+            body: parsedContent.body,
+          }),
+        );
+      }
+    },
+    [ctx.onContentChange, paneId, paneActiveTabId, parsedContent.body],
   );
 
   const handleSelectTab = useCallback(
@@ -180,7 +206,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
       onPointerDown={handleFocus}
     >
       <MarkdownEditor
-        content={content}
+        content={parsedContent.body}
         fileName={fileName}
         filePath={filePath}
         isEditable={isEditorEditable}
@@ -192,6 +218,15 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         footerMetaLabel={footerMetaLabel}
         wordCount={wordCount}
         readingTime={readingTime}
+        topContent={
+          parsedContent.frontmatterText ? (
+            <FrontmatterBlock
+              value={parsedContent.frontmatterText}
+              isEditable={isEditorEditable}
+              onChange={handleFrontmatterChange}
+            />
+          ) : null
+        }
         subheaderContent={
           noteTabItems.length > 0 ? (
             <NoteTabsBar

--- a/apps/desktop/src/components/frontmatter-block.tsx
+++ b/apps/desktop/src/components/frontmatter-block.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+type FrontmatterBlockProps = {
+  value: string;
+  isEditable: boolean;
+  onChange: (value: string) => void;
+};
+
+export function FrontmatterBlock({ value, isEditable, onChange }: FrontmatterBlockProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isFocusedRef = useRef(false);
+  const [draftValue, setDraftValue] = useState(value);
+
+  useEffect(() => {
+    if (!isFocusedRef.current) {
+      setDraftValue(value);
+    }
+  }, [value]);
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = "0px";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [draftValue]);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const nextValue = event.target.value;
+      setDraftValue(nextValue);
+      onChange(nextValue);
+    },
+    [onChange],
+  );
+
+  const handleFocus = useCallback(() => {
+    isFocusedRef.current = true;
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    isFocusedRef.current = false;
+    setDraftValue(value);
+  }, [value]);
+
+  return (
+    <div className="border-b border-border/55 pt-1 pb-5">
+      <div className="px-0 py-1">
+        {isEditable ? (
+          <textarea
+            ref={textareaRef}
+            aria-label="Document frontmatter"
+            className="block min-h-0 w-full resize-none overflow-hidden border-0 bg-transparent p-0 font-mono text-[13px] leading-6 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
+            spellCheck={false}
+            rows={1}
+            value={draftValue}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-mono text-[13px] leading-6 text-muted-foreground">
+            {draftValue}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/skills/skill-document-pane.tsx
+++ b/apps/desktop/src/components/skills/skill-document-pane.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/core/skills";
 
 import { MarkdownEditor } from "../markdown-editor";
+import { FrontmatterBlock } from "../frontmatter-block";
 import { Button } from "../ui/button";
 
 const OUTLINE_HEADING_PATTERN = /^#{1,4}\s+\S/;
@@ -82,8 +83,7 @@ export function SkillDocumentPane({
     return text ? text.split(/\s+/).length : 0;
   }, [parsed.body]);
   const readingTime = Math.max(1, Math.round(wordCount / 200));
-  const frontmatterRows = Math.max(2, parsed.frontmatterText?.split("\n").length ?? 0);
-  const handleBodyChange = useCallback(
+  const handleContentChange = useCallback(
     (nextBody: string) => {
       onChange(
         serializeSkillDocument({
@@ -134,65 +134,44 @@ export function SkillDocumentPane({
         })}
       </div>
     ) : null;
-  const topContent =
-    pendingExternalChange || parsed.frontmatterText ? (
-      <div className="space-y-4">
-        {pendingExternalChange ? (
-          <div className="rounded-xl border border-border/70 bg-muted/45 px-4 py-3 transition-opacity duration-150 ease-out">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">External change detected</p>
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                  {pendingExternalChange.name} changed on disk while you were editing.
-                </p>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    onReloadAfterExternalChange?.();
-                  }}
-                >
-                  Reload
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    onKeepMineAfterExternalChange?.();
-                  }}
-                >
-                  Keep mine
-                </Button>
-              </div>
+  const externalChangeContent = pendingExternalChange ? (
+    <div className="space-y-4">
+      {pendingExternalChange ? (
+        <div className="rounded-xl border border-border/70 bg-muted/45 px-4 py-3 transition-opacity duration-150 ease-out">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">External change detected</p>
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                {pendingExternalChange.name} changed on disk while you were editing.
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  onReloadAfterExternalChange?.();
+                }}
+              >
+                Reload
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  onKeepMineAfterExternalChange?.();
+                }}
+              >
+                Keep mine
+              </Button>
             </div>
           </div>
-        ) : null}
-        {parsed.frontmatterText ? (
-          <div className="rounded-xl border border-border/70 bg-muted/20 px-4 py-3 font-mono text-[13px] leading-6 text-muted-foreground transition-opacity duration-150 ease-out">
-            <div className="text-muted-foreground/70">---</div>
-            {activeDocument.isEditable ? (
-              <textarea
-                aria-label="Skill frontmatter"
-                className="mt-1 block w-full resize-none overflow-hidden border-0 bg-transparent p-0 font-mono text-[13px] leading-6 text-muted-foreground outline-none"
-                spellCheck={false}
-                rows={frontmatterRows}
-                value={parsed.frontmatterText}
-                onChange={(event) => handleFrontmatterChange(event.target.value)}
-              />
-            ) : (
-              <pre className="mt-1 overflow-x-auto whitespace-pre-wrap font-mono text-[13px] leading-6 text-muted-foreground">
-                {parsed.frontmatterText}
-              </pre>
-            )}
-            <div className="mt-1 text-muted-foreground/70">---</div>
-          </div>
-        ) : null}
-      </div>
-    ) : null;
+        </div>
+      ) : null}
+    </div>
+  ) : null;
 
   return (
     <section className="flex h-full min-h-0 flex-col bg-background">
@@ -207,7 +186,19 @@ export function SkillDocumentPane({
         wordCount={wordCount}
         readingTime={readingTime}
         headerAccessory={headerAccessory}
-        onChange={handleBodyChange}
+        topContent={
+          <>
+            {externalChangeContent}
+            {parsed.frontmatterText ? (
+              <FrontmatterBlock
+                value={parsed.frontmatterText}
+                isEditable={activeDocument.isEditable}
+                onChange={handleFrontmatterChange}
+              />
+            ) : null}
+          </>
+        }
+        onChange={handleContentChange}
         onOpenCommandPalette={onOpenCommandPalette}
         commandPaletteLabel="Search notes and skills"
         commandPaletteShortcut={commandPaletteShortcut}
@@ -221,7 +212,6 @@ export function SkillDocumentPane({
         folderRevealLabel={folderRevealLabel}
         onOpenLinkedFile={onOpenLinkedFile}
         showOutline={shouldShowOutline}
-        topContent={topContent}
       />
     </section>
   );

--- a/apps/desktop/src/components/tasks/task-column.tsx
+++ b/apps/desktop/src/components/tasks/task-column.tsx
@@ -1,6 +1,6 @@
 import { SortableContext, verticalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 
 import { ArrowDownIcon, DotsHorizontalIcon, PlusIcon } from "@/components/icons";
 import {
@@ -34,67 +34,77 @@ function DragGripIcon() {
 
 const COLOR_STYLES: Record<
   TaskColumnColor,
-  { add: string; dot: string; count: string; header: string }
+  { add: string; dot: string; count: string; header: string; resize: string }
 > = {
   amber: {
     add: "hover:border-chart-2/35 hover:text-chart-2",
     count: "bg-chart-2/15 text-chart-2",
     dot: "border-chart-2",
     header: "bg-chart-2/8",
+    resize: "bg-chart-2/45",
   },
   blue: {
     add: "hover:border-primary/35 hover:text-primary",
     count: "bg-primary/10 text-primary",
     dot: "border-primary",
     header: "bg-primary/5",
+    resize: "bg-primary/45",
   },
   cyan: {
     add: "hover:border-chart-3/35 hover:text-chart-3",
     count: "bg-chart-3/15 text-chart-3",
     dot: "border-chart-3",
     header: "bg-chart-3/8",
+    resize: "bg-chart-3/45",
   },
   emerald: {
     add: "hover:border-chart-5/35 hover:text-chart-5",
     count: "bg-chart-5/15 text-chart-5",
     dot: "border-chart-5",
     header: "bg-chart-5/8",
+    resize: "bg-chart-5/45",
   },
   lime: {
     add: "hover:border-chart-5/35 hover:text-chart-5",
     count: "bg-chart-5/15 text-chart-5",
     dot: "border-chart-5",
     header: "bg-chart-5/8",
+    resize: "bg-chart-5/45",
   },
   orange: {
     add: "hover:border-chart-2/35 hover:text-chart-2",
     count: "bg-chart-2/15 text-chart-2",
     dot: "border-chart-2",
     header: "bg-chart-2/8",
+    resize: "bg-chart-2/45",
   },
   pink: {
     add: "hover:border-chart-4/35 hover:text-chart-4",
     count: "bg-chart-4/15 text-chart-4",
     dot: "border-chart-4",
     header: "bg-chart-4/8",
+    resize: "bg-chart-4/45",
   },
   rose: {
     add: "hover:border-destructive/35 hover:text-destructive",
     count: "bg-destructive/12 text-destructive",
     dot: "border-destructive",
     header: "bg-destructive/8",
+    resize: "bg-destructive/45",
   },
   slate: {
     add: "hover:border-muted-foreground/35 hover:text-foreground",
     count: "bg-muted text-muted-foreground",
     dot: "border-muted-foreground",
     header: "bg-muted/40",
+    resize: "bg-muted-foreground/35",
   },
   violet: {
     add: "hover:border-chart-4/35 hover:text-chart-4",
     count: "bg-chart-4/15 text-chart-4",
     dot: "border-chart-4",
     header: "bg-chart-4/8",
+    resize: "bg-chart-4/45",
   },
 };
 
@@ -112,7 +122,13 @@ type TaskColumnProps = {
   onMoveTask: (taskId: string, columnId: string, index: number) => void;
   onUpdateColumn: (
     columnId: string,
-    patch: { title?: string; color?: TaskColumnColor; collapsed?: boolean; isDone?: boolean },
+    patch: {
+      title?: string;
+      color?: TaskColumnColor;
+      collapsed?: boolean;
+      width?: number | null;
+      isDone?: boolean;
+    },
   ) => void;
   onUpdateTask: (
     taskId: string,
@@ -137,6 +153,8 @@ export const TaskColumn = memo(function TaskColumn({
 }: TaskColumnProps) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftTitle, setDraftTitle] = useState(column.title);
+  const resizeStateRef = useRef<{ startX: number; startWidth: number; width: number } | null>(null);
+  const [liveWidth, setLiveWidth] = useState(column.width ?? 340);
 
   useEffect(() => {
     if (!isRenaming) {
@@ -148,6 +166,22 @@ export const TaskColumn = memo(function TaskColumn({
     data: { columnId: column.id, type: "column" },
   });
   const color = COLOR_STYLES[column.color];
+  const columnWidth = liveWidth;
+
+  useEffect(() => {
+    setLiveWidth(column.width ?? 340);
+  }, [column.width]);
+
+  useEffect(() => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    return () => {
+      if (resizeStateRef.current) {
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    };
+  }, []);
 
   const toggleCollapsed = useCallback(() => {
     onUpdateColumn(column.id, { collapsed: !column.collapsed });
@@ -166,6 +200,59 @@ export const TaskColumn = memo(function TaskColumn({
     }
     setIsRenaming(false);
   }, [column.id, column.title, draftTitle, onUpdateColumn]);
+
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startWidth = liveWidth;
+      resizeStateRef.current = { startX: event.clientX, startWidth, width: startWidth };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      document.body.style.userSelect = "none";
+    },
+    [liveWidth],
+  );
+
+  const handleResizePointerMove = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const state = resizeStateRef.current;
+    if (!state) {
+      return;
+    }
+
+    const nextWidth = Math.max(260, Math.min(560, state.startWidth + event.clientX - state.startX));
+    state.width = nextWidth;
+    setLiveWidth(nextWidth);
+  }, []);
+
+  const handleResizePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      const state = resizeStateRef.current;
+      if (!state) {
+        return;
+      }
+
+      resizeStateRef.current = null;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      document.body.style.userSelect = "";
+      onUpdateColumn(column.id, { width: Math.round(state.width) });
+    },
+    [column.id, onUpdateColumn],
+  );
+
+  const handleResizePointerCancel = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const state = resizeStateRef.current;
+    if (!state) {
+      return;
+    }
+
+    resizeStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    document.body.style.userSelect = "";
+    setLiveWidth(state.startWidth);
+  }, []);
 
   if (column.collapsed) {
     return (
@@ -210,9 +297,9 @@ export const TaskColumn = memo(function TaskColumn({
   return (
     <section
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      style={{ transform: CSS.Transform.toString(transform), transition, width: columnWidth }}
       className={cn(
-        "flex h-[calc(100vh-132px)] min-h-[520px] w-[340px] shrink-0 flex-col rounded-lg border border-border bg-muted/25 shadow-xs",
+        "relative flex h-[calc(100vh-132px)] min-h-[520px] shrink-0 flex-col rounded-lg border border-border bg-muted/25 shadow-xs",
         isDragging ? "opacity-55 shadow-md" : "",
       )}
       aria-label={`${column.title} tasks`}
@@ -367,6 +454,22 @@ export const TaskColumn = memo(function TaskColumn({
           Add a Task
         </button>
       </div>
+      <button
+        type="button"
+        aria-label={`Resize ${column.title} list`}
+        className="group/resize absolute top-2 right-[-4px] bottom-2 z-10 flex w-2 cursor-col-resize items-center justify-center rounded-full outline-none"
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerUp}
+        onPointerCancel={handleResizePointerCancel}
+      >
+        <span
+          className={cn(
+            "h-10 w-1 rounded-full opacity-0 transition-opacity duration-100 ease-out group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100 group-active/resize:opacity-100",
+            color.resize,
+          )}
+        />
+      </button>
     </section>
   );
 });

--- a/apps/desktop/src/components/tasks/tasks-view.tsx
+++ b/apps/desktop/src/components/tasks/tasks-view.tsx
@@ -37,7 +37,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type { TaskColumn as TaskColumnModel, TaskColumnColor, WorkspaceTask } from "@/core/tasks";
+import type {
+  TaskColumn as TaskColumnModel,
+  TaskColumnColor,
+  TaskColumnUpdateInput,
+  WorkspaceTask,
+} from "@/core/tasks";
 import { TASK_COLUMN_COLORS_PICKER } from "@/core/tasks";
 import { cn } from "@/core/utils";
 import { applyTaskMutation, groupTasksByColumn, useTasksStore } from "@/store/tasks";
@@ -511,10 +516,7 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
   );
 
   const handleUpdateColumn = useCallback(
-    (
-      columnId: string,
-      patch: { title?: string; color?: TaskColumnColor; collapsed?: boolean; isDone?: boolean },
-    ) => {
+    (columnId: string, patch: Omit<TaskColumnUpdateInput, "id">) => {
       void runMutation(glyph.updateTaskColumn({ id: columnId, ...patch }));
     },
     [glyph, runMutation],

--- a/apps/desktop/src/core/frontmatter.ts
+++ b/apps/desktop/src/core/frontmatter.ts
@@ -1,0 +1,78 @@
+import { parseDocument } from "yaml";
+
+export type ParsedMarkdownFrontmatter = {
+  frontmatterText: string | null;
+  body: string;
+};
+
+export function parseMarkdownFrontmatter(content: string): ParsedMarkdownFrontmatter {
+  const normalizedContent = content.replace(/\r\n?/g, "\n");
+  const lines = normalizedContent.split("\n");
+
+  if (lines[0] !== "---") {
+    return { frontmatterText: null, body: normalizedContent };
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (endIndex <= 0) {
+    return { frontmatterText: null, body: normalizedContent };
+  }
+
+  const frontmatterText = lines.slice(1, endIndex).join("\n");
+
+  return {
+    frontmatterText: frontmatterText.length > 0 ? frontmatterText : null,
+    body: lines
+      .slice(endIndex + 1)
+      .join("\n")
+      .trimStart(),
+  };
+}
+
+export function serializeMarkdownFrontmatter({
+  frontmatterText,
+  body,
+}: {
+  frontmatterText: string | null;
+  body: string;
+}) {
+  const normalizedFrontmatter = (frontmatterText ?? "").replace(/\r\n?/g, "\n");
+  const normalizedBody = body.replace(/\r\n?/g, "\n").replace(/^\n+/, "");
+
+  if (!normalizedFrontmatter.trim()) {
+    return normalizedBody;
+  }
+
+  if (!normalizedBody) {
+    return `---\n${normalizedFrontmatter}\n---\n`;
+  }
+
+  return `---\n${normalizedFrontmatter}\n---\n\n${normalizedBody}`;
+}
+
+export function formatMarkdownFrontmatter(frontmatterText: string) {
+  const normalizedFrontmatter = frontmatterText.replace(/\r\n?/g, "\n").trim();
+  if (!normalizedFrontmatter) {
+    return "";
+  }
+
+  const document = parseDocument(normalizedFrontmatter, {
+    merge: true,
+    prettyErrors: false,
+    strict: false,
+    uniqueKeys: false,
+  });
+
+  if (document.errors.length > 0) {
+    return null;
+  }
+
+  return document
+    .toString({
+      collectionStyle: "block",
+      indent: 2,
+      lineWidth: 0,
+      minContentWidth: 20,
+    })
+    .trim();
+}

--- a/apps/desktop/src/core/skills.ts
+++ b/apps/desktop/src/core/skills.ts
@@ -1,5 +1,7 @@
 import { parseDocument } from "yaml";
 
+import { parseMarkdownFrontmatter, serializeMarkdownFrontmatter } from "./frontmatter.js";
+
 export const SKILL_FILE_NAME = "SKILL.md";
 export const AGENTS_FILE_NAME = "AGENTS.md";
 
@@ -171,18 +173,7 @@ export function serializeSkillDocument({
   frontmatterText: string | null;
   body: string;
 }) {
-  const normalizedFrontmatter = (frontmatterText ?? "").replace(/\r\n?/g, "\n").trim();
-  const normalizedBody = body.replace(/\r\n?/g, "\n").replace(/^\n+/, "");
-
-  if (!normalizedFrontmatter) {
-    return normalizedBody;
-  }
-
-  if (!normalizedBody) {
-    return `---\n${normalizedFrontmatter}\n---\n`;
-  }
-
-  return `---\n${normalizedFrontmatter}\n---\n\n${normalizedBody}`;
+  return serializeMarkdownFrontmatter({ frontmatterText, body });
 }
 
 function normalizeFrontmatterValue(value: unknown): SkillMetadataValue {
@@ -334,25 +325,12 @@ function extractBodyDescription(body: string) {
 }
 
 export function parseSkillDocument(content: string): ParsedSkillDocument {
-  const normalizedContent = content.replace(/\r\n?/g, "\n");
-  const lines = normalizedContent.split("\n");
+  const parsedDocument = parseMarkdownFrontmatter(content);
   let frontmatter: Record<string, SkillMetadataValue> = {};
-  let body = normalizedContent;
-  let frontmatterText: string | null = null;
+  const { frontmatterText, body } = parsedDocument;
 
-  if (lines[0] === "---") {
-    const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
-
-    if (endIndex > 0) {
-      const frontmatterLines = lines.slice(1, endIndex);
-      frontmatterText = frontmatterLines.join("\n").trim() || null;
-      frontmatter = frontmatterText ? parseFrontmatter(frontmatterText) : {};
-
-      body = lines
-        .slice(endIndex + 1)
-        .join("\n")
-        .trimStart();
-    }
+  if (frontmatterText) {
+    frontmatter = parseFrontmatter(frontmatterText);
   }
 
   const titleFromFrontmatter = getSkillMetadataString(

--- a/apps/desktop/src/core/tasks.ts
+++ b/apps/desktop/src/core/tasks.ts
@@ -30,6 +30,7 @@ export type TaskColumn = {
   title: string;
   color: TaskColumnColor;
   collapsed: boolean;
+  width: number | null;
   /** When true, tasks in this column are considered "done" for archiving and visual dimming. */
   isDone: boolean;
   taskIds: string[];
@@ -131,6 +132,7 @@ export type TaskColumnUpdateInput = {
   title?: string;
   color?: TaskColumnColor;
   collapsed?: boolean;
+  width?: number | null;
   isDone?: boolean;
 };
 

--- a/apps/desktop/src/hooks/use-skill-library-controller.ts
+++ b/apps/desktop/src/hooks/use-skill-library-controller.ts
@@ -73,6 +73,7 @@ export function useSkillLibraryController(
   const draftContentRef = useRef(draftContent);
   const lastSyncedContentRef = useRef("");
   const isSavingRef = useRef(false);
+  const recentlySavedPathRef = useRef<string | null>(null);
   const autosaveTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const documentRequestNonceRef = useRef(0);
   const searchRequestNonceRef = useRef(0);
@@ -300,10 +301,8 @@ export function useSkillLibraryController(
 
     try {
       const savedDocument = await glyph.saveSkillDocument(currentDocument.path, nextDraft);
-      setActiveDocument(savedDocument);
-      setDraftContent(savedDocument.content);
-      draftContentRef.current = savedDocument.content;
-      lastSyncedContentRef.current = savedDocument.content;
+      recentlySavedPathRef.current = currentDocument.path;
+      lastSyncedContentRef.current = nextDraft;
       setLastSavedAt(savedDocument.lastModifiedAt);
       setPendingExternalChange(null);
       return true;
@@ -520,18 +519,32 @@ export function useSkillLibraryController(
     }
 
     return glyph.onSkillLibraryChanged((event) => {
+      const currentDocument = activeDocumentRef.current;
+      const isCurrentDocumentChanged = currentDocument
+        ? event.changedPaths.some((changedPath) => isSamePath(changedPath, currentDocument.path))
+        : false;
+
       setSnapshot(event.snapshot);
 
-      const currentDocument = activeDocumentRef.current;
+      if (
+        isCurrentDocumentChanged &&
+        currentDocument &&
+        recentlySavedPathRef.current &&
+        isSamePath(recentlySavedPathRef.current, currentDocument.path)
+      ) {
+        recentlySavedPathRef.current = null;
+        return;
+      }
+
+      if (isCurrentDocumentChanged && isSavingRef.current) {
+        return;
+      }
+
       if (!currentDocument) {
         return;
       }
 
-      const isCurrentDocumentChanged = event.changedPaths.some((changedPath) =>
-        isSamePath(changedPath, currentDocument.path),
-      );
-
-      if (!isCurrentDocumentChanged || isSavingRef.current) {
+      if (!isCurrentDocumentChanged) {
         return;
       }
 


### PR DESCRIPTION
## Summary

- Add task completion polish: tasks moved into Done lists now receive today's date, and Kanban list widths can be resized and persisted in `Tasks.md` metadata.
- Improve frontmatter editing: notes and skills render frontmatter as an inline metadata block while keeping YAML out of the Tiptap serializer so names/descriptions are not corrupted.
- Stabilize skill autosave: skill saves now preserve the live draft and ignore watcher events from the app's own save to avoid full-page refreshes while editing.

## Validation

- `pnpm typecheck:desktop`
- `pnpm --filter @glyph/desktop lint`
- `pnpm --filter @glyph/desktop test:e2e -- e2e/tests/tasks.spec.ts`
- Commit hook: `pnpm fmt:check`, `pnpm lint`, `pnpm -r typecheck`

Lint reports existing `no-empty-pattern` warnings in desktop e2e specs, with no errors.
