### PR TITLE
feat(desktop): unified top navbar with cross-surface navigation

### DIFF
--- a/apps/desktop/e2e/tests/app-launch.spec.ts
+++ b/apps/desktop/e2e/tests/app-launch.spec.ts
@@ -1,9 +1,10 @@
+/* eslint-disable no-empty-pattern */
 import { expect, test } from "@playwright/test";
 
 import { launchGlyph } from "../helpers";
 import { expectAppShell, openWorkspace, selectPaletteItem } from "../navigation";
 
-test("launches Glyph and opens settings from the command palette", async (_, testInfo) => {
+test("launches Glyph and opens settings from the command palette", async ({}, testInfo) => {
   const glyph = await launchGlyph();
 
   try {
@@ -17,7 +18,7 @@ test("launches Glyph and opens settings from the command palette", async (_, tes
   }
 });
 
-test("opens a seeded markdown note from the workspace", async (_, testInfo) => {
+test("opens a seeded markdown note from the workspace", async ({}, testInfo) => {
   const glyph = await launchGlyph();
 
   try {

--- a/apps/desktop/e2e/tests/app-launch.spec.ts
+++ b/apps/desktop/e2e/tests/app-launch.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { launchGlyph } from "../helpers";
 import { expectAppShell, openWorkspace, selectPaletteItem } from "../navigation";
 
-test("launches Glyph and opens settings from the command palette", async ({}, testInfo) => {
+test("launches Glyph and opens settings from the command palette", async (_, testInfo) => {
   const glyph = await launchGlyph();
 
   try {
@@ -17,7 +17,7 @@ test("launches Glyph and opens settings from the command palette", async ({}, te
   }
 });
 
-test("opens a seeded markdown note from the workspace", async ({}, testInfo) => {
+test("opens a seeded markdown note from the workspace", async (_, testInfo) => {
   const glyph = await launchGlyph();
 
   try {

--- a/apps/desktop/e2e/tests/command-palette.spec.ts
+++ b/apps/desktop/e2e/tests/command-palette.spec.ts
@@ -1,9 +1,10 @@
+/* eslint-disable no-empty-pattern */
 import { expect, test } from "@playwright/test";
 
 import { launchGlyph } from "../helpers";
 import { expectAppShell, openCommandPalette, openWorkspace } from "../navigation";
 
-test("command palette closes on Escape key", async (_, testInfo) => {
+test("command palette closes on Escape key", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -17,7 +18,7 @@ test("command palette closes on Escape key", async (_, testInfo) => {
   }
 });
 
-test("command palette search filters results to matching file names", async (_, testInfo) => {
+test("command palette search filters results to matching file names", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -32,7 +33,7 @@ test("command palette search filters results to matching file names", async (_, 
   }
 });
 
-test("command palette shows settings option", async (_, testInfo) => {
+test("command palette shows settings option", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);

--- a/apps/desktop/e2e/tests/command-palette.spec.ts
+++ b/apps/desktop/e2e/tests/command-palette.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { launchGlyph } from "../helpers";
 import { expectAppShell, openCommandPalette, openWorkspace } from "../navigation";
 
-test("command palette closes on Escape key", async ({}, testInfo) => {
+test("command palette closes on Escape key", async (_, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -17,7 +17,7 @@ test("command palette closes on Escape key", async ({}, testInfo) => {
   }
 });
 
-test("command palette search filters results to matching file names", async ({}, testInfo) => {
+test("command palette search filters results to matching file names", async (_, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -32,7 +32,7 @@ test("command palette search filters results to matching file names", async ({},
   }
 });
 
-test("command palette shows settings option", async ({}, testInfo) => {
+test("command palette shows settings option", async (_, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);

--- a/apps/desktop/e2e/tests/tabs.spec.ts
+++ b/apps/desktop/e2e/tests/tabs.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty-pattern */
 import { test, expect } from "@playwright/test";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -21,7 +22,7 @@ import {
   triggerTabSwitchShortcut,
 } from "../navigation";
 
-test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async (_, testInfo) => {
+test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -128,7 +129,7 @@ test("opens notes in multiple tabs and switches between them with keyboard short
   }
 });
 
-test("supports last-tab and adjacent tab keyboard shortcuts across long tab rails", async (_, testInfo) => {
+test("supports last-tab and adjacent tab keyboard shortcuts across long tab rails", async ({}, testInfo) => {
   const sandbox = await createGlyphSandbox();
   const generatedTabs = Array.from({ length: 8 }, (_, index) => {
     const label = String(index + 1).padStart(2, "0");
@@ -197,7 +198,7 @@ test("supports last-tab and adjacent tab keyboard shortcuts across long tab rail
   }
 });
 
-test("creates and closes tabs from shortcuts and restores tab sessions after relaunch", async (_, testInfo) => {
+test("creates and closes tabs from shortcuts and restores tab sessions after relaunch", async ({}, testInfo) => {
   const sandbox = await createGlyphSandbox();
   let firstRun: Awaited<ReturnType<typeof launchGlyph>> | null = null;
   let secondRun: Awaited<ReturnType<typeof launchGlyph>> | null = null;

--- a/apps/desktop/e2e/tests/tabs.spec.ts
+++ b/apps/desktop/e2e/tests/tabs.spec.ts
@@ -21,7 +21,7 @@ import {
   triggerTabSwitchShortcut,
 } from "../navigation";
 
-test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async ({}, testInfo) => {
+test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async (_, testInfo) => {
   const glyph = await launchGlyph();
   try {
     await expectAppShell(glyph.window);
@@ -128,7 +128,7 @@ test("opens notes in multiple tabs and switches between them with keyboard short
   }
 });
 
-test("supports last-tab and adjacent tab keyboard shortcuts across long tab rails", async ({}, testInfo) => {
+test("supports last-tab and adjacent tab keyboard shortcuts across long tab rails", async (_, testInfo) => {
   const sandbox = await createGlyphSandbox();
   const generatedTabs = Array.from({ length: 8 }, (_, index) => {
     const label = String(index + 1).padStart(2, "0");
@@ -197,7 +197,7 @@ test("supports last-tab and adjacent tab keyboard shortcuts across long tab rail
   }
 });
 
-test("creates and closes tabs from shortcuts and restores tab sessions after relaunch", async ({}, testInfo) => {
+test("creates and closes tabs from shortcuts and restores tab sessions after relaunch", async (_, testInfo) => {
   const sandbox = await createGlyphSandbox();
   let firstRun: Awaited<ReturnType<typeof launchGlyph>> | null = null;
   let secondRun: Awaited<ReturnType<typeof launchGlyph>> | null = null;

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -8,6 +8,7 @@ import type {
 import { Sidebar } from "./sidebar/sidebar";
 
 type AppLayoutProps = {
+  toolbar?: React.ReactNode;
   shouldCollapseSidebar: boolean;
   tree: SidebarTopLevelNode[];
   activePath: string | null;
@@ -40,6 +41,7 @@ type AppLayoutProps = {
 };
 
 export function AppLayout({
+  toolbar,
   shouldCollapseSidebar,
   tree,
   activePath,
@@ -71,46 +73,49 @@ export function AppLayout({
   children,
 }: AppLayoutProps) {
   return (
-    <div
-      className={`grid h-screen min-h-0 overflow-hidden transition-[grid-template-columns] duration-200 ${
-        shouldCollapseSidebar ? "grid-cols-[0_minmax(0,1fr)]" : "grid-cols-[280px_minmax(0,1fr)]"
-      }`}
-    >
-      {shouldCollapseSidebar ? (
-        <div aria-hidden="true" className="w-0 min-w-0 overflow-hidden" />
-      ) : (
-        <Sidebar
-          tree={tree}
-          activePath={activePath}
-          isCollapsed={isSidebarCollapsed}
-          isNotesExpanded={isNotesExpanded}
-          isSkillsExpanded={isSkillsExpanded}
-          isTasksActive={isTasksActive}
-          openInFolderLabel={openInFolderLabel}
-          pinnedNotes={pinnedNotes}
-          skillCollections={skillCollections}
-          onToggleNotesSection={onToggleNotesSection}
-          onToggleSkillsSection={onToggleSkillsSection}
-          onOpenTasks={onOpenTasks}
-          onSelectSkillCollection={onSelectSkillCollection}
-          onOpenFile={onOpenFile}
-          onOpenCommandPalette={onOpenCommandPalette}
-          onDeleteFile={onDeleteFile}
-          onDeleteFolder={onDeleteFolder}
-          onRemoveFileFromGlyph={onRemoveFileFromGlyph}
-          onTogglePinnedFile={onTogglePinnedFile}
-          onRemoveFolder={onRemoveFolder}
-          onRenameFile={onRenameFile}
-          onRenameFolder={onRenameFolder}
-          onRevealInFinder={onRevealInFinder}
-          onToggleFolder={onToggleFolder}
-          onReorderNodes={onReorderNodes}
-          onCreateNote={onCreateNote}
-          onCreateFolder={onCreateFolder}
-        />
-      )}
+    <div className="flex h-screen flex-col overflow-hidden">
+      {toolbar ? <div className="shrink-0 bg-sidebar">{toolbar}</div> : null}
+      <div
+        className={`grid flex-1 min-h-0 overflow-hidden transition-[grid-template-columns] duration-200 ${
+          shouldCollapseSidebar ? "grid-cols-[0_minmax(0,1fr)]" : "grid-cols-[280px_minmax(0,1fr)]"
+        }`}
+      >
+        {shouldCollapseSidebar ? (
+          <div aria-hidden="true" className="w-0 min-w-0 overflow-hidden" />
+        ) : (
+          <Sidebar
+            tree={tree}
+            activePath={activePath}
+            isCollapsed={isSidebarCollapsed}
+            isNotesExpanded={isNotesExpanded}
+            isSkillsExpanded={isSkillsExpanded}
+            isTasksActive={isTasksActive}
+            openInFolderLabel={openInFolderLabel}
+            pinnedNotes={pinnedNotes}
+            skillCollections={skillCollections}
+            onToggleNotesSection={onToggleNotesSection}
+            onToggleSkillsSection={onToggleSkillsSection}
+            onOpenTasks={onOpenTasks}
+            onSelectSkillCollection={onSelectSkillCollection}
+            onOpenFile={onOpenFile}
+            onOpenCommandPalette={onOpenCommandPalette}
+            onDeleteFile={onDeleteFile}
+            onDeleteFolder={onDeleteFolder}
+            onRemoveFileFromGlyph={onRemoveFileFromGlyph}
+            onTogglePinnedFile={onTogglePinnedFile}
+            onRemoveFolder={onRemoveFolder}
+            onRenameFile={onRenameFile}
+            onRenameFolder={onRenameFolder}
+            onRevealInFinder={onRevealInFinder}
+            onToggleFolder={onToggleFolder}
+            onReorderNodes={onReorderNodes}
+            onCreateNote={onCreateNote}
+            onCreateFolder={onCreateFolder}
+          />
+        )}
 
-      <main className="relative h-full min-h-0 overflow-hidden bg-background">{children}</main>
+        <main className="relative h-full min-h-0 overflow-hidden bg-background">{children}</main>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -122,17 +122,18 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       (skill) => isSamePath(skill.skillFilePath, path) || isSamePath(skill.agentsFilePath, path),
     );
     const opened = await skillsController.openSkillByPath(path);
-    if (opened) {
-      const nextCollectionId = matchingSkill
-        ? matchingSkill.sourceId === "agents-global"
-          ? "global-skills"
-          : matchingSkill.sourceId === "project-skills"
-            ? "project-skills"
-            : `${matchingSkill.sourceKind}-tool`
-        : "all-skills";
-      setSkillsExpanded(true);
-      setSelectedSkillCollectionId(nextCollectionId);
+    if (!opened) {
+      return;
     }
+    const nextCollectionId = matchingSkill
+      ? matchingSkill.sourceId === "agents-global"
+        ? "global-skills"
+        : matchingSkill.sourceId === "project-skills"
+          ? "project-skills"
+          : `${matchingSkill.sourceKind}-tool`
+      : "all-skills";
+    setSkillsExpanded(true);
+    setSelectedSkillCollectionId(nextCollectionId);
     setViewerMode("skill");
   };
   onRestoreTasksRef.current = () => {

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -33,6 +33,7 @@ import { SkillView } from "./skills/skill-view";
 import { SkillsBrowserPane } from "./skills/skills-browser-pane";
 import { SplitContainer } from "./split-container";
 import { SplitViewActivePaneProvider, SplitViewProvider } from "./split-view-context";
+import { TasksHeaderActions } from "./tasks/tasks-header-actions";
 const LazyTasksView = React.lazy(() =>
   import("./tasks/tasks-view").then((module) => ({ default: module.TasksView })),
 );
@@ -97,15 +98,47 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     hasCapturedInitialSessionRef.current = true;
   }
 
+  // Stable refs for cross-surface navigation callbacks — populated after
+  // skillsController and setViewerMode are in scope.
+  const onRestoreSkillRef = useRef<(path: string) => Promise<void>>(async () => {});
+  const onRestoreTasksRef = useRef<() => void>(() => {});
+
   const controller = useDesktopAppController(glyph, {
     initialFilePath: initialNoteSessionRef.current.filePath,
     initialTabPaths: initialNoteSessionRef.current.tabPaths,
     initialWorkspacePath: initialNoteSessionRef.current.workspacePath,
     sessionReady: sessionHasHydrated,
+    onRestoreSkill: useCallback((path: string) => onRestoreSkillRef.current(path), []),
+    onRestoreTasks: useCallback(() => onRestoreTasksRef.current(), []),
   });
   const skillsController = useSkillLibraryController(glyph, {
     enabled: true,
   });
+
+  // Wire cross-surface navigation restore callbacks (populated each render so
+  // the stable refs always call the latest closures).
+  onRestoreSkillRef.current = async (path: string) => {
+    const matchingSkill = (skillsController.snapshot?.skills ?? []).find(
+      (skill) => isSamePath(skill.skillFilePath, path) || isSamePath(skill.agentsFilePath, path),
+    );
+    const opened = await skillsController.openSkillByPath(path);
+    if (opened) {
+      const nextCollectionId = matchingSkill
+        ? matchingSkill.sourceId === "agents-global"
+          ? "global-skills"
+          : matchingSkill.sourceId === "project-skills"
+            ? "project-skills"
+            : `${matchingSkill.sourceKind}-tool`
+        : "all-skills";
+      setSkillsExpanded(true);
+      setSelectedSkillCollectionId(nextCollectionId);
+    }
+    setViewerMode("skill");
+  };
+  onRestoreTasksRef.current = () => {
+    setSelectedSkillCollectionId(null);
+    setViewerMode("tasks");
+  };
   const [pendingNoteRename, setPendingNoteRename] = useState<PendingNoteRename | null>(null);
   const [pendingNoteConfirm, setPendingNoteConfirm] = useState<PendingNoteConfirm | null>(null);
   const [paletteSkillResultIds, setPaletteSkillResultIds] = useState<string[] | null>(null);
@@ -281,6 +314,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         await skillsController.openSkill(skillId);
       }
 
+      useWorkspaceStore.getState().pushHistory({ kind: "skill", path: targetPath });
       setViewerMode("skill");
     },
     [allSkills, getPreferredSkillDocumentKind, setViewerMode, skillsController],
@@ -451,6 +485,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
 
   const handleOpenTasks = useCallback(() => {
     setSelectedSkillCollectionId(null);
+    useWorkspaceStore.getState().pushHistory({ kind: "tasks" });
     setViewerMode("tasks");
   }, [setSelectedSkillCollectionId, setViewerMode]);
 
@@ -492,6 +527,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
           activateSkillCollection("all-skills");
         }
 
+        useWorkspaceStore.getState().pushHistory({ kind: "skill", path: targetPath });
         setViewerMode("skill");
         return;
       }
@@ -1182,8 +1218,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
 
   const toPathKey = useCallback((path: string) => normalizePath(path).toLowerCase(), []);
   const isMacLike = useMemo(() => navigator.platform.includes("Mac"), []);
-  const noteHeaderPaddingClass =
-    (controller.isSidebarCollapsed || controller.isFocusMode) && isMacLike ? "pl-20 pr-4" : "px-4";
+  const noteHeaderPaddingClass = isMacLike ? "pl-20 pr-4" : "px-4";
   const noteUpdateStateFlags = useUpdateStateFlags(
     controller.updateState,
     controller.appInfo?.updatesMode,
@@ -1389,9 +1424,240 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       isSamePath(filePath, activeNoteFile.path),
     );
 
+  const toolbarNode: React.ReactNode = isAppBootstrapping ? (
+    <div
+      className={`flex items-center gap-2 border-b border-border/40 py-2 ${noteHeaderPaddingClass}`}
+    >
+      <div className="h-8 w-8 rounded-md bg-muted/70 motion-safe:animate-pulse" />
+      <div className="mx-auto h-8 w-full max-w-sm rounded-full bg-muted/60 motion-safe:animate-pulse" />
+      <div className="h-8 w-8 rounded-md bg-muted/70 motion-safe:animate-pulse" />
+    </div>
+  ) : isTasksSurfaceVisible ? (
+    <EditorToolbar
+      _isMacLike={isMacLike}
+      isSidebarCollapsed={controller.isSidebarCollapsed}
+      toggleSidebarShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-sidebar",
+        navigator.platform,
+      )}
+      onToggleSidebar={handleToggleSidebar}
+      canGoBack={controller.canGoBack}
+      canGoForward={controller.canGoForward}
+      navigateBackShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-back",
+        navigator.platform,
+      )}
+      navigateForwardShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-forward",
+        navigator.platform,
+      )}
+      onNavigateBack={handleNavigateBack}
+      onNavigateForward={handleNavigateForward}
+      onCreateNote={undefined}
+      newNoteShortcut={undefined}
+      fileName={null}
+      filePath={null}
+      shouldShowCommandPalette={true}
+      onOpenCommandPalette={handleOpenCommandPalette}
+      commandPaletteShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "command-palette",
+        navigator.platform,
+      )}
+      commandPaletteLabel="Search notes and skills"
+      isFocusMode={undefined}
+      onToggleFocusMode={undefined}
+      focusModeShortcut={undefined}
+      shouldShowUpdateActionButton={false}
+      shouldShowMoreOptions={false}
+      updateButtonVariant="outline"
+      isUpdateButtonDisabled={true}
+      updateButtonLabel=""
+      updateButtonTooltip=""
+      onUpdateAction={undefined}
+      onDismissUpdateAction={undefined}
+      isManualReleaseButton={false}
+      headerPaddingClass={noteHeaderPaddingClass}
+      onOpenSettings={handleOpenSettings}
+      headerAccessory={
+        <TasksHeaderActions glyph={glyph} onOpenMarkdown={() => void handleOpenTasksMarkdown()} />
+      }
+      content=""
+      documentLabel="task"
+      revealInFolderLabel={controller.folderRevealLabel}
+      onCopy={handleDisabledToolbarAction}
+      onCopyPath={handleDisabledToolbarAction}
+      onOpenExternal={handleDisabledToolbarAction}
+      onExportPDF={handleDisabledToolbarAction}
+      onTogglePinnedFile={undefined}
+      isActiveFilePinned={false}
+      editorScale={controller.editorScale}
+      onEditorScaleChange={undefined}
+      zoomInShortcut={undefined}
+      zoomOutShortcut={undefined}
+      zoomResetShortcut={undefined}
+    />
+  ) : isSkillSurfaceVisible ? (
+    <EditorToolbar
+      _isMacLike={isMacLike}
+      isSidebarCollapsed={controller.isSidebarCollapsed}
+      toggleSidebarShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-sidebar",
+        navigator.platform,
+      )}
+      onToggleSidebar={handleToggleSidebar}
+      canGoBack={controller.canGoBack}
+      canGoForward={controller.canGoForward}
+      navigateBackShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-back",
+        navigator.platform,
+      )}
+      navigateForwardShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-forward",
+        navigator.platform,
+      )}
+      onNavigateBack={handleNavigateBack}
+      onNavigateForward={handleNavigateForward}
+      onCreateNote={undefined}
+      newNoteShortcut={undefined}
+      fileName={skillsController.activeDocument?.name ?? null}
+      filePath={null}
+      shouldShowCommandPalette={true}
+      onOpenCommandPalette={handleOpenCommandPalette}
+      commandPaletteShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "command-palette",
+        navigator.platform,
+      )}
+      commandPaletteLabel="Search notes and skills"
+      isFocusMode={undefined}
+      onToggleFocusMode={undefined}
+      focusModeShortcut={undefined}
+      shouldShowUpdateActionButton={false}
+      shouldShowMoreOptions={Boolean(skillsController.activeDocument)}
+      updateButtonVariant="outline"
+      isUpdateButtonDisabled={true}
+      updateButtonLabel=""
+      updateButtonTooltip=""
+      onUpdateAction={undefined}
+      onDismissUpdateAction={undefined}
+      isManualReleaseButton={false}
+      headerPaddingClass={noteHeaderPaddingClass}
+      onOpenSettings={handleOpenSettings}
+      headerAccessory={null}
+      content={skillsController.draftContent}
+      documentLabel="skill"
+      revealInFolderLabel={controller.folderRevealLabel}
+      onCopy={() => copyText(skillsController.draftContent)}
+      onCopyPath={() =>
+        skillsController.activeDocument
+          ? copyText(skillsController.activeDocument.path)
+          : Promise.resolve()
+      }
+      onOpenExternal={() =>
+        skillsController.activeDocument
+          ? skillsController.revealInFinder(skillsController.activeDocument.path)
+          : Promise.resolve()
+      }
+      onExportPDF={() =>
+        skillsController.activeDocument
+          ? exportDocumentToPdf(skillsController.draftContent, skillsController.activeDocument.name)
+          : Promise.resolve()
+      }
+      onTogglePinnedFile={undefined}
+      isActiveFilePinned={false}
+      editorScale={controller.editorScale}
+      onEditorScaleChange={undefined}
+      zoomInShortcut={undefined}
+      zoomOutShortcut={undefined}
+      zoomResetShortcut={undefined}
+    />
+  ) : (
+    <EditorToolbar
+      _isMacLike={isMacLike}
+      isSidebarCollapsed={controller.isSidebarCollapsed}
+      toggleSidebarShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-sidebar",
+        navigator.platform,
+      )}
+      onToggleSidebar={handleToggleSidebar}
+      canGoBack={controller.canGoBack}
+      canGoForward={controller.canGoForward}
+      navigateBackShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-back",
+        navigator.platform,
+      )}
+      navigateForwardShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "navigate-forward",
+        navigator.platform,
+      )}
+      onNavigateBack={() => void controller.navigateBack()}
+      onNavigateForward={() => void controller.navigateForward()}
+      onCreateNote={() => void controller.createNote()}
+      newNoteShortcut={getShortcutDisplay(controller.shortcuts, "new-note", navigator.platform)}
+      fileName={activeNoteFile?.name ?? null}
+      filePath={activeNoteFile?.path ?? null}
+      shouldShowCommandPalette={true}
+      onOpenCommandPalette={handleOpenCommandPalette}
+      commandPaletteShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "command-palette",
+        navigator.platform,
+      )}
+      commandPaletteLabel="Search notes and skills"
+      isFocusMode={controller.isFocusMode}
+      onToggleFocusMode={() => void controller.toggleFocusMode()}
+      focusModeShortcut={getShortcutDisplay(controller.shortcuts, "focus-mode", navigator.platform)}
+      shouldShowUpdateActionButton={noteUpdateStateFlags.shouldShowUpdateActionButton}
+      shouldShowMoreOptions={true}
+      updateButtonVariant={noteUpdateStateFlags.updateButtonVariant}
+      isUpdateButtonDisabled={noteUpdateStateFlags.isUpdateButtonDisabled}
+      updateButtonLabel={noteUpdateStateFlags.updateButtonLabel}
+      updateButtonTooltip={noteUpdateStateFlags.updateButtonTooltip}
+      onUpdateAction={() => void controller.triggerUpdateAction()}
+      onDismissUpdateAction={() => void controller.dismissUpdateNotification()}
+      isManualReleaseButton={noteUpdateStateFlags.isManualReleaseButton}
+      headerPaddingClass={noteHeaderPaddingClass}
+      onOpenSettings={handleOpenSettings}
+      headerAccessory={null}
+      content={controller.draftContent}
+      documentLabel="note"
+      revealInFolderLabel={controller.folderRevealLabel}
+      onCopy={() => copyText(controller.draftContent)}
+      onCopyPath={() => (activeNoteFile ? copyText(activeNoteFile.path) : Promise.resolve())}
+      onOpenExternal={() =>
+        activeNoteFile ? controller.revealInFinder(activeNoteFile.path) : Promise.resolve()
+      }
+      onExportPDF={() =>
+        activeNoteFile
+          ? exportDocumentToPdf(controller.draftContent, activeNoteFile.name)
+          : Promise.resolve()
+      }
+      onTogglePinnedFile={
+        activeNoteFile ? () => void controller.togglePinnedFile(activeNoteFile.path) : undefined
+      }
+      isActiveFilePinned={Boolean(isActiveNotePinned)}
+      editorScale={controller.editorScale}
+      onEditorScaleChange={(scale) => void controller.setEditorScale(scale)}
+      zoomInShortcut={getShortcutDisplay(controller.shortcuts, "zoom-in", navigator.platform)}
+      zoomOutShortcut={getShortcutDisplay(controller.shortcuts, "zoom-out", navigator.platform)}
+      zoomResetShortcut={getShortcutDisplay(controller.shortcuts, "zoom-reset", navigator.platform)}
+    />
+  );
+
   return (
     <TooltipProvider>
       <AppLayout
+        toolbar={toolbarNode}
         shouldCollapseSidebar={shouldCollapseSidebar}
         tree={controller.visibleSidebarNodes}
         activePath={viewerMode === "note" ? (controller.activeFile?.path ?? null) : null}
@@ -1457,17 +1723,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
           <div className="min-h-0 min-w-0">
             {isAppBootstrapping ? (
               <div className="flex h-full min-h-0 flex-col bg-background">
-                <div
-                  className={`flex items-center gap-2 border-b border-border/40 py-2 ${
-                    controller.isSidebarCollapsed && navigator.platform.includes("Mac")
-                      ? "pl-20 pr-4"
-                      : "px-4"
-                  }`}
-                >
-                  <div className="h-8 w-8 rounded-md bg-muted/70 motion-safe:animate-pulse" />
-                  <div className="mx-auto h-8 w-full max-w-sm rounded-full bg-muted/60 motion-safe:animate-pulse" />
-                  <div className="h-8 w-8 rounded-md bg-muted/70 motion-safe:animate-pulse" />
-                </div>
                 <div className="flex min-h-0 flex-1 flex-col gap-4 px-8 py-8">
                   <div className="h-6 w-40 rounded-md bg-muted/60 motion-safe:animate-pulse" />
                   <div className="h-4 w-72 rounded-md bg-muted/40 motion-safe:animate-pulse" />
@@ -1478,74 +1733,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
               </div>
             ) : isTasksSurfaceVisible ? (
               <div className="flex h-full min-h-0 flex-col bg-background">
-                <div className="sticky top-0 z-20 shrink-0 bg-background/95 supports-backdrop-filter:backdrop-blur-md">
-                  <EditorToolbar
-                    _isMacLike={isMacLike}
-                    isSidebarCollapsed={controller.isSidebarCollapsed}
-                    toggleSidebarShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "toggle-sidebar",
-                      navigator.platform,
-                    )}
-                    onToggleSidebar={handleToggleSidebar}
-                    canGoBack={controller.canGoBack}
-                    canGoForward={controller.canGoForward}
-                    navigateBackShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "navigate-back",
-                      navigator.platform,
-                    )}
-                    navigateForwardShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "navigate-forward",
-                      navigator.platform,
-                    )}
-                    onNavigateBack={handleNavigateBack}
-                    onNavigateForward={handleNavigateForward}
-                    onCreateNote={undefined}
-                    newNoteShortcut={undefined}
-                    surfaceTitle="Tasks"
-                    fileName={null}
-                    filePath={null}
-                    shouldShowCommandPalette={true}
-                    onOpenCommandPalette={handleOpenCommandPalette}
-                    commandPaletteShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "command-palette",
-                      navigator.platform,
-                    )}
-                    commandPaletteLabel="Search notes and skills"
-                    isFocusMode={undefined}
-                    onToggleFocusMode={undefined}
-                    focusModeShortcut={undefined}
-                    shouldShowUpdateActionButton={false}
-                    shouldShowMoreOptions={false}
-                    updateButtonVariant="outline"
-                    isUpdateButtonDisabled={true}
-                    updateButtonLabel=""
-                    updateButtonTooltip=""
-                    onUpdateAction={undefined}
-                    onDismissUpdateAction={undefined}
-                    isManualReleaseButton={false}
-                    headerPaddingClass={noteHeaderPaddingClass}
-                    onOpenSettings={handleOpenSettings}
-                    headerAccessory={null}
-                    content=""
-                    documentLabel="task"
-                    revealInFolderLabel={controller.folderRevealLabel}
-                    onCopy={handleDisabledToolbarAction}
-                    onCopyPath={handleDisabledToolbarAction}
-                    onOpenExternal={handleDisabledToolbarAction}
-                    onExportPDF={handleDisabledToolbarAction}
-                    onTogglePinnedFile={undefined}
-                    isActiveFilePinned={false}
-                    editorScale={controller.editorScale}
-                    onEditorScaleChange={undefined}
-                    zoomInShortcut={undefined}
-                    zoomOutShortcut={undefined}
-                    zoomResetShortcut={undefined}
-                  />
-                </div>
                 <Suspense
                   fallback={
                     <div className="grid h-full place-items-center text-sm text-muted-foreground">
@@ -1556,7 +1743,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                   <LazyTasksView
                     glyph={glyph}
                     onOpenTaskSource={(task) => void handleOpenTaskSource(task)}
-                    onOpenMarkdown={() => void handleOpenTasksMarkdown()}
                   />
                 </Suspense>
               </div>
@@ -1575,13 +1761,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
                 saveStateLabel={skillsController.saveStateLabel}
                 skillInitialScrollTop={skillInitialScrollTop}
                 skillEmptyState={skillEmptyState}
-                isSidebarCollapsed={controller.isSidebarCollapsed}
-                shortcuts={controller.shortcuts}
                 folderRevealLabel={controller.folderRevealLabel}
                 showOutline={controller.showOutline}
-                onSetIsPaletteOpen={controller.setIsPaletteOpen}
-                onSetIsSettingsOpen={controller.setIsSettingsOpen}
-                onToggleSidebar={handleToggleSidebar}
                 onOpenLinkedFile={handleOpenSkillLink}
                 onScrollPositionChange={handleDocumentScrollPositionChange}
                 onDraftContentChange={skillsController.setDraftContent}
@@ -1591,107 +1772,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
               />
             ) : (
               <div className="flex h-full min-h-0 flex-col bg-background">
-                <div className="sticky top-0 z-20 shrink-0 bg-background/95 supports-backdrop-filter:backdrop-blur-md">
-                  <EditorToolbar
-                    _isMacLike={isMacLike}
-                    isSidebarCollapsed={controller.isSidebarCollapsed}
-                    toggleSidebarShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "toggle-sidebar",
-                      navigator.platform,
-                    )}
-                    onToggleSidebar={handleToggleSidebar}
-                    canGoBack={controller.canGoBack}
-                    canGoForward={controller.canGoForward}
-                    navigateBackShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "navigate-back",
-                      navigator.platform,
-                    )}
-                    navigateForwardShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "navigate-forward",
-                      navigator.platform,
-                    )}
-                    onNavigateBack={() => void controller.navigateBack()}
-                    onNavigateForward={() => void controller.navigateForward()}
-                    onCreateNote={() => void controller.createNote()}
-                    newNoteShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "new-note",
-                      navigator.platform,
-                    )}
-                    fileName={activeNoteFile?.name ?? null}
-                    filePath={activeNoteFile?.path ?? null}
-                    shouldShowCommandPalette={true}
-                    onOpenCommandPalette={handleOpenCommandPalette}
-                    commandPaletteShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "command-palette",
-                      navigator.platform,
-                    )}
-                    commandPaletteLabel="Search notes and skills"
-                    isFocusMode={controller.isFocusMode}
-                    onToggleFocusMode={() => void controller.toggleFocusMode()}
-                    focusModeShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "focus-mode",
-                      navigator.platform,
-                    )}
-                    shouldShowUpdateActionButton={noteUpdateStateFlags.shouldShowUpdateActionButton}
-                    shouldShowMoreOptions={true}
-                    updateButtonVariant={noteUpdateStateFlags.updateButtonVariant}
-                    isUpdateButtonDisabled={noteUpdateStateFlags.isUpdateButtonDisabled}
-                    updateButtonLabel={noteUpdateStateFlags.updateButtonLabel}
-                    updateButtonTooltip={noteUpdateStateFlags.updateButtonTooltip}
-                    onUpdateAction={() => void controller.triggerUpdateAction()}
-                    onDismissUpdateAction={() => void controller.dismissUpdateNotification()}
-                    isManualReleaseButton={noteUpdateStateFlags.isManualReleaseButton}
-                    headerPaddingClass={noteHeaderPaddingClass}
-                    onOpenSettings={handleOpenSettings}
-                    headerAccessory={null}
-                    content={controller.draftContent}
-                    documentLabel="note"
-                    revealInFolderLabel={controller.folderRevealLabel}
-                    onCopy={() => copyText(controller.draftContent)}
-                    onCopyPath={() =>
-                      activeNoteFile ? copyText(activeNoteFile.path) : Promise.resolve()
-                    }
-                    onOpenExternal={() =>
-                      activeNoteFile
-                        ? controller.revealInFinder(activeNoteFile.path)
-                        : Promise.resolve()
-                    }
-                    onExportPDF={() =>
-                      activeNoteFile
-                        ? exportDocumentToPdf(controller.draftContent, activeNoteFile.name)
-                        : Promise.resolve()
-                    }
-                    onTogglePinnedFile={
-                      activeNoteFile
-                        ? () => void controller.togglePinnedFile(activeNoteFile.path)
-                        : undefined
-                    }
-                    isActiveFilePinned={Boolean(isActiveNotePinned)}
-                    editorScale={controller.editorScale}
-                    onEditorScaleChange={(scale) => void controller.setEditorScale(scale)}
-                    zoomInShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "zoom-in",
-                      navigator.platform,
-                    )}
-                    zoomOutShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "zoom-out",
-                      navigator.platform,
-                    )}
-                    zoomResetShortcut={getShortcutDisplay(
-                      controller.shortcuts,
-                      "zoom-reset",
-                      navigator.platform,
-                    )}
-                  />
-                </div>
                 <div className="min-h-0 flex-1">
                   <SplitViewProvider value={splitViewContextValue}>
                     <SplitViewActivePaneProvider value={splitViewActivePaneContextValue}>

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -41,7 +41,6 @@ type EditorToolbarProps = {
   onNavigateForward: (() => void) | undefined;
   onCreateNote: (() => void) | undefined;
   newNoteShortcut: string | undefined;
-  surfaceTitle?: string;
   fileName: string | null;
   filePath: string | null;
   shouldShowCommandPalette: boolean;
@@ -92,7 +91,6 @@ export function EditorToolbar({
   onNavigateForward,
   onCreateNote,
   newNoteShortcut,
-  surfaceTitle,
   fileName,
   shouldShowCommandPalette,
   onOpenCommandPalette,
@@ -166,7 +164,9 @@ export function EditorToolbar({
   const searchButtonLabel = commandPaletteLabel ?? "Search notes";
 
   return (
-    <div className={`flex items-center py-2 border-b border-border/40 gap-2 ${headerPaddingClass}`}>
+    <div
+      className={`app-drag-region flex items-center py-2 border-b border-border/40 gap-2 ${headerPaddingClass}`}
+    >
       {/* Left: toolbar + title */}
       <div className="flex items-center gap-1 flex-shrink-0 min-w-0">
         {onToggleSidebar && (
@@ -242,11 +242,6 @@ export function EditorToolbar({
             </TooltipTrigger>
             <TooltipContent side="bottom">{`New Note${newNoteShortcut ? ` (${newNoteShortcut})` : ""}`}</TooltipContent>
           </Tooltip>
-        ) : null}
-        {surfaceTitle ? (
-          <span className="max-w-[220px] truncate pl-1 text-sm font-medium text-foreground">
-            {surfaceTitle}
-          </span>
         ) : null}
       </div>
 

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -165,6 +165,8 @@ export function EditorToolbar({
 
   return (
     <div
+      role="banner"
+      aria-label="Glyph"
       className={`app-drag-region flex items-center py-2 border-b border-border/40 gap-2 ${headerPaddingClass}`}
     >
       {/* Left: toolbar + title */}

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from "react";
-import type { CSSProperties } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -21,7 +20,6 @@ import type {
   SidebarSkillCollectionItem,
 } from "@/types/sidebar";
 
-import { LogoComponent } from "@/components/logo-component";
 import { SkillSourceLogo } from "@/components/skills/skill-source-logo";
 import { ChevronRightIcon, PlusIcon, FolderPlusIcon } from "@/components/icons";
 import { SidebarTreeNode } from "./sidebar-tree-node";
@@ -145,15 +143,6 @@ export const Sidebar = ({
 
   return (
     <aside className="flex h-full min-h-0 w-[280px] flex-col border-r border-border bg-sidebar">
-      <div
-        className="flex items-center justify-center flex-shrink-0 bg-sidebar"
-        style={{ WebkitAppRegion: "drag" } as CSSProperties}
-      >
-        <div style={{ WebkitAppRegion: "no-drag" } as CSSProperties}>
-          <LogoComponent size={120} />
-        </div>
-      </div>
-
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto overflow-x-hidden py-3">
         <div className="mb-3 px-2">
           <button

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -46,7 +46,7 @@ function SidebarSkillCollectionRow({
         <SkillSourceLogo iconKind={item.iconKind} sourceKind={item.sourceKind} variant="compact" />
         <span className="truncate text-sm font-medium">{item.label}</span>
       </span>
-      <span className="ml-3 rounded-full bg-background/80 px-1.5 py-0.5 text-[11px] font-semibold text-muted-foreground">
+      <span className="ml-3 rounded-full px-1.5 py-0.5 text-[11px] font-semibold text-muted-foreground">
         {item.count}
       </span>
     </button>

--- a/apps/desktop/src/components/skills/skill-document-pane.tsx
+++ b/apps/desktop/src/components/skills/skill-document-pane.tsx
@@ -25,22 +25,16 @@ type SkillDocumentPaneProps = {
     name: string;
     path: string;
   } | null;
-  isSidebarCollapsed: boolean;
   isSwitchingDocuments?: boolean;
   saveStateLabel: string;
-  commandPaletteShortcut?: string;
   onChange: (value: string) => void;
   onKeepMineAfterExternalChange?: () => void;
   onOpenLinkedFile?: (path: string) => void;
-  onOpenCommandPalette?: () => void;
-  onOpenSettings?: () => void;
   onReloadAfterExternalChange?: () => void;
   onScrollPositionChange?: (targetPath: string | null, scrollTop: number) => void;
   onSelectDocumentTab: (kind: SkillDocumentKind) => void;
-  onToggleSidebar?: () => void;
   scrollRestorationKey?: string | null;
   showOutline?: boolean;
-  toggleSidebarShortcut?: string;
 };
 
 export function SkillDocumentPane({
@@ -51,22 +45,16 @@ export function SkillDocumentPane({
   folderRevealLabel,
   initialScrollTop = 0,
   pendingExternalChange,
-  isSidebarCollapsed,
   isSwitchingDocuments = false,
   saveStateLabel,
-  commandPaletteShortcut,
   onChange,
   onKeepMineAfterExternalChange,
   onOpenLinkedFile,
-  onOpenCommandPalette,
-  onOpenSettings,
   onReloadAfterExternalChange,
   onScrollPositionChange,
   onSelectDocumentTab,
-  onToggleSidebar,
   scrollRestorationKey = null,
   showOutline = true,
-  toggleSidebarShortcut,
 }: SkillDocumentPaneProps) {
   const parsed = useMemo(() => parseSkillDocument(draftContent), [draftContent]);
   const outlineHeadingCount = useMemo(
@@ -199,19 +187,13 @@ export function SkillDocumentPane({
           </>
         }
         onChange={handleContentChange}
-        onOpenCommandPalette={onOpenCommandPalette}
-        commandPaletteLabel="Search notes and skills"
-        commandPaletteShortcut={commandPaletteShortcut}
-        onOpenSettings={onOpenSettings}
         onScrollPositionChange={onScrollPositionChange}
-        onToggleSidebar={onToggleSidebar}
-        isSidebarCollapsed={isSidebarCollapsed}
         initialScrollTop={initialScrollTop}
         scrollRestorationKey={scrollRestorationKey}
-        toggleSidebarShortcut={toggleSidebarShortcut}
         folderRevealLabel={folderRevealLabel}
         onOpenLinkedFile={onOpenLinkedFile}
         showOutline={shouldShowOutline}
+        showToolbar={false}
       />
     </section>
   );

--- a/apps/desktop/src/components/skills/skill-empty-pane.tsx
+++ b/apps/desktop/src/components/skills/skill-empty-pane.tsx
@@ -1,113 +1,16 @@
-import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-
-import { GearIcon, PanelLeftIcon, PanelRightIcon, SearchIcon } from "../icons";
-
 type SkillEmptyPaneProps = {
-  commandPaletteShortcut?: string;
   description: string;
-  isSidebarCollapsed?: boolean;
-  onOpenCommandPalette?: () => void;
-  onOpenSettings?: () => void;
-  onToggleSidebar?: () => void;
-  titleLabel?: string;
   title: string;
-  toggleSidebarShortcut?: string;
+  titleLabel?: string;
 };
 
-export function SkillEmptyPane({
-  commandPaletteShortcut,
-  description,
-  isSidebarCollapsed = false,
-  onOpenCommandPalette,
-  onOpenSettings,
-  onToggleSidebar,
-  title,
-  titleLabel = "Skills",
-  toggleSidebarShortcut,
-}: SkillEmptyPaneProps) {
-  const isMacLike = navigator.platform.includes("Mac");
-  const headerPaddingClass = isSidebarCollapsed && isMacLike ? "pl-20 pr-4" : "px-4";
-
+export function SkillEmptyPane({ description, title, titleLabel = "Skills" }: SkillEmptyPaneProps) {
   return (
     <section className="flex h-full min-h-0 flex-col bg-background">
-      <div
-        className={`flex items-center gap-2 border-b border-border/40 py-2 ${headerPaddingClass}`}
-      >
-        <div className="flex min-w-0 flex-shrink-0 items-center gap-1">
-          {onToggleSidebar ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="flex-shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  onClick={onToggleSidebar}
-                  aria-label={isSidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-                  type="button"
-                >
-                  {isSidebarCollapsed ? <PanelRightIcon size={16} /> : <PanelLeftIcon size={16} />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {isSidebarCollapsed
-                  ? `Show Sidebar${toggleSidebarShortcut ? ` (${toggleSidebarShortcut})` : ""}`
-                  : `Hide Sidebar${toggleSidebarShortcut ? ` (${toggleSidebarShortcut})` : ""}`}
-              </TooltipContent>
-            </Tooltip>
-          ) : null}
-          <span className="max-w-[220px] truncate pl-1 text-sm font-medium text-foreground">
-            {titleLabel}
-          </span>
-        </div>
-
-        {onOpenCommandPalette ? (
-          <div className="flex min-w-0 flex-1 justify-center px-2">
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full max-w-sm justify-between px-3 py-1.5 text-sm text-muted-foreground shadow-sm hover:bg-accent hover:text-accent-foreground"
-              onClick={onOpenCommandPalette}
-              type="button"
-            >
-              <div className="flex items-center gap-2">
-                <SearchIcon size={13} className="flex-shrink-0 opacity-60" />
-                <span>Search notes and skills</span>
-              </div>
-              <span className="ml-4 flex-shrink-0 font-mono text-xs opacity-50">
-                {commandPaletteShortcut ?? (isMacLike ? "⌘P" : "Ctrl+P")}
-              </span>
-            </Button>
-          </div>
-        ) : (
-          <div className="flex-1" />
-        )}
-
-        <div className="flex flex-shrink-0 items-center gap-1">
-          {onOpenSettings ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-muted-foreground hover:bg-muted hover:text-foreground"
-                  onClick={onOpenSettings}
-                  aria-label="Settings"
-                  type="button"
-                >
-                  <GearIcon size={16} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Settings</TooltipContent>
-            </Tooltip>
-          ) : null}
-        </div>
-      </div>
-
       <div className="flex min-h-0 flex-1 items-center justify-center px-10">
         <div className="mx-auto max-w-md text-center">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            Skills
+            {titleLabel}
           </p>
           <h2 className="mt-3 text-2xl font-semibold tracking-tight text-foreground">{title}</h2>
           <p className="mt-3 text-sm leading-6 text-muted-foreground">{description}</p>

--- a/apps/desktop/src/components/skills/skill-view.tsx
+++ b/apps/desktop/src/components/skills/skill-view.tsx
@@ -1,8 +1,4 @@
-import { useCallback } from "react";
-
-import { getShortcutDisplay } from "@/core/shortcuts";
 import type { SkillDocument, SkillDocumentKind, SkillEntry } from "@/core/skills";
-import type { ShortcutSetting } from "@/core/workspace";
 
 import { SkillDocumentPane } from "./skill-document-pane";
 import { SkillEmptyPane } from "./skill-empty-pane";
@@ -21,13 +17,8 @@ type SkillViewProps = {
   saveStateLabel: string;
   skillInitialScrollTop: number;
   skillEmptyState: { title: string; description: string };
-  isSidebarCollapsed: boolean;
-  shortcuts: ShortcutSetting[];
   folderRevealLabel: string;
   showOutline: boolean;
-  onSetIsPaletteOpen: (open: boolean) => void;
-  onSetIsSettingsOpen: (open: boolean) => void;
-  onToggleSidebar: () => void;
   onOpenLinkedFile: (targetPath: string) => void;
   onScrollPositionChange: (targetPath: string | null, scrollTop: number) => void;
   onDraftContentChange: (value: string) => void;
@@ -50,13 +41,8 @@ export function SkillView({
   saveStateLabel,
   skillInitialScrollTop,
   skillEmptyState,
-  isSidebarCollapsed,
-  shortcuts,
   folderRevealLabel,
   showOutline,
-  onSetIsPaletteOpen,
-  onSetIsSettingsOpen,
-  onToggleSidebar,
   onOpenLinkedFile,
   onScrollPositionChange,
   onDraftContentChange,
@@ -64,31 +50,12 @@ export function SkillView({
   onReloadAfterExternalChange,
   onSelectDocumentTab,
 }: SkillViewProps) {
-  const commandPaletteShortcut =
-    getShortcutDisplay(shortcuts, "command-palette", navigator.platform) ??
-    (navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P");
-  const toggleSidebarShortcut = getShortcutDisplay(shortcuts, "toggle-sidebar", navigator.platform);
-
-  const handleOpenCommandPalette = useCallback(() => {
-    onSetIsPaletteOpen(true);
-  }, [onSetIsPaletteOpen]);
-
-  const handleOpenSettings = useCallback(() => {
-    onSetIsSettingsOpen(true);
-  }, [onSetIsSettingsOpen]);
-
   if (isSkillSurfaceLoading) {
     return (
       <SkillEmptyPane
-        commandPaletteShortcut={commandPaletteShortcut}
         description="Restoring your last skill session and loading the current document."
-        isSidebarCollapsed={isSidebarCollapsed}
-        onOpenCommandPalette={handleOpenCommandPalette}
-        onOpenSettings={handleOpenSettings}
-        onToggleSidebar={onToggleSidebar}
         title="Loading skills"
         titleLabel={activeSkillCollection?.label ?? "Skills"}
-        toggleSidebarShortcut={toggleSidebarShortcut}
       />
     );
   }
@@ -100,24 +67,18 @@ export function SkillView({
         draftContent={draftContent}
         documentTabs={documentTabs}
         fileLabel={activeSkill?.name ?? activeDocument.name}
-        commandPaletteShortcut={commandPaletteShortcut}
         initialScrollTop={skillInitialScrollTop}
-        isSidebarCollapsed={isSidebarCollapsed}
         isSwitchingDocuments={isDocumentLoading || isSaving}
         pendingExternalChange={pendingExternalChange}
         saveStateLabel={saveStateLabel}
         onChange={onDraftContentChange}
         onKeepMineAfterExternalChange={onKeepMineAfterExternalChange}
         showOutline={showOutline}
-        toggleSidebarShortcut={toggleSidebarShortcut}
         folderRevealLabel={folderRevealLabel}
-        onOpenCommandPalette={handleOpenCommandPalette}
         onOpenLinkedFile={onOpenLinkedFile}
-        onOpenSettings={handleOpenSettings}
         onReloadAfterExternalChange={onReloadAfterExternalChange}
         onScrollPositionChange={onScrollPositionChange}
         onSelectDocumentTab={onSelectDocumentTab}
-        onToggleSidebar={onToggleSidebar}
         scrollRestorationKey={activeDocument.path}
       />
     );
@@ -125,15 +86,9 @@ export function SkillView({
 
   return (
     <SkillEmptyPane
-      commandPaletteShortcut={commandPaletteShortcut}
       description={skillEmptyState.description}
-      isSidebarCollapsed={isSidebarCollapsed}
-      onOpenCommandPalette={handleOpenCommandPalette}
-      onOpenSettings={handleOpenSettings}
-      onToggleSidebar={onToggleSidebar}
       title={skillEmptyState.title}
       titleLabel={activeSkillCollection?.label ?? "Skills"}
-      toggleSidebarShortcut={toggleSidebarShortcut}
     />
   );
 }

--- a/apps/desktop/src/components/tasks/tasks-header-actions.tsx
+++ b/apps/desktop/src/components/tasks/tasks-header-actions.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useDeferredValue } from "react";
+
+import {
+  ArchiveIcon,
+  FileIcon,
+  OutlineIcon,
+  PlusIcon,
+  SearchIcon,
+  TickIcon,
+} from "@/components/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { applyTaskMutation, useTasksStore } from "@/store/tasks";
+import { useTasksUIStore, type TasksViewMode } from "@/store/tasks-ui";
+
+type TasksHeaderActionsProps = {
+  glyph: NonNullable<Window["glyph"]>;
+  onOpenMarkdown: () => void;
+};
+
+export function TasksHeaderActions({ glyph, onOpenMarkdown }: TasksHeaderActionsProps) {
+  const columns = useTasksStore((s) => s.columns);
+  const tasks = useTasksStore((s) => s.tasks);
+  const setSnapshot = useTasksStore((s) => s.setSnapshot);
+  const setError = useTasksStore((s) => s.setError);
+
+  const isSearching = useTasksUIStore((s) => s.isSearching);
+  const searchQuery = useTasksUIStore((s) => s.searchQuery);
+  const viewMode = useTasksUIStore((s) => s.viewMode);
+  const setIsSearching = useTasksUIStore((s) => s.setIsSearching);
+  const setSearchQuery = useTasksUIStore((s) => s.setSearchQuery);
+  const setViewMode = useTasksUIStore((s) => s.setViewMode);
+  const setIsAddingColumn = useTasksUIStore((s) => s.setIsAddingColumn);
+
+  const _deferredQuery = useDeferredValue(searchQuery);
+
+  const handleArchiveCompleted = useCallback(async () => {
+    const doneColumns = columns.filter((c) => c.isDone);
+    const doneTaskCount = tasks.filter((t) => doneColumns.some((c) => c.id === t.columnId)).length;
+    if (doneTaskCount === 0) {
+      return;
+    }
+    if (
+      !window.confirm(
+        `Archive ${doneTaskCount} task${doneTaskCount === 1 ? "" : "s"} from done list${doneColumns.length === 1 ? "" : "s"}? They will be stored in the Tasks.md archive section.`,
+      )
+    ) {
+      return;
+    }
+    const result = await applyTaskMutation(glyph.archiveCompletedTasks(), setSnapshot);
+    if (!result.ok) {
+      setError(result.message);
+    }
+  }, [columns, glyph, setError, setSnapshot, tasks]);
+
+  const handleToggleSearch = useCallback(() => {
+    setIsSearching(!isSearching);
+    if (isSearching) {
+      setSearchQuery("");
+    }
+  }, [isSearching, setIsSearching, setSearchQuery]);
+
+  const handleChangeViewMode = useCallback(
+    (nextMode: TasksViewMode) => {
+      setViewMode(nextMode);
+    },
+    [setViewMode],
+  );
+
+  return (
+    <div className="flex items-center gap-1">
+      {isSearching ? (
+        <Input
+          autoFocus
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setIsSearching(false);
+              setSearchQuery("");
+            }
+          }}
+          placeholder="Search tasks"
+          className="h-7 w-44 bg-background text-sm"
+        />
+      ) : null}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => setIsAddingColumn(true)}
+            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+            aria-label="Add a list"
+          >
+            <PlusIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Add a list</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleToggleSearch}
+            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+            aria-label="Search tasks"
+          >
+            <SearchIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Search tasks</TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger
+              render={
+                <button
+                  type="button"
+                  className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                  aria-label="Change tasks view"
+                />
+              }
+            >
+              <OutlineIcon size={15} />
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">View options</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" className="w-44 bg-popover text-popover-foreground">
+          {(["board", "table"] as TasksViewMode[]).map((mode) => (
+            <DropdownMenuItem key={mode} onClick={() => handleChangeViewMode(mode)}>
+              <span className="mr-2 grid h-4 w-4 place-items-center">
+                {viewMode === mode ? <TickIcon size={14} /> : null}
+              </span>
+              View as {mode[0].toUpperCase()}
+              {mode.slice(1)}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => void handleArchiveCompleted()}
+            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+            aria-label="Archive done tasks"
+          >
+            <ArchiveIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Archive done tasks</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onOpenMarkdown}
+            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+            aria-label="Open as Markdown"
+          >
+            <FileIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open as Markdown</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/tasks/tasks-view.tsx
+++ b/apps/desktop/src/components/tasks/tasks-view.tsx
@@ -18,16 +18,7 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  ArchiveIcon,
-  FileIcon,
-  OutlineIcon,
-  PlusIcon,
-  SearchIcon,
-  TickIcon,
-} from "@/components/icons";
+import { ArrowDownIcon, ArrowUpIcon, TickIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -46,6 +37,7 @@ import type {
 import { TASK_COLUMN_COLORS_PICKER } from "@/core/tasks";
 import { cn } from "@/core/utils";
 import { applyTaskMutation, groupTasksByColumn, useTasksStore } from "@/store/tasks";
+import { useTasksUIStore } from "@/store/tasks-ui";
 
 import { TaskCardSurface } from "./task-card";
 import { TaskColumn } from "./task-column";
@@ -54,15 +46,10 @@ import { getErrorMessage } from "./task-view-model";
 type TasksViewProps = {
   glyph: NonNullable<Window["glyph"]>;
   onOpenTaskSource: (task: WorkspaceTask) => void;
-  onOpenMarkdown: () => void;
 };
-
-type TasksViewMode = "board" | "table";
 
 type SortColumn = "task" | "list" | "date";
 type SortDirection = "asc" | "desc";
-
-const TASK_VIEW_STORAGE_KEY = "glyph.tasks.viewMode";
 
 const COLOR_DOTS: Record<TaskColumnColor, string> = {
   amber: "border-chart-2",
@@ -101,14 +88,6 @@ const LIST_BG_COLORS: Record<TaskColumnColor, string> = {
   rose: "bg-destructive/10",
   slate: "bg-muted",
   violet: "bg-chart-4/10",
-};
-
-const isTasksViewMode = (value: string | null): value is TasksViewMode =>
-  value === "board" || value === "table";
-
-const getInitialViewMode = (): TasksViewMode => {
-  const stored = window.localStorage.getItem(TASK_VIEW_STORAGE_KEY);
-  return isTasksViewMode(stored) ? stored : "board";
 };
 
 function getTaskColumn(task: WorkspaceTask, columns: TaskColumnModel[]) {
@@ -346,7 +325,7 @@ const TableRow = memo(function TableRow({
   );
 });
 
-export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
+export function TasksView({ glyph, onOpenTaskSource: _onOpenTaskSource }: TasksViewProps) {
   const columns = useTasksStore((state) => state.columns);
   const tasks = useTasksStore((state) => state.tasks);
   const tagSuggestions = useTasksStore((state) => state.tagSuggestions);
@@ -355,16 +334,16 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
   const setSnapshot = useTasksStore((state) => state.setSnapshot);
   const setLoading = useTasksStore((state) => state.setLoading);
   const setError = useTasksStore((state) => state.setError);
+  const isAddingColumn = useTasksUIStore((s) => s.isAddingColumn);
+  const setIsAddingColumn = useTasksUIStore((s) => s.setIsAddingColumn);
+  const searchQuery = useTasksUIStore((s) => s.searchQuery);
+  const viewMode = useTasksUIStore((s) => s.viewMode);
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const [creatingColumnId, setCreatingColumnId] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  const [isAddingColumn, setIsAddingColumn] = useState(false);
   const [newColumnTitle, setNewColumnTitle] = useState("");
   const [newColumnColor, setNewColumnColor] = useState<TaskColumnColor>("blue");
   const [newColumnIsDone, setNewColumnIsDone] = useState(false);
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const deferredSearchQuery = useDeferredValue(searchQuery);
-  const [viewMode, setViewMode] = useState<TasksViewMode>(getInitialViewMode);
   const [sortColumn, setSortColumn] = useState<SortColumn>("task");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const isDraggingRef = useRef(false);
@@ -381,19 +360,11 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
 
   useEffect(() => {
     const handleAddColumn = () => setIsAddingColumn(true);
-    const handleViewChanged = () => {
-      const stored = window.localStorage.getItem(TASK_VIEW_STORAGE_KEY);
-      if (isTasksViewMode(stored)) {
-        setViewMode(stored);
-      }
-    };
     window.addEventListener("glyph:tasks-add-column", handleAddColumn);
-    window.addEventListener("glyph:tasks-view-changed", handleViewChanged);
     return () => {
       window.removeEventListener("glyph:tasks-add-column", handleAddColumn);
-      window.removeEventListener("glyph:tasks-view-changed", handleViewChanged);
     };
-  }, []);
+  }, [setIsAddingColumn]);
 
   useEffect(() => {
     setLoading(true);
@@ -433,11 +404,6 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
     () => tasks.find((task) => task.id === activeDragId) ?? null,
     [activeDragId, tasks],
   );
-
-  const handleChangeViewMode = useCallback((nextMode: TasksViewMode) => {
-    setViewMode(nextMode);
-    window.localStorage.setItem(TASK_VIEW_STORAGE_KEY, nextMode);
-  }, []);
 
   const handleSort = useCallback(
     (column: SortColumn) => {
@@ -528,22 +494,6 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
     },
     [glyph, runMutation],
   );
-
-  const handleArchiveCompleted = useCallback(async () => {
-    const doneColumns = columns.filter((c) => c.isDone);
-    const doneTaskCount = tasks.filter((t) => doneColumns.some((c) => c.id === t.columnId)).length;
-    if (doneTaskCount === 0) {
-      return;
-    }
-    if (
-      !window.confirm(
-        `Archive ${doneTaskCount} task${doneTaskCount === 1 ? "" : "s"} from done list${doneColumns.length === 1 ? "" : "s"}? They will be stored in the Tasks.md archive section.`,
-      )
-    ) {
-      return;
-    }
-    await runMutation(glyph.archiveCompletedTasks());
-  }, [columns, glyph, runMutation, tasks]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveDragId(String(event.active.id));
@@ -642,115 +592,6 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
           </div>
         ) : (
           <div className="relative h-full min-h-0">
-            <div className="absolute top-3 right-5 z-30 flex items-center gap-1.5">
-              {isSearching ? (
-                <Input
-                  autoFocus
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Escape") {
-                      setIsSearching(false);
-                      setSearchQuery("");
-                    }
-                  }}
-                  placeholder="Search tasks"
-                  className="h-8 w-52 bg-background"
-                />
-              ) : null}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={onOpenMarkdown}
-                    className="grid h-8 w-8 place-items-center rounded text-muted-foreground hover:text-foreground"
-                    aria-label="Open as Markdown"
-                  >
-                    <FileIcon size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Open as Markdown</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => setIsAddingColumn(true)}
-                    className="grid h-8 w-8 place-items-center rounded text-muted-foreground hover:text-foreground"
-                    aria-label="Add a list"
-                  >
-                    <PlusIcon size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Add a list</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setIsSearching((value) => {
-                        const next = !value;
-                        if (!next) {
-                          setSearchQuery("");
-                        }
-                        return next;
-                      })
-                    }
-                    className="grid h-8 w-8 place-items-center rounded text-muted-foreground hover:text-foreground"
-                    aria-label="Search tasks"
-                  >
-                    <SearchIcon size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Search tasks</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => void handleArchiveCompleted()}
-                    className="grid h-8 w-8 place-items-center rounded text-muted-foreground hover:text-foreground"
-                    aria-label="Archive done tasks"
-                  >
-                    <ArchiveIcon size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Archive done tasks</TooltipContent>
-              </Tooltip>
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger
-                      render={
-                        <button
-                          type="button"
-                          className="grid h-8 w-8 place-items-center rounded text-muted-foreground hover:text-foreground"
-                          aria-label="Change tasks view"
-                        />
-                      }
-                    >
-                      <OutlineIcon size={16} />
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">View options</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent
-                  align="end"
-                  className="w-44 bg-popover text-popover-foreground"
-                >
-                  {(["board", "table"] as TasksViewMode[]).map((mode) => (
-                    <DropdownMenuItem key={mode} onClick={() => handleChangeViewMode(mode)}>
-                      <span className="mr-2 grid h-4 w-4 place-items-center">
-                        {viewMode === mode ? <TickIcon size={14} /> : null}
-                      </span>
-                      View as {mode[0].toUpperCase()}
-                      {mode.slice(1)}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
             {viewMode === "board" ? (
               <DndContext
                 sensors={sensors}
@@ -761,7 +602,7 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
               >
                 <div
                   ref={boardScrollRef}
-                  className="scrollbar-hide flex h-full items-start gap-5 overflow-x-auto bg-background px-5 pt-16 pb-5"
+                  className="scrollbar-hide flex h-full items-start gap-5 overflow-x-auto bg-background px-5 pt-4 pb-5"
                 >
                   <SortableContext
                     items={columns.map((column) => column.id)}
@@ -796,7 +637,7 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
                 </DragOverlay>
               </DndContext>
             ) : (
-              <div ref={tableContainerRef} className="h-full overflow-auto px-5 pt-16 pb-5">
+              <div ref={tableContainerRef} className="h-full overflow-auto px-5 pt-4 pb-5">
                 <div className="mx-auto max-w-5xl overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm">
                   <table className="w-full text-left">
                     <thead className="border-b border-border/60 bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
@@ -889,7 +730,7 @@ export function TasksView({ glyph, onOpenMarkdown }: TasksViewProps) {
             {isAddingColumn ? (
               <form
                 onSubmit={handleCreateColumn}
-                className="absolute top-14 right-5 z-40 w-[280px] rounded-lg border border-border bg-popover p-3 shadow-xl"
+                className="absolute top-3 right-5 z-40 w-[280px] rounded-lg border border-border bg-popover p-3 shadow-xl"
               >
                 <Input
                   autoFocus

--- a/apps/desktop/src/core/shortcuts.ts
+++ b/apps/desktop/src/core/shortcuts.ts
@@ -127,6 +127,16 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "settings", label: "Settings", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ,` },
   { id: "toggle-sidebar", label: "Toggle Sidebar", keys: `${MODIFIER_TOKENS.cmdOrCtrl} \\` },
   {
+    id: "navigate-back",
+    label: "Navigate Back",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} ←`,
+  },
+  {
+    id: "navigate-forward",
+    label: "Navigate Forward",
+    keys: `${MODIFIER_TOKENS.alt} ${MODIFIER_TOKENS.cmdOrCtrl} →`,
+  },
+  {
     id: "focus-mode",
     label: "Toggle Focus Mode",
     keys: `${MODIFIER_TOKENS.shift} ${MODIFIER_TOKENS.cmdOrCtrl} F`,

--- a/apps/desktop/src/core/workspace.ts
+++ b/apps/desktop/src/core/workspace.ts
@@ -166,7 +166,9 @@ export type AppCommand =
   | "split-down"
   | "close-pane"
   | "focus-next-pane"
-  | "focus-previous-pane";
+  | "focus-previous-pane"
+  | "navigate-back"
+  | "navigate-forward";
 
 export type ExternalFileTarget = {
   path: string;

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -155,6 +155,8 @@ type UseDesktopAppControllerOptions = {
   initialTabPaths?: string[];
   initialWorkspacePath?: string | null;
   sessionReady?: boolean;
+  onRestoreSkill?: (path: string) => Promise<void>;
+  onRestoreTasks?: () => void;
 };
 
 export const useDesktopAppController = (
@@ -164,6 +166,8 @@ export const useDesktopAppController = (
     initialTabPaths = [],
     initialWorkspacePath = null,
     sessionReady = true,
+    onRestoreSkill,
+    onRestoreTasks,
   }: UseDesktopAppControllerOptions = {},
 ) => {
   const {
@@ -484,7 +488,7 @@ export const useDesktopAppController = (
       setIsWorkspaceMode(isFileInsideWorkspace(file.path, currentRootPath));
       setSidebarNodes((prev) => upsertSidebarFile(prev, file));
       if (options?.recordHistory) {
-        pushHistory(file.path);
+        pushHistory({ kind: "note", path: file.path });
       }
       requestEditorFocus(shouldPreserveFocus ? "preserve" : "end");
       setIsPaletteOpen(false);
@@ -534,7 +538,7 @@ export const useDesktopAppController = (
       }
       setIsWorkspaceMode(isFileInsideWorkspace(filePath, currentRootPath));
       if (options?.recordHistory) {
-        pushHistory(filePath);
+        pushHistory({ kind: "note", path: filePath });
       }
       requestEditorFocus(shouldPreserveFocus ? "preserve" : "end");
       setIsPaletteOpen(false);
@@ -986,7 +990,7 @@ export const useDesktopAppController = (
       setSidebarNodes((prev) => upsertSidebarFile(prev, file));
     }
 
-    pushHistory(file.path);
+    pushHistory({ kind: "note", path: file.path });
     requestEditorFocus("start");
   }, [
     activeFile,
@@ -1104,7 +1108,7 @@ export const useDesktopAppController = (
         attachActiveFile(file);
         setIsWorkspaceMode(true);
         setSidebarNodes((prev) => upsertSidebarFile(prev, file));
-        pushHistory(file.path);
+        pushHistory({ kind: "note", path: file.path });
         return file;
       })();
 
@@ -1176,9 +1180,16 @@ export const useDesktopAppController = (
           .noteTabs.filter((tab) => isFileInsideWorkspace(tab.file.path, folderPath))
           .map((tab) => tab.id);
         Array.from(
-          new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, folderPath))),
-        ).forEach((entry) => {
-          removeHistoryPath(entry);
+          new Set(
+            navigationHistory
+              .filter(
+                (entry): entry is Extract<typeof entry, { path: string }> =>
+                  entry.kind !== "tasks" && isFileInsideWorkspace(entry.path, folderPath),
+              )
+              .map((entry) => entry.path),
+          ),
+        ).forEach((path) => {
+          removeHistoryPath(path);
         });
         removeTabsInFolder(folderPath);
         for (const tabId of removedLayoutTabIds) {
@@ -1313,9 +1324,16 @@ export const useDesktopAppController = (
               ] as const,
           );
         Array.from(
-          new Set(navigationHistory.filter((entry) => isFileInsideWorkspace(entry, oldPath))),
-        ).forEach((entry) => {
-          replaceHistoryPath(entry, getRenamedFolderFilePath(oldPath, newPath, entry));
+          new Set(
+            navigationHistory
+              .filter(
+                (entry): entry is Extract<typeof entry, { path: string }> =>
+                  entry.kind !== "tasks" && isFileInsideWorkspace(entry.path, oldPath),
+              )
+              .map((entry) => entry.path),
+          ),
+        ).forEach((path) => {
+          replaceHistoryPath(path, getRenamedFolderFilePath(oldPath, newPath, path));
         });
         remapTabsForFolderRename(oldPath, newPath);
         for (const [oldTabId, nextTabId] of layoutTabRemaps) {
@@ -1698,6 +1716,9 @@ export const useDesktopAppController = (
   const navigationController = useNavigationController({
     glyph,
     syncOpenedFile,
+    activateNoteTab,
+    onRestoreSkill: onRestoreSkill ?? (() => Promise.resolve()),
+    onRestoreTasks: onRestoreTasks ?? (() => {}),
   });
   const { canGoBack, canGoForward, navigateBack, navigateForward } = navigationController;
 
@@ -2162,6 +2183,8 @@ export const useDesktopAppController = (
     toggleFocusMode,
     setEditorScale,
     editorScale,
+    navigateBack,
+    navigateForward,
   });
 
   // Boot sequence
@@ -2267,7 +2290,7 @@ export const useDesktopAppController = (
           try {
             const file = await glyph.readFile(target.path);
             setActiveFile(file);
-            pushHistory(file.path);
+            pushHistory({ kind: "note", path: file.path });
             const refreshedSettings = await glyph.getSettings();
             setSettings(refreshedSettings);
             setIsWorkspaceMode(
@@ -2292,7 +2315,7 @@ export const useDesktopAppController = (
           nextSidebarNodes = upsertSidebarFolder(nextSidebarNodes, workspace);
           if (restoredTabPaths.length === 0 && workspace.activeFile) {
             nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, workspace.activeFile);
-            pushHistory(workspace.activeFile.path);
+            pushHistory({ kind: "note", path: workspace.activeFile.path });
             bootFocusMode = "end";
           }
           nextExpandedFolders.add(workspace.rootPath);
@@ -2332,7 +2355,7 @@ export const useDesktopAppController = (
                 workspace && isFileInsideWorkspace(nextActiveRestoredFile.path, workspace.rootPath),
               ),
             );
-            pushHistory(nextActiveRestoredFile.path);
+            pushHistory({ kind: "note", path: nextActiveRestoredFile.path });
             bootFocusMode = "preserve";
           } else if (workspace?.activeFile) {
             setActiveFile(workspace.activeFile);
@@ -2340,7 +2363,7 @@ export const useDesktopAppController = (
               isFileInsideWorkspace(workspace.activeFile.path, workspace.rootPath),
             );
             nextSidebarNodes = upsertSidebarFile(nextSidebarNodes, workspace.activeFile);
-            pushHistory(workspace.activeFile.path);
+            pushHistory({ kind: "note", path: workspace.activeFile.path });
             bootFocusMode = "end";
           }
         }

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -2746,6 +2746,16 @@ export const useDesktopAppController = (
         return;
       }
 
+      if (command === "navigate-back") {
+        navigateBack();
+        return;
+      }
+
+      if (command === "navigate-forward") {
+        navigateForward();
+        return;
+      }
+
       if (command === "next-tab") {
         await activateAdjacentNoteTab(1);
         return;
@@ -2806,6 +2816,8 @@ export const useDesktopAppController = (
     closeActivePane,
     focusNextPane,
     focusPreviousPane,
+    navigateBack,
+    navigateForward,
     syncOpenedFile,
     syncWorkspace,
     glyph,

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -34,6 +34,8 @@ type UseKeyboardShortcutsOptions = {
   toggleFocusMode: () => Promise<void>;
   setEditorScale: (scale: number) => Promise<void>;
   editorScale: number;
+  navigateBack: () => Promise<void>;
+  navigateForward: () => Promise<void>;
 };
 
 export function useKeyboardShortcuts({
@@ -67,6 +69,8 @@ export function useKeyboardShortcuts({
   toggleFocusMode,
   setEditorScale,
   editorScale,
+  navigateBack,
+  navigateForward,
 }: UseKeyboardShortcutsOptions) {
   useEffect(() => {
     const onKeyDown = async (event: KeyboardEvent) => {
@@ -176,6 +180,8 @@ export function useKeyboardShortcuts({
         "close-pane",
         "focus-next-pane",
         "focus-previous-pane",
+        "navigate-back",
+        "navigate-forward",
       ]);
       const globalShortcut = shortcuts.find(
         (entry) => globalShortcutIds.has(entry.id) && matchShortcut(event, entry.keys, platform),
@@ -236,6 +242,12 @@ export function useKeyboardShortcuts({
             break;
           case "focus-previous-pane":
             focusPreviousPane();
+            break;
+          case "navigate-back":
+            void navigateBack();
+            break;
+          case "navigate-forward":
+            void navigateForward();
             break;
         }
         return;
@@ -328,5 +340,7 @@ export function useKeyboardShortcuts({
     toggleFocusMode,
     setEditorScale,
     editorScale,
+    navigateBack,
+    navigateForward,
   ]);
 }

--- a/apps/desktop/src/hooks/use-navigation-controller.ts
+++ b/apps/desktop/src/hooks/use-navigation-controller.ts
@@ -1,14 +1,24 @@
 import { useCallback } from "react";
 
 import type { FileDocument } from "@/core/workspace";
+import type { NavigationEntry } from "@/store/workspace";
 import { useWorkspaceStore } from "@/store/workspace";
 
 type UseNavigationControllerOptions = {
   glyph: NonNullable<Window["glyph"]>;
   syncOpenedFile: (file: FileDocument, options?: { recordHistory?: boolean }) => Promise<void>;
+  activateNoteTab: (path: string) => Promise<void>;
+  onRestoreSkill: (path: string) => Promise<void>;
+  onRestoreTasks: () => void;
 };
 
-export function useNavigationController({ glyph, syncOpenedFile }: UseNavigationControllerOptions) {
+export function useNavigationController({
+  glyph,
+  syncOpenedFile,
+  activateNoteTab,
+  onRestoreSkill,
+  onRestoreTasks,
+}: UseNavigationControllerOptions) {
   // Subscribe to the index/history length directly so the component re-renders
   // when navigation state changes (canGoBack/canGoForward are stable function
   // references and do NOT trigger re-renders on their own).
@@ -17,21 +27,38 @@ export function useNavigationController({ glyph, syncOpenedFile }: UseNavigation
   const goBack = useWorkspaceStore((s) => s.goBack);
   const goForward = useWorkspaceStore((s) => s.goForward);
 
+  const restoreEntry = useCallback(
+    async (entry: NavigationEntry) => {
+      if (entry.kind === "note") {
+        const existingTab = useWorkspaceStore.getState().getTabByPath(entry.path);
+        if (existingTab) {
+          await activateNoteTab(entry.path);
+        } else {
+          const file = await glyph.readFile(entry.path);
+          await syncOpenedFile(file);
+        }
+      } else if (entry.kind === "skill") {
+        await onRestoreSkill(entry.path);
+      } else {
+        onRestoreTasks();
+      }
+    },
+    [glyph, syncOpenedFile, activateNoteTab, onRestoreSkill, onRestoreTasks],
+  );
+
   const navigateBack = useCallback(async () => {
-    const prevPath = goBack();
-    if (prevPath) {
-      const file = await glyph.readFile(prevPath);
-      await syncOpenedFile(file);
+    const entry = goBack();
+    if (entry) {
+      await restoreEntry(entry);
     }
-  }, [goBack, glyph, syncOpenedFile]);
+  }, [goBack, restoreEntry]);
 
   const navigateForward = useCallback(async () => {
-    const nextPath = goForward();
-    if (nextPath) {
-      const file = await glyph.readFile(nextPath);
-      await syncOpenedFile(file);
+    const entry = goForward();
+    if (entry) {
+      await restoreEntry(entry);
     }
-  }, [goForward, glyph, syncOpenedFile]);
+  }, [goForward, restoreEntry]);
 
   return {
     canGoBack,

--- a/apps/desktop/src/store/tasks-ui.ts
+++ b/apps/desktop/src/store/tasks-ui.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+export type TasksViewMode = "board" | "table";
+
+export const TASK_VIEW_STORAGE_KEY = "glyph.tasks.viewMode";
+
+const isTasksViewMode = (value: string | null): value is TasksViewMode =>
+  value === "board" || value === "table";
+
+const getInitialViewMode = (): TasksViewMode => {
+  try {
+    const stored = window.localStorage.getItem(TASK_VIEW_STORAGE_KEY);
+    return isTasksViewMode(stored) ? stored : "board";
+  } catch {
+    return "board";
+  }
+};
+
+type TasksUIState = {
+  isSearching: boolean;
+  searchQuery: string;
+  viewMode: TasksViewMode;
+  isAddingColumn: boolean;
+  setIsSearching: (value: boolean) => void;
+  setSearchQuery: (value: string) => void;
+  setViewMode: (mode: TasksViewMode) => void;
+  setIsAddingColumn: (value: boolean) => void;
+};
+
+export const useTasksUIStore = create<TasksUIState>()((set) => ({
+  isSearching: false,
+  searchQuery: "",
+  viewMode: getInitialViewMode(),
+  isAddingColumn: false,
+  setIsSearching: (value) => set({ isSearching: value }),
+  setSearchQuery: (value) => set({ searchQuery: value }),
+  setViewMode: (mode) => {
+    set({ viewMode: mode });
+    try {
+      window.localStorage.setItem(TASK_VIEW_STORAGE_KEY, mode);
+      window.dispatchEvent(new Event("glyph:tasks-view-changed"));
+    } catch {
+      // ignore storage errors
+    }
+  },
+  setIsAddingColumn: (value) => set({ isAddingColumn: value }),
+}));

--- a/apps/desktop/src/store/workspace.ts
+++ b/apps/desktop/src/store/workspace.ts
@@ -4,12 +4,27 @@ import { getBaseName, isPathInside, isSamePath, normalizePath } from "@/core/pat
 
 import type { DirectoryNode, FileDocument, NoteTab, TabMovePosition } from "@/core/workspace";
 
-const getClosestHistoryIndex = (history: string[], currentIndex: number, filePath: string) => {
+export type NavigationEntry =
+  | { kind: "note"; path: string }
+  | { kind: "skill"; path: string }
+  | { kind: "tasks" };
+
+const isSameEntry = (a: NavigationEntry, b: NavigationEntry): boolean => {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "tasks") return true;
+  return isSamePath((a as { path: string }).path, (b as { path: string }).path);
+};
+
+const getClosestHistoryIndex = (
+  history: NavigationEntry[],
+  currentIndex: number,
+  entry: NavigationEntry,
+) => {
   let closestIndex = -1;
   let closestDistance = Number.POSITIVE_INFINITY;
 
-  history.forEach((entry, index) => {
-    if (!isSamePath(entry, filePath)) {
+  history.forEach((h, index) => {
+    if (!isSameEntry(h, entry)) {
       return;
     }
 
@@ -90,7 +105,7 @@ type WorkspaceState = {
   isSaving: boolean;
   lastSavedAt: number | null;
   error: string | null;
-  navigationHistory: string[];
+  navigationHistory: NavigationEntry[];
   navigationIndex: number;
   setWorkspace: (payload: {
     rootPath: string;
@@ -118,13 +133,13 @@ type WorkspaceState = {
   remapTabsForFolderRename: (oldFolderPath: string, newFolderPath: string) => void;
   getActiveTab: () => NoteTab | null;
   getTabByPath: (filePath: string) => NoteTab | null;
-  pushHistory: (filePath: string) => void;
+  pushHistory: (entry: NavigationEntry) => void;
   replaceHistoryPath: (oldPath: string, newPath: string) => void;
   removeHistoryPath: (targetPath: string) => void;
   canGoBack: () => boolean;
   canGoForward: () => boolean;
-  goBack: () => string | null;
-  goForward: () => string | null;
+  goBack: () => NavigationEntry | null;
+  goForward: () => NavigationEntry | null;
 };
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
@@ -635,21 +650,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const state = get();
     return state.noteTabs.find((tab) => isSamePath(tab.file.path, filePath)) ?? null;
   },
-  pushHistory: (filePath) => {
+  pushHistory: (entry) => {
     set((state) => {
-      const currentPath =
+      const currentEntry =
         state.navigationIndex >= 0
           ? (state.navigationHistory[state.navigationIndex] ?? null)
           : null;
 
-      if (currentPath && isSamePath(currentPath, filePath)) {
+      if (currentEntry && isSameEntry(currentEntry, entry)) {
         return state;
       }
 
       const existingIndex = getClosestHistoryIndex(
         state.navigationHistory,
         state.navigationIndex,
-        filePath,
+        entry,
       );
       if (existingIndex >= 0) {
         return {
@@ -659,11 +674,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       }
 
       const newHistory = state.navigationHistory.slice(0, state.navigationIndex + 1);
-      if (isSamePath(newHistory[newHistory.length - 1], filePath)) {
+      if (newHistory.length > 0 && isSameEntry(newHistory[newHistory.length - 1]!, entry)) {
         return state;
       }
 
-      newHistory.push(filePath);
+      newHistory.push(entry);
 
       if (newHistory.length > 50) {
         newHistory.shift();
@@ -677,20 +692,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
   replaceHistoryPath: (oldPath, newPath) => {
     set((state) => ({
-      navigationHistory: state.navigationHistory.map((entry) =>
-        isSamePath(entry, oldPath) ? newPath : entry,
-      ),
+      navigationHistory: state.navigationHistory.map((entry) => {
+        if (entry.kind === "tasks") return entry;
+        return isSamePath(entry.path, oldPath) ? { ...entry, path: newPath } : entry;
+      }),
     }));
   },
   removeHistoryPath: (targetPath) => {
     set((state) => {
       const removedIndices: number[] = [];
       const nextHistory = state.navigationHistory.filter((entry, index) => {
-        if (isSamePath(entry, targetPath)) {
+        if (entry.kind === "tasks") return true;
+        if (isSamePath(entry.path, targetPath)) {
           removedIndices.push(index);
           return false;
         }
-
         return true;
       });
 
@@ -732,7 +748,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     if (state.navigationIndex > 0) {
       const newIndex = state.navigationIndex - 1;
       set({ navigationIndex: newIndex });
-      return state.navigationHistory[newIndex];
+      return state.navigationHistory[newIndex] ?? null;
     }
     return null;
   },
@@ -741,7 +757,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     if (state.navigationIndex < state.navigationHistory.length - 1) {
       const newIndex = state.navigationIndex + 1;
       set({ navigationIndex: newIndex });
-      return state.navigationHistory[newIndex];
+      return state.navigationHistory[newIndex] ?? null;
     }
     return null;
   },


### PR DESCRIPTION
## Summary

- **Full-width toolbar** across all surfaces (Notes, Tasks, Skills) — single consistent `EditorToolbar` component with surface-specific props
- **New Note `+` button** moved back to the left group beside back/forward arrows
- **Tasks toolbar icon order** reordered by usage frequency: `+` (Add list) → Search → View options → Archive → Open as Markdown
- **Skills toolbar**: zoom controls removed (skills use a fixed layout, not editor scale)
- **Navigate back/forward shortcuts** changed from `⌘[`/`⌘]` (conflicted with tab cycling) to `⌥⌘←` / `⌥⌘→`; wired into `globalShortcutIds` and the keyboard handler switch statement so they actually fire
- **Back/forward note tab fix**: `restoreEntry` now calls `activateNoteTab` when the target tab already exists, instead of `syncOpenedFile` which was re-adding it to the active pane and breaking split-pane layout
- **Cross-surface history**: `NavigationEntry` discriminated union (`note | skill | tasks`) replaces flat `string[]` — back/forward correctly restores each surface
- `TasksHeaderActions` is eagerly importable (own file) so it renders in the navbar before `TasksView` lazy-loads

Related to #69 · Part of #57