### PR TITLE
feat(desktop): add second-brain context foundation

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -349,32 +349,6 @@ test("opens a seeded markdown note from the workspace", async ({}, testInfo) => 
   }
 });
 
-test("persists theme mode changes from settings", async ({}, testInfo) => {
-  const glyph = await launchGlyph();
-
-  try {
-    await expectAppShell(glyph.window);
-    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
-    await selectPaletteItem(glyph.window, "settings", /settings/i);
-    await glyph.window.getByLabel("Theme mode").click();
-    await glyph.window.getByRole("option", { name: "Dark" }).click();
-
-    await expect
-      .poll(async () =>
-        glyph.window.evaluate(() => document.documentElement.classList.contains("dark")),
-      )
-      .toBe(true);
-
-    await expect
-      .poll(async () => {
-        const settings = await readJson<{ themeMode?: string }>(glyph.sandbox.settingsPath);
-        return settings?.themeMode ?? null;
-      })
-      .toBe("dark");
-  } finally {
-    await glyph.stop(testInfo);
-  }
-});
 
 test("toggles the current note pin action from the command palette", async ({}, testInfo) => {
   const glyph = await launchGlyph();
@@ -568,26 +542,6 @@ test("settings panel closes when Escape is pressed", async ({}, testInfo) => {
   }
 });
 
-test("theme mode persists as light in settings file", async ({}, testInfo) => {
-  const glyph = await launchGlyph();
-  try {
-    await expectAppShell(glyph.window);
-    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
-    await selectPaletteItem(glyph.window, "settings", /settings/i);
-
-    await glyph.window.getByLabel("Theme mode").click();
-    await glyph.window.getByRole("option", { name: "Light" }).click();
-
-    await expect
-      .poll(async () => {
-        const settings = await readJson<{ themeMode?: string }>(glyph.sandbox.settingsPath);
-        return settings?.themeMode ?? null;
-      })
-      .toBe("light");
-  } finally {
-    await glyph.stop(testInfo);
-  }
-});
 
 // ─── Note lifecycle ───────────────────────────────────────────────────────────
 

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -55,6 +55,8 @@ async function createGlyphSandbox(): Promise<GlyphSandbox> {
       "Smoke test note content.",
       "",
       "Preview the [Nested Note](notes/nested-note.md).",
+      "",
+      "Wiki jump to [[Nested Note]].",
     ].join("\n"),
   );
   await fs.writeFile(
@@ -643,6 +645,39 @@ test("hovering a markdown note link shows a local note preview", async ({}, test
     await expect(previewCard.getByText("Nested Note", { exact: true })).toBeVisible();
     await expect(previewCard.getByText("Nested note body.")).toBeVisible();
   } finally {
+    await glyph.stop(testInfo);
+  }
+});
+
+test("wikilinks preview, open notes, and appear as backlinks", async ({}, testInfo) => {
+  const glyph = await launchGlyph();
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, glyph.sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    const wikiLink = glyph.window
+      .locator('[data-glyph-editor="true"] [data-wiki-link="[[Nested Note]]"]')
+      .first();
+    await expect(wikiLink).toBeVisible();
+
+    await wikiLink.hover();
+    const previewCard = glyph.window.getByLabel("Note link preview");
+    await expect(previewCard).toBeVisible();
+    await expect(previewCard.getByText("Nested Note", { exact: true })).toBeVisible();
+
+    await glyph.window.keyboard.down(modKey);
+    await wikiLink.click();
+    await glyph.window.keyboard.up(modKey);
+    await expect(
+      glyph.window.locator('[data-glyph-editor="true"]').getByText("Nested note body."),
+    ).toBeVisible();
+
+    await glyph.window.getByLabel("Open properties panel").click();
+    await expect(glyph.window.getByText("Backlinks")).toBeVisible();
+    await expect(glyph.window.getByRole("button", { name: /Welcome to Glyph/i })).toBeVisible();
+  } finally {
+    await glyph.window.keyboard.up(modKey).catch(() => {});
     await glyph.stop(testInfo);
   }
 });

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -682,6 +682,44 @@ test("wikilinks preview, open notes, and appear as backlinks", async ({}, testIn
   }
 });
 
+test("wikilinks resolve correctly even with special characters like pipes in the filename", async ({}, testInfo) => {
+  const sandbox = await createGlyphSandbox();
+  // Create a note that specifically contains '||' in its filename
+  const weirdFileName = "Special || Pipe Note.md";
+  await fs.writeFile(path.join(sandbox.workspaceRoot, weirdFileName), "# Complex Name\nBody Content here.");
+
+  // Add a wikilink pointing to it inside Welcome note
+  const welcomePath = path.join(sandbox.workspaceRoot, "welcome.md");
+  const welcomeContent = await fs.readFile(welcomePath, "utf8");
+  await fs.writeFile(welcomePath, welcomeContent + "\n[[Special || Pipe Note]]");
+
+  const glyph = await launchGlyph(sandbox);
+  try {
+    await expectAppShell(glyph.window);
+    await openWorkspace(glyph.window, sandbox.workspaceRoot);
+
+    await selectPaletteItem(glyph.window, "welcome", /welcome\.md/i);
+    const wikiLink = glyph.window
+      .locator('[data-glyph-editor="true"] [data-wiki-link="[[Special || Pipe Note]]"]')
+      .first();
+    await expect(wikiLink).toBeVisible();
+
+    // Cmd/Ctrl-Click to navigate
+    await glyph.window.keyboard.down(modKey);
+    await wikiLink.click();
+    await glyph.window.keyboard.up(modKey);
+
+    // It should successfully land on the target note page
+    await expect(
+      glyph.window.locator('[data-glyph-editor="true"]').getByText("Body Content here."),
+    ).toBeVisible();
+  } finally {
+    await glyph.window.keyboard.up(modKey).catch(() => {});
+    await glyph.stop(testInfo);
+    await sandbox.cleanup();
+  }
+});
+
 test("opens notes in multiple tabs and switches between them with keyboard shortcuts", async ({}, testInfo) => {
   const glyph = await launchGlyph();
   try {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -115,6 +115,11 @@ const NOTE_COLLECTION_ICON_KEYS = [
   "camera",
   "notebook",
   "star",
+  "idea",
+  "file",
+  "sun",
+  "moon",
+  "monitor",
 ] as const;
 type NoteCollectionAccentValue = (typeof NOTE_COLLECTION_ACCENT_KEYS)[number];
 type NoteCollectionIconValue = (typeof NOTE_COLLECTION_ICON_KEYS)[number];

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -847,6 +847,54 @@ async function resolveWorkspaceMarkdownTarget(target: string) {
   return null;
 }
 
+function parseWikiLinkHref(href: string) {
+  const wikiMatch = href.match(/^!?\[\[([^\]\n]+)\]\]$/);
+  const rawTarget = wikiMatch?.[1] ?? (href.startsWith("wiki:") ? href.slice(5) : "");
+  if (!rawTarget.trim()) {
+    return null;
+  }
+
+  const [target] = rawTarget.split("|").map((part) => part.trim());
+  return target || null;
+}
+
+function normalizeWikiTargetName(value: string) {
+  return value
+    .replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+async function resolveWorkspaceWikiTarget(target: string) {
+  if (!activeWorkspaceRoot) {
+    return null;
+  }
+
+  const targetWithoutAnchor = stripLinkAnchor(target).replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "");
+  if (!targetWithoutAnchor) {
+    return null;
+  }
+
+  const normalizedTarget = normalizePathForComparison(targetWithoutAnchor);
+  const normalizedBaseName = normalizePathForComparison(path.basename(targetWithoutAnchor));
+  const normalizedWikiName = normalizeWikiTargetName(targetWithoutAnchor);
+  const matches = searchableFilesCache.filter((filePath) => {
+    const baseName = path.basename(filePath).replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "");
+    const relativePath = path
+      .relative(activeWorkspaceRoot as string, filePath)
+      .replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "");
+
+    return (
+      normalizePathForComparison(baseName) === normalizedBaseName ||
+      normalizePathForComparison(relativePath) === normalizedTarget ||
+      normalizeWikiTargetName(baseName) === normalizedWikiName ||
+      normalizeWikiTargetName(relativePath) === normalizedWikiName
+    );
+  });
+
+  return matches.length === 1 ? matches[0] : null;
+}
+
 async function resolveLinkTarget(
   currentFilePath: string | null,
   href: string,
@@ -854,6 +902,12 @@ async function resolveLinkTarget(
   const trimmed = href.trim();
   if (!trimmed) {
     return null;
+  }
+
+  const wikiTarget = parseWikiLinkHref(trimmed);
+  if (wikiTarget) {
+    const existingPath = await resolveWorkspaceWikiTarget(wikiTarget);
+    return existingPath ? { kind: "markdown-file", target: existingPath } : null;
   }
 
   if (/^https?:\/\//i.test(trimmed)) {
@@ -2614,6 +2668,22 @@ async function createWindow() {
   mainWindow.once("ready-to-show", () => {
     mainWindow?.show();
   });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith("https:") || url.startsWith("http:")) {
+      void shell.openExternal(url);
+      return { action: "deny" };
+    }
+    return { action: "allow" };
+  });
+
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (url.startsWith("https:") || url.startsWith("http:")) {
+      event.preventDefault();
+      void shell.openExternal(url);
+    }
+  });
+
 
   mainWindow.webContents.on("did-fail-load", (_event, code, description, validatedUrl) => {
     console.error("Renderer load failed:", {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16,6 +16,7 @@ import fs from "node:fs/promises";
 import type { Stats } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseDocument } from "yaml";
 import { createSkillsService } from "./skills-service.js";
 import { createTasksService } from "./tasks-service.js";
 import type {
@@ -27,12 +28,18 @@ import type {
   DirectoryNode,
   FileOpenResult,
   NoteBrowserEntry,
+  NoteKnowledgeDocument,
+  NoteKnowledgeHeading,
+  NoteKnowledgeIndexSnapshot,
+  NoteKnowledgeLink,
+  NoteKnowledgeTag,
   NoteLinkPreview,
   ResolvedLinkTarget,
   SearchResult,
   UpdateState,
   WorkspaceSnapshot,
 } from "../src/core/workspace.js";
+import { parseMarkdownFrontmatter } from "../src/core/frontmatter.js";
 import type {
   TaskColumnCreateInput,
   TaskColumnDeleteInput,
@@ -72,6 +79,9 @@ const GITHUB_RELEASES_URL = "https://github.com/FALAK097/glyph/releases";
 const GITHUB_LATEST_RELEASE_API_URL = "https://api.github.com/repos/FALAK097/glyph/releases/latest";
 const MARKDOWN_PREVIEW_SUFFIX_PATTERN = /\.(md|mdx|markdown)$/i;
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s+(.*)$/;
+const MARKDOWN_LINK_PATTERN = /!?\[([^\]\n]+)\]\(([^)\n]+)\)/g;
+const WIKI_LINK_PATTERN = /!?\[\[([^\]\n]+)\]\]/g;
+const INLINE_TAG_PATTERN = /(^|[\s([{])#([A-Za-z0-9][A-Za-z0-9_/-]*)\b/g;
 const NOTE_COLLECTION_ACCENT_KEYS = [
   "violet",
   "indigo",
@@ -1998,6 +2008,317 @@ async function getNoteBrowserEntriesBatch(
   return Promise.all(targetPaths.map((targetPath) => getNoteBrowserEntries(targetPath)));
 }
 
+function createKnowledgeHeadingId(input: string) {
+  const normalized = input
+    .toLowerCase()
+    .trim()
+    .replace(/[`*_~[\]()>#+.!?,:;'"/\\]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+
+  return normalized || "section";
+}
+
+function normalizeKnowledgeTagName(input: string) {
+  return input.trim().replace(/^#/, "").toLowerCase();
+}
+
+function extractFrontmatterTags(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((entry) => extractFrontmatterTags(entry))
+      .map(normalizeKnowledgeTagName)
+      .filter(Boolean);
+  }
+
+  if (typeof value === "string") {
+    return value
+      .split(/[,\s]+/)
+      .map(normalizeKnowledgeTagName)
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function getKnowledgeFrontmatterTags(frontmatter: Record<string, unknown>) {
+  const candidates = [
+    frontmatter.tags,
+    frontmatter.tag,
+    frontmatter.keywords,
+    typeof frontmatter.metadata === "object" && frontmatter.metadata
+      ? (frontmatter.metadata as Record<string, unknown>).tags
+      : null,
+  ];
+
+  return Array.from(new Set(candidates.flatMap(extractFrontmatterTags)));
+}
+
+function parseKnowledgeFrontmatter(frontmatterText: string | null): Record<string, unknown> {
+  if (!frontmatterText) {
+    return {};
+  }
+
+  const document = parseDocument(frontmatterText, {
+    merge: true,
+    prettyErrors: false,
+    strict: false,
+    uniqueKeys: false,
+  });
+
+  if (document.errors.length > 0) {
+    return {};
+  }
+
+  const parsed = document.toJSON();
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}
+
+function getKnowledgeTitle(filePath: string, frontmatter: Record<string, unknown>, body: string) {
+  const frontmatterTitle = frontmatter.title;
+  if (typeof frontmatterTitle === "string" && frontmatterTitle.trim()) {
+    return frontmatterTitle.trim();
+  }
+
+  const firstHeading = body
+    .split("\n")
+    .map((line) => line.match(MARKDOWN_HEADING_PATTERN)?.[1]?.trim())
+    .find((title) => title && title.length > 0);
+
+  return firstHeading ?? getDisplayMarkdownFileName(filePath);
+}
+
+function extractKnowledgeFromMarkdown(
+  filePath: string,
+  content: string,
+  stats: Stats,
+): Omit<NoteKnowledgeDocument, "backlinks"> {
+  const normalizedContent = content.replace(/\r\n?/g, "\n");
+  const { frontmatterText, body } = parseMarkdownFrontmatter(normalizedContent);
+  const frontmatter = parseKnowledgeFrontmatter(frontmatterText);
+  const headings: NoteKnowledgeHeading[] = [];
+  const tagsByName = new Map<string, NoteKnowledgeTag>();
+  const links: NoteKnowledgeLink[] = [];
+  const headingCounts = new Map<string, number>();
+  const frontmatterTags = getKnowledgeFrontmatterTags(frontmatter);
+
+  frontmatterTags.forEach((name) => {
+    tagsByName.set(name, { name, line: 1 });
+  });
+
+  body.split("\n").forEach((line, index) => {
+    const lineNumber = index + 1;
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      const title = headingMatch[2]?.trim() ?? "";
+      if (title) {
+        const baseId = createKnowledgeHeadingId(title);
+        const instanceCount = headingCounts.get(baseId) ?? 0;
+        headingCounts.set(baseId, instanceCount + 1);
+        headings.push({
+          id: instanceCount === 0 ? baseId : `${baseId}-${instanceCount + 1}`,
+          level: headingMatch[1]?.length ?? 1,
+          title,
+          line: lineNumber,
+        });
+      }
+    }
+
+    INLINE_TAG_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(INLINE_TAG_PATTERN)) {
+      const name = normalizeKnowledgeTagName(match[2] ?? "");
+      if (name && !tagsByName.has(name)) {
+        tagsByName.set(name, { name, line: lineNumber });
+      }
+    }
+
+    MARKDOWN_LINK_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
+      const target = (match[2] ?? "").trim();
+      if (!target) {
+        continue;
+      }
+
+      links.push({
+        kind: "markdown",
+        target,
+        label: (match[1] ?? target).trim(),
+        resolvedPath: null,
+        line: lineNumber,
+      });
+    }
+
+    WIKI_LINK_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(WIKI_LINK_PATTERN)) {
+      const rawTarget = (match[1] ?? "").trim();
+      if (!rawTarget) {
+        continue;
+      }
+
+      const [target, alias] = rawTarget.split("|").map((part) => part.trim());
+      if (!target) {
+        continue;
+      }
+
+      links.push({
+        kind: "wiki",
+        target,
+        label: alias || target,
+        resolvedPath: null,
+        line: lineNumber,
+      });
+    }
+  });
+
+  const wordCount = normalizedContent.split(/\s+/).filter(Boolean).length;
+
+  return {
+    path: filePath,
+    title: getKnowledgeTitle(filePath, frontmatter, body),
+    excerpt: extractNoteExcerpt(body),
+    frontmatter,
+    tags: Array.from(tagsByName.values()).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    ),
+    headings,
+    links,
+    modifiedAt: stats.mtime.toISOString(),
+    createdAt: stats.birthtime.toISOString(),
+    sizeBytes: stats.size,
+    wordCount,
+  };
+}
+
+function stripLinkAnchor(target: string) {
+  return target.split("#", 1)[0]?.trim() ?? "";
+}
+
+function createMarkdownPathCandidates(sourcePath: string, target: string) {
+  const withoutTitle = stripLinkAnchor(target.split(/\s+"[^"]*"$/)[0] ?? target);
+  if (!withoutTitle || /^[a-z][a-z0-9+.-]*:/i.test(withoutTitle)) {
+    return [];
+  }
+
+  const sourceDir = path.dirname(sourcePath);
+  const baseTarget = withoutTitle.replace(/\\/g, "/");
+  const targetWithExtension = MARKDOWN_PREVIEW_SUFFIX_PATTERN.test(baseTarget)
+    ? baseTarget
+    : `${baseTarget}.md`;
+
+  return [
+    path.resolve(sourceDir, baseTarget),
+    path.resolve(sourceDir, targetWithExtension),
+    path.resolve(activeWorkspaceRoot ?? sourceDir, baseTarget),
+    path.resolve(activeWorkspaceRoot ?? sourceDir, targetWithExtension),
+  ];
+}
+
+function resolveKnowledgeLink(
+  sourcePath: string,
+  link: NoteKnowledgeLink,
+  documentsByPathKey: Map<string, NoteKnowledgeDocument>,
+  documentsByNameKey: Map<string, NoteKnowledgeDocument>,
+) {
+  if (link.kind === "wiki") {
+    const targetWithoutAnchor = stripLinkAnchor(link.target);
+    const nameKey = targetWithoutAnchor.replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "").toLowerCase();
+    return documentsByNameKey.get(nameKey)?.path ?? null;
+  }
+
+  for (const candidate of createMarkdownPathCandidates(sourcePath, link.target)) {
+    const match = documentsByPathKey.get(normalizePathForComparison(candidate));
+    if (match) {
+      return match.path;
+    }
+  }
+
+  return null;
+}
+
+async function getKnowledgeIndex(): Promise<NoteKnowledgeIndexSnapshot> {
+  if (!activeWorkspaceRoot) {
+    return {
+      workspaceRoot: null,
+      notes: [],
+      tags: [],
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  const documents: NoteKnowledgeDocument[] = [];
+
+  for (const filePath of searchableFilesCache) {
+    try {
+      const stats = await fs.stat(filePath);
+      const content = await fs.readFile(filePath, "utf8");
+      documents.push({
+        ...extractKnowledgeFromMarkdown(filePath, content, stats),
+        backlinks: [],
+      });
+    } catch {
+      // Skip unreadable files.
+    }
+  }
+
+  const documentsByPathKey = new Map(
+    documents.map((document) => [normalizePathForComparison(document.path), document]),
+  );
+  const documentsByNameKey = new Map<string, NoteKnowledgeDocument>();
+  documents.forEach((document) => {
+    const baseName = path.basename(document.path).replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "");
+    documentsByNameKey.set(baseName.toLowerCase(), document);
+    documentsByNameKey.set(document.title.toLowerCase(), document);
+  });
+
+  const backlinkSets = new Map<string, Set<string>>();
+  documents.forEach((document) => {
+    document.links = document.links.map((link) => {
+      const resolvedPath = resolveKnowledgeLink(
+        document.path,
+        link,
+        documentsByPathKey,
+        documentsByNameKey,
+      );
+
+      if (resolvedPath) {
+        const key = normalizePathForComparison(resolvedPath);
+        const linksToDocument = backlinkSets.get(key) ?? new Set<string>();
+        linksToDocument.add(document.path);
+        backlinkSets.set(key, linksToDocument);
+      }
+
+      return {
+        ...link,
+        resolvedPath,
+      };
+    });
+  });
+
+  documents.forEach((document) => {
+    document.backlinks = Array.from(
+      backlinkSets.get(normalizePathForComparison(document.path)) ?? [],
+    ).sort((left, right) => left.localeCompare(right));
+  });
+
+  const tagCounts = new Map<string, number>();
+  documents.forEach((document) => {
+    document.tags.forEach((tag) => {
+      tagCounts.set(tag.name, (tagCounts.get(tag.name) ?? 0) + 1);
+    });
+  });
+
+  return {
+    workspaceRoot: activeWorkspaceRoot,
+    notes: documents.sort((left, right) => left.title.localeCompare(right.title)),
+    tags: Array.from(tagCounts.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((left, right) => right.count - left.count || left.name.localeCompare(right.name)),
+    generatedAt: new Date().toISOString(),
+  };
+}
+
 async function buildDirectoryTree(dirPath: string): Promise<DirectoryNode[]> {
   const entries = await fs.readdir(dirPath, { withFileTypes: true });
   const sorted = entries.sort((left, right) => {
@@ -2471,6 +2792,8 @@ ipcMain.handle("workspace:createFolder", async (_event, parentDir: string, folde
 });
 
 ipcMain.handle("workspace:search", async (_event, query: string) => searchWorkspace(query));
+
+ipcMain.handle("knowledge:getIndex", async () => getKnowledgeIndex());
 
 ipcMain.handle("tasks:list", async () => {
   if (!activeWorkspaceRoot) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -854,8 +854,7 @@ function parseWikiLinkHref(href: string) {
     return null;
   }
 
-  const [target] = rawTarget.split("|").map((part) => part.trim());
-  return target || null;
+  return rawTarget.trim() || null;
 }
 
 function normalizeWikiTargetName(value: string) {
@@ -906,7 +905,17 @@ async function resolveLinkTarget(
 
   const wikiTarget = parseWikiLinkHref(trimmed);
   if (wikiTarget) {
-    const existingPath = await resolveWorkspaceWikiTarget(wikiTarget);
+    // Phase 1: Try resolving the FULL string as a note title (supports filenames with pipes)
+    let existingPath = await resolveWorkspaceWikiTarget(wikiTarget);
+
+    // Phase 2: Fallback to standard Alias split if phase 1 yielded nothing
+    if (!existingPath && wikiTarget.includes("|")) {
+      const [baseTarget] = wikiTarget.split("|").map((s) => s.trim());
+      if (baseTarget) {
+        existingPath = await resolveWorkspaceWikiTarget(baseTarget);
+      }
+    }
+
     return existingPath ? { kind: "markdown-file", target: existingPath } : null;
   }
 
@@ -2222,15 +2231,15 @@ function extractKnowledgeFromMarkdown(
         continue;
       }
 
-      const [target, alias] = rawTarget.split("|").map((part) => part.trim());
-      if (!target) {
+      const [targetPart, alias] = rawTarget.split("|").map((part) => part.trim());
+      if (!rawTarget) {
         continue;
       }
 
       links.push({
         kind: "wiki",
-        target,
-        label: alias || target,
+        target: rawTarget,
+        label: alias || targetPart || rawTarget,
         resolvedPath: null,
         line: lineNumber,
       });
@@ -2287,9 +2296,28 @@ function resolveKnowledgeLink(
   documentsByNameKey: Map<string, NoteKnowledgeDocument>,
 ) {
   if (link.kind === "wiki") {
-    const targetWithoutAnchor = stripLinkAnchor(link.target);
-    const nameKey = targetWithoutAnchor.replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "").toLowerCase();
-    return documentsByNameKey.get(nameKey)?.path ?? null;
+    // Phase 1: Direct full string lookup
+    const fullTargetWithoutAnchor = stripLinkAnchor(link.target);
+    const fullKey = fullTargetWithoutAnchor.replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "").toLowerCase();
+    const directMatch = documentsByNameKey.get(fullKey);
+    if (directMatch) {
+      return directMatch.path;
+    }
+
+    // Phase 2: Fallback if we fail, try splitting by pipe
+    if (link.target.includes("|")) {
+      const [baseTarget] = link.target.split("|").map((part) => part.trim());
+      if (baseTarget) {
+        const baseWithoutAnchor = stripLinkAnchor(baseTarget);
+        const baseKey = baseWithoutAnchor.replace(MARKDOWN_PREVIEW_SUFFIX_PATTERN, "").toLowerCase();
+        const splitMatch = documentsByNameKey.get(baseKey);
+        if (splitMatch) {
+          return splitMatch.path;
+        }
+      }
+    }
+
+    return null;
   }
 
   for (const candidate of createMarkdownPathCandidates(sourcePath, link.target)) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1979,12 +1979,18 @@ async function getNoteBrowserEntries(targetPath: string | null): Promise<NoteBro
       const stats = await fs.stat(filePath);
       const content = await fs.readFile(filePath, "utf8");
       const normalizedContent = content.replace(/\r\n?/g, "\n");
+      const { frontmatterText, body } = parseMarkdownFrontmatter(normalizedContent);
+      const frontmatter = parseKnowledgeFrontmatter(frontmatterText);
       const wordCount = normalizedContent.split(/\s+/).filter(Boolean).length;
+      const icon = typeof frontmatter.icon === "string" && frontmatter.icon.trim()
+        ? frontmatter.icon.trim()
+        : null;
 
       entries.push({
         path: filePath,
         title: getDisplayMarkdownFileName(filePath),
-        excerpt: extractNoteExcerpt(normalizedContent),
+        icon,
+        excerpt: extractNoteExcerpt(body),
         modifiedAt: stats.mtime.toISOString(),
         createdAt: stats.birthtime.toISOString(),
         sizeBytes: stats.size,

--- a/apps/desktop/electron/preload.cts
+++ b/apps/desktop/electron/preload.cts
@@ -10,6 +10,7 @@ import type {
   FileDocument,
   FileOpenResult,
   NoteLinkPreview,
+  NoteKnowledgeIndexSnapshot,
   ResolvedLinkTarget,
   SearchResult,
   WorkspaceChangeEvent,
@@ -139,6 +140,9 @@ const api = {
   },
   searchWorkspace(query: string) {
     return ipcRenderer.invoke("workspace:search", query) as Promise<SearchResult[]>;
+  },
+  getKnowledgeIndex() {
+    return ipcRenderer.invoke("knowledge:getIndex") as Promise<NoteKnowledgeIndexSnapshot>;
   },
   listTasks() {
     return ipcRenderer.invoke("tasks:list") as Promise<TaskIndexSnapshot>;

--- a/apps/desktop/src/components/app-footer.tsx
+++ b/apps/desktop/src/components/app-footer.tsx
@@ -1,12 +1,21 @@
+import type { ThemeMode } from "@/core/workspace";
+import { ThemeToggle } from "./theme-toggle";
+
 type AppFooterProps = {
   content: React.ReactNode;
+  themeMode: ThemeMode;
+  onChangeTheme: (mode: ThemeMode) => void;
 };
 
-export function AppFooter({ content }: AppFooterProps) {
+export function AppFooter({ content, themeMode, onChangeTheme }: AppFooterProps) {
   return (
     <div className="shrink-0 flex items-center justify-between border-t border-border/40 bg-footer px-4 py-1.5 h-8">
       <div>{/* Left side - reserved for future use */}</div>
-      <div className="flex items-center gap-3">{content}</div>
+      <div className="flex items-center gap-3">
+        {content}
+        <div className="w-px h-2.5 bg-border/50 shrink-0" />
+        <ThemeToggle themeMode={themeMode} onChangeTheme={onChangeTheme} />
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -1,5 +1,5 @@
 import type { NoteCollectionItem } from "@/core/note-collections";
-import type { NoteCollectionAccentKey, NoteCollectionIconKey } from "@/core/workspace";
+import type { NoteCollectionAccentKey, NoteCollectionIconKey, ThemeMode } from "@/core/workspace";
 import type { NoteShortcutItem } from "@/types/navigation";
 import type {
   DragPosition,
@@ -47,6 +47,8 @@ type AppLayoutProps = {
   onCreateFolderInCollection?: (collectionPath: string) => void;
   onChangeNoteCollectionAccent?: (collectionPath: string, accent: NoteCollectionAccentKey) => void;
   onChangeNoteCollectionIcon?: (collectionPath: string, icon: NoteCollectionIconKey) => void;
+  themeMode: ThemeMode;
+  onChangeTheme: (mode: ThemeMode) => void;
   children: React.ReactNode;
 };
 
@@ -87,6 +89,8 @@ export function AppLayout({
   onCreateFolderInCollection,
   onChangeNoteCollectionAccent,
   onChangeNoteCollectionIcon,
+  themeMode,
+  onChangeTheme,
   children,
 }: AppLayoutProps) {
   return (
@@ -139,7 +143,9 @@ export function AppLayout({
 
         <main className="relative flex-1 min-h-0 overflow-hidden bg-background">{children}</main>
       </div>
-      {footer ? <AppFooter content={footer} /> : null}
+      {footer ? (
+        <AppFooter content={footer} themeMode={themeMode} onChangeTheme={onChangeTheme} />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/app-surface-shell.tsx
+++ b/apps/desktop/src/components/app-surface-shell.tsx
@@ -6,6 +6,7 @@ type AppSurfaceShellProps = {
   browserPane?: ReactNode;
   browserPaneWidth?: number;
   onBrowserPaneResize?: (width: number) => void;
+  contextPane?: ReactNode;
   children: ReactNode;
 };
 
@@ -22,28 +23,47 @@ export function AppSurfaceShell({
   browserPane,
   browserPaneWidth,
   onBrowserPaneResize,
+  contextPane,
   children,
 }: AppSurfaceShellProps) {
-  if (!browserPane) {
+  if (!browserPane && !contextPane) {
     return <div className="h-full min-h-0 min-w-0">{children}</div>;
   }
 
   return (
     <Group orientation="horizontal" className="h-full min-h-0 min-w-0">
-      <Panel
-        id="surface-browser-pane"
-        defaultSize={browserPaneWidth ? `${browserPaneWidth}px` : "320px"}
-        minSize="240px"
-        maxSize="520px"
-        groupResizeBehavior="preserve-pixel-size"
-        onResize={(size) => onBrowserPaneResize?.(size.inPixels)}
-      >
-        <div className="h-full min-h-0 min-w-0 overflow-hidden">{browserPane}</div>
-      </Panel>
-      <BrowserResizeHandle />
+      {browserPane ? (
+        <>
+          <Panel
+            id="surface-browser-pane"
+            defaultSize={browserPaneWidth ? `${browserPaneWidth}px` : "320px"}
+            minSize="240px"
+            maxSize="520px"
+            groupResizeBehavior="preserve-pixel-size"
+            onResize={(size) => onBrowserPaneResize?.(size.inPixels)}
+          >
+            <div className="h-full min-h-0 min-w-0 overflow-hidden">{browserPane}</div>
+          </Panel>
+          <BrowserResizeHandle />
+        </>
+      ) : null}
       <Panel id="surface-main-pane" minSize="30%">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">{children}</div>
       </Panel>
+      {contextPane ? (
+        <>
+          <BrowserResizeHandle />
+          <Panel
+            id="surface-context-pane"
+            defaultSize="320px"
+            minSize="280px"
+            maxSize="460px"
+            groupResizeBehavior="preserve-pixel-size"
+          >
+            <div className="h-full min-h-0 min-w-0 overflow-hidden">{contextPane}</div>
+          </Panel>
+        </>
+      ) : null}
     </Group>
   );
 }

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -53,7 +53,7 @@ import { useUpdateStateFlags } from "./update-notification";
 
 import { matchesPaletteQuery, matchesSkillPaletteFallback } from "./desktop-app/palette-utils";
 
-function collectNoteTitles(nodes: DirectoryNode[]): string[] {
+function collectNoteTitles(nodes: DirectoryNode[]): Array<{ title: string; icon: string | null }> {
   const titles = new Set<string>();
   const visit = (node: DirectoryNode) => {
     if (node.type === "file") {
@@ -65,7 +65,16 @@ function collectNoteTitles(nodes: DirectoryNode[]): string[] {
     node.children.forEach(visit);
   };
   nodes.forEach(visit);
-  return Array.from(titles).sort((left, right) => left.localeCompare(right));
+  return Array.from(titles)
+    .sort((left, right) => left.localeCompare(right))
+    .map((title) => ({ title, icon: null }));
+}
+
+function getFrontmatterIcon(content: string) {
+  const parsed = parseMarkdownFrontmatter(content);
+  const match = parsed.frontmatterText?.match(/^icon:\s*(.+?)\s*$/m);
+  const icon = match?.[1]?.trim().replace(/^['"]|['"]$/g, "") ?? null;
+  return icon && icon !== "none" ? icon : null;
 }
 
 export const DesktopApp = ({ glyph }: DesktopAppProps) => {
@@ -144,7 +153,14 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   // skillsController and setViewerMode are in scope.
   const onRestoreSkillRef = useRef<(path: string) => Promise<void>>(async () => {});
   const onRestoreTasksRef = useRef<() => void>(() => {});
+  const exitFocusModeRef = useRef<() => void>(() => {});
+  const isFocusModeRef = useRef(false);
   const handleToggleNoteContext = useCallback(() => {
+    if (isFocusModeRef.current) {
+      exitFocusModeRef.current();
+      setNoteContextOpen(true);
+      return;
+    }
     setNoteContextOpen(!useSessionStore.getState().isNoteContextOpen);
   }, [setNoteContextOpen]);
 
@@ -160,6 +176,10 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const skillsController = useSkillLibraryController(glyph, {
     enabled: true,
   });
+  isFocusModeRef.current = controller.isFocusMode;
+  exitFocusModeRef.current = () => {
+    void controller.toggleFocusMode();
+  };
 
   // Wire cross-surface navigation restore callbacks (populated each render so
   // the stable refs always call the latest closures).
@@ -354,10 +374,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     setSelectedNoteCollectionPath,
     setLastNotePathForCollection,
   ]);
-  const noteTitleSuggestions = useMemo(
-    () => collectNoteTitles(controller.visibleSidebarNodes.map((entry) => entry.node)),
-    [controller.visibleSidebarNodes],
-  );
   const currentNoteDisplayName = useMemo(
     () => (controller.activeFile ? getDisplayFileName(controller.activeFile.name) : ""),
     [controller.activeFile],
@@ -378,6 +394,35 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     () => filterNoteBrowserEntries(noteBrowserEntries, "", activeNoteCollection),
     [activeNoteCollection, noteBrowserEntries],
   );
+  const activeNoteIcon = useMemo(
+    () => (controller.activeFile ? getFrontmatterIcon(controller.draftContent) : null),
+    [controller.activeFile, controller.draftContent],
+  );
+  const visibleNoteBrowserEntriesWithMetadata = useMemo(
+    () =>
+      visibleNoteBrowserEntries.map((entry) =>
+        controller.activeFile && isSamePath(entry.path, controller.activeFile.path)
+          ? { ...entry, icon: activeNoteIcon }
+          : entry,
+      ),
+    [activeNoteIcon, controller.activeFile, visibleNoteBrowserEntries],
+  );
+  const noteTitleSuggestions = useMemo(() => {
+    const titleMap = new Map<string, { title: string; icon: string | null }>();
+    collectNoteTitles(controller.visibleSidebarNodes.map((entry) => entry.node)).forEach((entry) => {
+      titleMap.set(entry.title.toLowerCase(), entry);
+    });
+    noteBrowserEntries.forEach((entry) => {
+      const icon =
+        controller.activeFile && isSamePath(entry.path, controller.activeFile.path)
+          ? activeNoteIcon
+          : entry.icon;
+      titleMap.set(entry.title.toLowerCase(), { title: entry.title, icon });
+    });
+    return Array.from(titleMap.values()).sort((left, right) =>
+      left.title.localeCompare(right.title),
+    );
+  }, [activeNoteIcon, controller.activeFile, controller.visibleSidebarNodes, noteBrowserEntries]);
   const activeNoteCollectionPath = activeNoteCollection?.path ?? null;
 
   const handleToggleSkillsSection = useCallback(() => {
@@ -1600,8 +1645,18 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   );
 
   const handleToggleSidebar = useCallback(() => {
+    if (controller.isFocusMode) {
+      void controller.toggleFocusMode();
+      controller.setIsSidebarCollapsed(false);
+      return;
+    }
     controller.setIsSidebarCollapsed(!controller.isSidebarCollapsed);
-  }, [controller.isSidebarCollapsed, controller.setIsSidebarCollapsed]);
+  }, [
+    controller.isFocusMode,
+    controller.isSidebarCollapsed,
+    controller.setIsSidebarCollapsed,
+    controller.toggleFocusMode,
+  ]);
 
   const handleOpenCommandPalette = useCallback(() => {
     controller.setIsPaletteOpen(true);
@@ -1632,8 +1687,11 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     void controller.navigateForward();
   }, [controller.navigateForward]);
   const handleToggleFocusMode = useCallback(() => {
+    if (!controller.isFocusMode) {
+      setNoteContextOpen(false);
+    }
     void controller.toggleFocusMode();
-  }, [controller.toggleFocusMode]);
+  }, [controller.isFocusMode, controller.toggleFocusMode, setNoteContextOpen]);
   const handleEditorScaleChange = useCallback(
     (scale: number) => {
       void controller.setEditorScale(scale);
@@ -1908,7 +1966,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       isSamePath(filePath, activeNoteFile.path),
     );
   const noteContextPane =
-    activeNoteFile && isNoteContextOpen ? (
+    activeNoteFile && isNoteContextOpen && !controller.isFocusMode ? (
       <NoteContextSidebar
         activeFile={activeNoteFile}
         draftContent={controller.draftContent}
@@ -2326,7 +2384,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
               shouldCollapseBrowserPane ? undefined : activeNoteCollection ? (
                 <NotesBrowserPane
                   activePath={controller.activeFile?.path ?? null}
-                  entries={visibleNoteBrowserEntries}
+                  entries={visibleNoteBrowserEntriesWithMetadata}
                   isLoading={isNoteBrowserLoading}
                   accent={activeNoteCollection.accent}
                   onOpenNote={handleBrowserOpenNote}

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -58,6 +58,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const viewerMode = useSessionStore((state) => state.viewerMode);
   const isNotesExpanded = useSessionStore((state) => state.isNotesExpanded);
   const isSkillsExpanded = useSessionStore((state) => state.isSkillsExpanded);
+  const isNoteContextOpen = useSessionStore((state) => state.isNoteContextOpen);
   const workspaceRootPath = useWorkspaceStore((state) => state.rootPath);
   const selectedNoteCollectionPath = useSessionStore((state) => state.selectedNoteCollectionPath);
   const notesBrowserPaneWidth = useSessionStore((state) => state.notesBrowserPaneWidth);
@@ -83,6 +84,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   );
   const setNoteOrderForCollection = useSessionStore((state) => state.setNoteOrderForCollection);
   const getNoteOrderForCollection = useSessionStore((state) => state.getNoteOrderForCollection);
+  const setNoteContextOpen = useSessionStore((state) => state.setNoteContextOpen);
   const setNotesBrowserPaneWidth = useSessionStore((state) => state.setNotesBrowserPaneWidth);
   const setSelectedSkillCollectionId = useSessionStore(
     (state) => state.setSelectedSkillCollectionId,
@@ -177,7 +179,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);
   const [pendingSkillRestorePath, setPendingSkillRestorePath] = useState<string | null>(null);
   const [isInitialSkillRestorePending, setIsInitialSkillRestorePending] = useState(false);
-  const [isNoteContextOpen, setIsNoteContextOpen] = useState(false);
   const paletteSkillSearchNonceRef = useRef(0);
   const paletteFilterQuery = controller.paletteQuery.trim().toLowerCase();
   const shouldCollapseSidebar =
@@ -1281,7 +1282,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         section: "Note",
         kind: "command",
         onSelect: () => {
-          setIsNoteContextOpen((current) => !current);
+          setNoteContextOpen(!isNoteContextOpen);
           closePalette();
         },
       },
@@ -1892,8 +1893,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         outlineItems={controller.outlineItems}
         wordCount={controller.wordCount}
         readingTime={controller.readingTime}
-        onClose={() => setIsNoteContextOpen(false)}
+        onClose={() => setNoteContextOpen(false)}
         onJumpToHeading={controller.requestOutlineJump}
+        onUpdateContent={controller.updateDraftContent}
       />
     ) : null;
 
@@ -2015,6 +2017,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       isManualReleaseButton={false}
       headerPaddingClass={noteHeaderPaddingClass}
       onOpenSettings={handleOpenSettings}
+      isNoteContextOpen={isNoteContextOpen}
+      onToggleNoteContext={activeNoteFile ? () => setNoteContextOpen(!isNoteContextOpen) : undefined}
       headerAccessory={null}
       content={skillsController.draftContent}
       documentLabel="skill"
@@ -2135,6 +2139,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       <AppLayout
         toolbar={toolbarNode}
         footer={footerNode}
+        themeMode={controller.settings?.themeMode ?? "system"}
+        onChangeTheme={(mode) => void controller.changeThemeMode(mode)}
         shouldCollapseSidebar={shouldCollapseSidebar}
         tree={controller.visibleSidebarNodes}
         activePath={

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -32,6 +32,7 @@ import { AppSurfaceShell } from "./app-surface-shell";
 import { CommandPalette } from "./command-palette";
 import { NotesBrowserPane } from "./notes/notes-browser-pane";
 import { EditorToolbar } from "./editor-toolbar";
+import { NoteContextSidebar } from "./note-context-sidebar";
 import { NotesFooterContent } from "./notes-footer-content";
 import { NoteConfirmDialog } from "./note-confirm-dialog";
 import { NoteRenameDialog } from "./note-rename-dialog";
@@ -57,6 +58,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const viewerMode = useSessionStore((state) => state.viewerMode);
   const isNotesExpanded = useSessionStore((state) => state.isNotesExpanded);
   const isSkillsExpanded = useSessionStore((state) => state.isSkillsExpanded);
+  const workspaceRootPath = useWorkspaceStore((state) => state.rootPath);
   const selectedNoteCollectionPath = useSessionStore((state) => state.selectedNoteCollectionPath);
   const notesBrowserPaneWidth = useSessionStore((state) => state.notesBrowserPaneWidth);
   const selectedSkillCollectionId = useSessionStore((state) => state.selectedSkillCollectionId);
@@ -175,6 +177,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);
   const [pendingSkillRestorePath, setPendingSkillRestorePath] = useState<string | null>(null);
   const [isInitialSkillRestorePending, setIsInitialSkillRestorePending] = useState(false);
+  const [isNoteContextOpen, setIsNoteContextOpen] = useState(false);
   const paletteSkillSearchNonceRef = useRef(0);
   const paletteFilterQuery = controller.paletteQuery.trim().toLowerCase();
   const shouldCollapseSidebar =
@@ -1272,6 +1275,17 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         },
       },
       {
+        id: "toggle-note-context",
+        title: isNoteContextOpen ? "Hide Note Context" : "Show Note Context",
+        subtitle: "Toggle properties, links, tags, and outline",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          setIsNoteContextOpen((current) => !current);
+          closePalette();
+        },
+      },
+      {
         id: "reveal-current-note",
         title: controller.folderRevealLabel,
         subtitle: "Show the current note in the file manager",
@@ -1353,6 +1367,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     controller.editorScale,
     controller.shortcuts,
     closePalette,
+    isNoteContextOpen,
   ]);
 
   const skillPaletteItems = useMemo<CommandPaletteItem[]>(() => {
@@ -1868,6 +1883,19 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     (controller.settings?.pinnedFiles ?? []).some((filePath) =>
       isSamePath(filePath, activeNoteFile.path),
     );
+  const noteContextPane =
+    activeNoteFile && isNoteContextOpen ? (
+      <NoteContextSidebar
+        activeFile={activeNoteFile}
+        draftContent={controller.draftContent}
+        rootPath={workspaceRootPath}
+        outlineItems={controller.outlineItems}
+        wordCount={controller.wordCount}
+        readingTime={controller.readingTime}
+        onClose={() => setIsNoteContextOpen(false)}
+        onJumpToHeading={controller.requestOutlineJump}
+      />
+    ) : null;
 
   const toolbarNode: React.ReactNode = isAppBootstrapping ? null : isTasksSurfaceVisible ? (
     <EditorToolbar
@@ -2271,6 +2299,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
               ) : null
             }
             browserPaneWidth={notesBrowserPaneWidth}
+            contextPane={noteContextPane}
             onBrowserPaneResize={setNotesBrowserPaneWidth}
           >
             <div className="flex h-full min-h-0 flex-col bg-background">

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1,6 +1,11 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getBaseName, getDisplayFileName, isSamePath, normalizePath } from "@/core/paths";
+import {
+  formatMarkdownFrontmatter,
+  parseMarkdownFrontmatter,
+  serializeMarkdownFrontmatter,
+} from "@/core/frontmatter";
 import { buildNoteCollections, filterNoteBrowserEntries } from "@/core/note-collections";
 import { countGroupedSkills, groupSkillsForBrowse } from "@/core/skill-groups";
 import { getShortcutDisplay } from "@/core/shortcuts";
@@ -1179,6 +1184,17 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     }
 
     const query = paletteFilterQuery;
+    const headingItems: CommandPaletteItem[] = controller.outlineItems.map((item) => ({
+      id: `jump-heading-${item.id}`,
+      title: item.title,
+      subtitle: `Jump to H${item.depth} in ${controller.activeFile?.name ?? "current note"}`,
+      section: "Headings",
+      kind: "command",
+      onSelect: () => {
+        controller.requestOutlineJump(item.id);
+        closePalette();
+      },
+    }));
     const items: CommandPaletteItem[] = [
       {
         id: "find-in-current-note",
@@ -1233,6 +1249,26 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         kind: "command",
         onSelect: () => {
           void handleCopyCurrentNotePath();
+        },
+      },
+      {
+        id: "format-frontmatter",
+        title: "Format Frontmatter",
+        subtitle: "Clean up YAML metadata at the top of this note",
+        section: "Note",
+        kind: "command",
+        onSelect: () => {
+          const parsed = parseMarkdownFrontmatter(controller.draftContent);
+          const formattedFrontmatter = formatMarkdownFrontmatter(parsed.frontmatterText ?? "");
+          if (formattedFrontmatter !== null) {
+            controller.updateDraftContent(
+              serializeMarkdownFrontmatter({
+                frontmatterText: formattedFrontmatter,
+                body: parsed.body,
+              }),
+            );
+          }
+          closePalette();
         },
       },
       {
@@ -1294,13 +1330,18 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
           closePalette();
         },
       },
+      ...headingItems,
     ];
 
     return items.filter((item) => matchesPaletteQuery(query, item.title, item.subtitle));
   }, [
     controller.activeFile,
+    controller.draftContent,
     controller.folderRevealLabel,
+    controller.outlineItems,
     controller.requestFindInNote,
+    controller.requestOutlineJump,
+    controller.updateDraftContent,
     handleCopyCurrentNoteMarkdown,
     handleCopyCurrentNotePath,
     handleExportCurrentNote,

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -11,10 +11,10 @@ import { countGroupedSkills, groupSkillsForBrowse } from "@/core/skill-groups";
 import { getShortcutDisplay } from "@/core/shortcuts";
 import { SKILL_AGENT_CATALOG } from "@/core/skill-agent-catalog";
 import type {
+  DirectoryNode,
   NoteCollectionAccentKey,
   NoteCollectionIconKey,
   NoteBrowserEntry,
-  ThemeMode,
   TabMovePosition,
 } from "@/core/workspace";
 import { useLayoutStore } from "@/store/layout";
@@ -52,6 +52,21 @@ import { TooltipProvider } from "./ui/tooltip";
 import { useUpdateStateFlags } from "./update-notification";
 
 import { matchesPaletteQuery, matchesSkillPaletteFallback } from "./desktop-app/palette-utils";
+
+function collectNoteTitles(nodes: DirectoryNode[]): string[] {
+  const titles = new Set<string>();
+  const visit = (node: DirectoryNode) => {
+    if (node.type === "file") {
+      if (/\.md$/i.test(node.name)) {
+        titles.add(node.name.replace(/\.md$/i, ""));
+      }
+      return;
+    }
+    node.children.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return Array.from(titles).sort((left, right) => left.localeCompare(right));
+}
 
 export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   const sessionHasHydrated = useSessionStore((state) => state.hasHydrated);
@@ -335,6 +350,10 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     setSelectedNoteCollectionPath,
     setLastNotePathForCollection,
   ]);
+  const noteTitleSuggestions = useMemo(
+    () => collectNoteTitles(controller.visibleSidebarNodes.map((entry) => entry.node)),
+    [controller.visibleSidebarNodes],
+  );
   const currentNoteDisplayName = useMemo(
     () => (controller.activeFile ? getDisplayFileName(controller.activeFile.name) : ""),
     [controller.activeFile],
@@ -1890,6 +1909,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         activeFile={activeNoteFile}
         draftContent={controller.draftContent}
         rootPath={workspaceRootPath}
+        noteTitleSuggestions={noteTitleSuggestions}
         onClose={() => setNoteContextOpen(false)}
         onUpdateContent={controller.updateDraftContent}
       />

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -53,21 +53,22 @@ import { useUpdateStateFlags } from "./update-notification";
 
 import { matchesPaletteQuery, matchesSkillPaletteFallback } from "./desktop-app/palette-utils";
 
-function collectNoteTitles(nodes: DirectoryNode[]): Array<{ title: string; icon: string | null }> {
-  const titles = new Set<string>();
+function collectNoteTitles(nodes: DirectoryNode[]): Array<{ title: string; icon: string | null; path: string | null }> {
+  const titles = new Map<string, { title: string; path: string }>();
   const visit = (node: DirectoryNode) => {
     if (node.type === "file") {
       if (/\.md$/i.test(node.name)) {
-        titles.add(node.name.replace(/\.md$/i, ""));
+        const title = node.name.replace(/\.md$/i, "");
+        titles.set(title.toLowerCase(), { title, path: node.path });
       }
       return;
     }
     node.children.forEach(visit);
   };
   nodes.forEach(visit);
-  return Array.from(titles)
-    .sort((left, right) => left.localeCompare(right))
-    .map((title) => ({ title, icon: null }));
+  return Array.from(titles.values())
+    .map((entry) => ({ ...entry, icon: null }))
+    .sort((left, right) => left.title.localeCompare(right.title));
 }
 
 function getFrontmatterIcon(content: string) {
@@ -408,7 +409,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     [activeNoteIcon, controller.activeFile, visibleNoteBrowserEntries],
   );
   const noteTitleSuggestions = useMemo(() => {
-    const titleMap = new Map<string, { title: string; icon: string | null }>();
+    const titleMap = new Map<string, { title: string; icon: string | null; path: string | null }>();
     collectNoteTitles(controller.visibleSidebarNodes.map((entry) => entry.node)).forEach((entry) => {
       titleMap.set(entry.title.toLowerCase(), entry);
     });
@@ -417,7 +418,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         controller.activeFile && isSamePath(entry.path, controller.activeFile.path)
           ? activeNoteIcon
           : entry.icon;
-      titleMap.set(entry.title.toLowerCase(), { title: entry.title, icon });
+      titleMap.set(entry.title.toLowerCase(), { title: entry.title, icon, path: entry.path });
     });
     return Array.from(titleMap.values()).sort((left, right) =>
       left.title.localeCompare(right.title),
@@ -1973,6 +1974,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         rootPath={workspaceRootPath}
         noteTitleSuggestions={noteTitleSuggestions}
         onClose={() => setNoteContextOpen(false)}
+        onOpenNote={(path) => void handleOpenLinkedFile(path)}
         onUpdateContent={controller.updateDraftContent}
       />
     ) : null;

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -15,6 +15,7 @@ import type {
   NoteCollectionAccentKey,
   NoteCollectionIconKey,
   NoteBrowserEntry,
+  NoteKnowledgeIndexSnapshot,
   TabMovePosition,
 } from "@/core/workspace";
 import { useLayoutStore } from "@/store/layout";
@@ -76,6 +77,22 @@ function getFrontmatterIcon(content: string) {
   const match = parsed.frontmatterText?.match(/^icon:\s*(.+?)\s*$/m);
   const icon = match?.[1]?.trim().replace(/^['"]|['"]$/g, "") ?? null;
   return icon && icon !== "none" ? icon : null;
+}
+
+function getMetadataString(value: unknown) {
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+function getMetadataStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(getMetadataStringArray);
+  }
+  if (typeof value === "string") {
+    return value.split(/[,\s]+/).map((entry) => entry.trim().replace(/^#/, "").toLowerCase()).filter(Boolean);
+  }
+  return [];
 }
 
 export const DesktopApp = ({ glyph }: DesktopAppProps) => {
@@ -214,6 +231,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     name: string;
   } | null>(null);
   const [noteBrowserRefreshNonce, setNoteBrowserRefreshNonce] = useState(0);
+  const [knowledgeIndex, setKnowledgeIndex] = useState<NoteKnowledgeIndexSnapshot | null>(null);
   const [paletteSkillResultIds, setPaletteSkillResultIds] = useState<string[] | null>(null);
   const [resolvedPaletteSkillQuery, setResolvedPaletteSkillQuery] = useState("");
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);
@@ -424,6 +442,51 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       left.title.localeCompare(right.title),
     );
   }, [activeNoteIcon, controller.activeFile, controller.visibleSidebarNodes, noteBrowserEntries]);
+  const metadataOptions = useMemo(() => {
+    const types = new Set<string>();
+    const statuses = new Set<string>();
+    const tags = new Set<string>();
+
+    knowledgeIndex?.notes.forEach((note) => {
+      const type = getMetadataString(note.frontmatter.type);
+      const status = getMetadataString(note.frontmatter.status);
+      if (type) types.add(type);
+      if (status) statuses.add(status);
+      getMetadataStringArray(note.frontmatter.tags).forEach((tag) => tags.add(tag));
+      getMetadataStringArray(note.frontmatter.tag).forEach((tag) => tags.add(tag));
+      getMetadataStringArray(note.frontmatter.keywords).forEach((tag) => tags.add(tag));
+      note.tags.forEach((tag) => tags.add(tag.name));
+    });
+
+    return {
+      statuses: Array.from(statuses).sort((left, right) => left.localeCompare(right)),
+      tags: Array.from(tags).sort((left, right) => left.localeCompare(right)),
+      types: Array.from(types).sort((left, right) => left.localeCompare(right)),
+    };
+  }, [knowledgeIndex]);
+  const activeNoteBacklinks = useMemo(() => {
+    if (!controller.activeFile || !knowledgeIndex) {
+      return [];
+    }
+
+    const notesByPath = new Map(
+      knowledgeIndex.notes.map((note) => [normalizePath(note.path).toLowerCase(), note]),
+    );
+    const activeNote = notesByPath.get(normalizePath(controller.activeFile.path).toLowerCase());
+    if (!activeNote) {
+      return [];
+    }
+
+    return activeNote.backlinks.flatMap((sourcePath) => {
+      const source = notesByPath.get(normalizePath(sourcePath).toLowerCase());
+      if (!source) {
+        return [];
+      }
+
+      const icon = getMetadataString(source.frontmatter.icon) || null;
+      return [{ path: source.path, title: source.title, icon }];
+    });
+  }, [controller.activeFile, knowledgeIndex]);
   const activeNoteCollectionPath = activeNoteCollection?.path ?? null;
 
   const handleToggleSkillsSection = useCallback(() => {
@@ -700,6 +763,30 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     noteCollections,
     noteBrowserRefreshNonce,
   ]);
+
+  useEffect(() => {
+    if (!controller.hasBooted) {
+      return;
+    }
+
+    let isCancelled = false;
+    void glyph
+      .getKnowledgeIndex()
+      .then((snapshot) => {
+        if (!isCancelled) {
+          setKnowledgeIndex(snapshot);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setKnowledgeIndex(null);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [controller.hasBooted, controller.saveStateLabel, glyph, noteBrowserRefreshNonce]);
 
   useEffect(() => {
     if (
@@ -1971,6 +2058,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       <NoteContextSidebar
         activeFile={activeNoteFile}
         draftContent={controller.draftContent}
+        metadataOptions={metadataOptions}
+        backlinks={activeNoteBacklinks}
         rootPath={workspaceRootPath}
         noteTitleSuggestions={noteTitleSuggestions}
         onClose={() => setNoteContextOpen(false)}

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -231,7 +231,8 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     name: string;
   } | null>(null);
   const [noteBrowserRefreshNonce, setNoteBrowserRefreshNonce] = useState(0);
-  const [knowledgeIndex, setKnowledgeIndex] = useState<NoteKnowledgeIndexSnapshot | null>(null);
+  const knowledgeIndex = useWorkspaceStore((state) => state.knowledgeIndex);
+  const setKnowledgeIndex = useWorkspaceStore((state) => state.setKnowledgeIndex);
   const [paletteSkillResultIds, setPaletteSkillResultIds] = useState<string[] | null>(null);
   const [resolvedPaletteSkillQuery, setResolvedPaletteSkillQuery] = useState("");
   const [skillInitialScrollTop, setSkillInitialScrollTop] = useState(0);

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -2332,7 +2332,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         appInfo={controller.appInfo}
         onClose={() => controller.setIsSettingsOpen(false)}
         onChooseFolder={() => void controller.chooseFolderAndUpdateWorkspace()}
-        onChangeMode={(mode: ThemeMode) => void controller.changeThemeMode(mode)}
         onChangeShortcuts={(shortcuts) => void controller.changeShortcuts(shortcuts)}
       />
       <NoteRenameDialog

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -144,6 +144,9 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
   // skillsController and setViewerMode are in scope.
   const onRestoreSkillRef = useRef<(path: string) => Promise<void>>(async () => {});
   const onRestoreTasksRef = useRef<() => void>(() => {});
+  const handleToggleNoteContext = useCallback(() => {
+    setNoteContextOpen(!useSessionStore.getState().isNoteContextOpen);
+  }, [setNoteContextOpen]);
 
   const controller = useDesktopAppController(glyph, {
     initialFilePath: initialNoteSessionRef.current.filePath,
@@ -152,6 +155,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
     sessionReady: sessionHasHydrated,
     onRestoreSkill: useCallback((path: string) => onRestoreSkillRef.current(path), []),
     onRestoreTasks: useCallback(() => onRestoreTasksRef.current(), []),
+    onToggleNoteContext: handleToggleNoteContext,
   });
   const skillsController = useSkillLibraryController(glyph, {
     enabled: true,
@@ -1945,6 +1949,13 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       filePath={null}
       shouldShowCommandPalette={true}
       onOpenCommandPalette={handleOpenCommandPalette}
+      isNoteContextOpen={isNoteContextOpen}
+      onToggleNoteContext={handleToggleNoteContext}
+      toggleNoteContextShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-note-context",
+        navigator.platform,
+      )}
       commandPaletteShortcut={getShortcutDisplay(
         controller.shortcuts,
         "command-palette",
@@ -2019,6 +2030,13 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         navigator.platform,
       )}
       commandPaletteLabel="Search notes and skills"
+      isNoteContextOpen={isNoteContextOpen}
+      onToggleNoteContext={activeNoteFile ? handleToggleNoteContext : undefined}
+      toggleNoteContextShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-note-context",
+        navigator.platform,
+      )}
       isFocusMode={undefined}
       onToggleFocusMode={undefined}
       focusModeShortcut={undefined}
@@ -2033,8 +2051,6 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       isManualReleaseButton={false}
       headerPaddingClass={noteHeaderPaddingClass}
       onOpenSettings={handleOpenSettings}
-      isNoteContextOpen={isNoteContextOpen}
-      onToggleNoteContext={activeNoteFile ? () => setNoteContextOpen(!isNoteContextOpen) : undefined}
       headerAccessory={null}
       content={skillsController.draftContent}
       documentLabel="skill"
@@ -2113,6 +2129,13 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
       isManualReleaseButton={noteUpdateStateFlags.isManualReleaseButton}
       headerPaddingClass={noteHeaderPaddingClass}
       onOpenSettings={handleOpenSettings}
+      isNoteContextOpen={isNoteContextOpen}
+      onToggleNoteContext={activeNoteFile ? handleToggleNoteContext : undefined}
+      toggleNoteContextShortcut={getShortcutDisplay(
+        controller.shortcuts,
+        "toggle-note-context",
+        navigator.platform,
+      )}
       headerAccessory={null}
       content={controller.draftContent}
       documentLabel="note"

--- a/apps/desktop/src/components/desktop-app.tsx
+++ b/apps/desktop/src/components/desktop-app.tsx
@@ -1890,11 +1890,7 @@ export const DesktopApp = ({ glyph }: DesktopAppProps) => {
         activeFile={activeNoteFile}
         draftContent={controller.draftContent}
         rootPath={workspaceRootPath}
-        outlineItems={controller.outlineItems}
-        wordCount={controller.wordCount}
-        readingTime={controller.readingTime}
         onClose={() => setNoteContextOpen(false)}
-        onJumpToHeading={controller.requestOutlineJump}
         onUpdateContent={controller.updateDraftContent}
       />
     ) : null;

--- a/apps/desktop/src/components/editor-pane.tsx
+++ b/apps/desktop/src/components/editor-pane.tsx
@@ -218,15 +218,7 @@ export const EditorPane = memo(function EditorPane({ paneId }: EditorPaneProps) 
         footerMetaLabel={footerMetaLabel}
         wordCount={wordCount}
         readingTime={readingTime}
-        topContent={
-          parsedContent.frontmatterText ? (
-            <FrontmatterBlock
-              value={parsedContent.frontmatterText}
-              isEditable={isEditorEditable}
-              onChange={handleFrontmatterChange}
-            />
-          ) : null
-        }
+        topContent={null}
         subheaderContent={
           noteTabItems.length > 0 ? (
             <NoteTabsBar

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -16,6 +16,7 @@ import {
   FocusIcon,
   GearIcon,
   LinkIcon,
+  NotebookIcon,
   PanelLeftIcon,
   PanelRightIcon,
   PinIcon,
@@ -61,6 +62,8 @@ type EditorToolbarProps = {
   isManualReleaseButton: boolean;
   headerPaddingClass: string;
   onOpenSettings: (() => void) | undefined;
+  isNoteContextOpen?: boolean;
+  onToggleNoteContext?: (() => void) | undefined;
   headerAccessory: React.ReactNode;
   content: string;
   documentLabel: string;
@@ -110,6 +113,8 @@ export function EditorToolbar({
   isManualReleaseButton,
   headerPaddingClass,
   onOpenSettings,
+  isNoteContextOpen = false,
+  onToggleNoteContext,
   headerAccessory,
   content,
   documentLabel,
@@ -445,6 +450,30 @@ export function EditorToolbar({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : null}
+        {onOpenSettings && (
+          <>
+            {onToggleNoteContext ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className={`text-muted-foreground hover:text-foreground hover:bg-transparent ${
+                      isNoteContextOpen ? "text-primary hover:text-primary" : ""
+                    }`}
+                    onClick={onToggleNoteContext}
+                    aria-pressed={isNoteContextOpen}
+                    aria-label={isNoteContextOpen ? "Hide note context" : "Show note context"}
+                    type="button"
+                  >
+                    <NotebookIcon size={16} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Note Context</TooltipContent>
+              </Tooltip>
+            ) : null}
+          </>
+        )}
         {onOpenSettings && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/desktop/src/components/editor-toolbar.tsx
+++ b/apps/desktop/src/components/editor-toolbar.tsx
@@ -64,6 +64,7 @@ type EditorToolbarProps = {
   onOpenSettings: (() => void) | undefined;
   isNoteContextOpen?: boolean;
   onToggleNoteContext?: (() => void) | undefined;
+  toggleNoteContextShortcut?: string | undefined;
   headerAccessory: React.ReactNode;
   content: string;
   documentLabel: string;
@@ -115,6 +116,7 @@ export function EditorToolbar({
   onOpenSettings,
   isNoteContextOpen = false,
   onToggleNoteContext,
+  toggleNoteContextShortcut,
   headerAccessory,
   content,
   documentLabel,
@@ -458,18 +460,21 @@ export function EditorToolbar({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className={`text-muted-foreground hover:text-foreground hover:bg-transparent ${
-                      isNoteContextOpen ? "text-primary hover:text-primary" : ""
+                    className={`text-muted-foreground transition-colors ${
+                      isNoteContextOpen ? "text-primary hover:text-primary/80 bg-primary/10" : "hover:text-foreground hover:bg-muted"
                     }`}
                     onClick={onToggleNoteContext}
                     aria-pressed={isNoteContextOpen}
-                    aria-label={isNoteContextOpen ? "Hide note context" : "Show note context"}
+                    aria-label={isNoteContextOpen ? "Hide properties panel" : "Open properties panel"}
                     type="button"
                   >
-                    <NotebookIcon size={16} />
+                    <PanelRightIcon size={16} />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">Note Context</TooltipContent>
+                <TooltipContent side="bottom">
+                  {isNoteContextOpen ? "Hide properties panel" : "Open properties panel"}
+                  {toggleNoteContextShortcut ? ` (${toggleNoteContextShortcut})` : ""}
+                </TooltipContent>
               </Tooltip>
             ) : null}
           </>

--- a/apps/desktop/src/components/footer-stats.tsx
+++ b/apps/desktop/src/components/footer-stats.tsx
@@ -8,19 +8,24 @@ type FooterStatsProps = {
 export function FooterStats({ wordCount, readingTime, fileSize, saveState }: FooterStatsProps) {
   return (
     <div className="flex items-center gap-2.5 text-xs text-muted-foreground">
-      <span>{wordCount} words</span>
-      <div className="w-px h-2.5 bg-border/50" />
-      <span>{readingTime} min read</span>
-      {fileSize && (
-        <>
-          <div className="w-px h-2.5 bg-border/50" />
-          <span>{fileSize}</span>
-        </>
-      )}
       {saveState && (
         <>
-          <div className="w-px h-2.5 bg-border/50" />
-          <span className="font-medium text-foreground">{saveState}</span>
+          <span
+            key={saveState}
+            className="font-medium text-foreground animate-in fade-in duration-300 ease-out whitespace-nowrap"
+          >
+            {saveState}
+          </span>
+          <div className="w-px h-2.5 bg-border/50 shrink-0" />
+        </>
+      )}
+      <span className="shrink-0">{wordCount} words</span>
+      <div className="w-px h-2.5 bg-border/50 shrink-0" />
+      <span className="shrink-0">{readingTime} min read</span>
+      {fileSize && (
+        <>
+          <div className="w-px h-2.5 bg-border/50 shrink-0" />
+          <span className="shrink-0">{fileSize}</span>
         </>
       )}
     </div>

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -42,6 +42,9 @@ import {
   SparklesIcon as SparklesSvg,
   UnfoldMoreIcon as UnfoldMoreSvg,
   Tick02Icon as Tick02Svg,
+  Sun01Icon as Sun01Svg,
+  Moon01Icon as Moon01Svg,
+  ComputerIcon as ComputerSvg,
 } from "@hugeicons/core-free-icons";
 
 import type { HugeIconProps, IconProps } from "../types/icons";
@@ -177,3 +180,7 @@ export const LeafIcon = (props: IconProps) => <HugeIcon icon={Leaf01Svg} {...pro
 export const NotebookIcon = (props: IconProps) => <HugeIcon icon={Notebook01Svg} {...props} />;
 export const RocketIcon = (props: IconProps) => <HugeIcon icon={Rocket01Svg} {...props} />;
 export const SparklesIcon = (props: IconProps) => <HugeIcon icon={SparklesSvg} {...props} />;
+
+export const SunIcon = (props: IconProps) => <HugeIcon icon={Sun01Svg} {...props} />;
+export const MoonIcon = (props: IconProps) => <HugeIcon icon={Moon01Svg} {...props} />;
+export const MonitorIcon = (props: IconProps) => <HugeIcon icon={ComputerSvg} {...props} />;

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -26,6 +26,7 @@ import {
 } from "./tiptap-extension/find-highlight";
 import { MarkdownShortcuts } from "./tiptap-extension/markdown-shortcuts";
 import { TaskTokenHighlight } from "./tiptap-extension/task-token-highlight";
+import { WikiLink } from "./tiptap-extension/wiki-link";
 
 import { Button } from "@/components/ui/button";
 
@@ -761,6 +762,7 @@ export const MarkdownEditor = ({
         SlashCommand,
         FindHighlightExtension,
         TaskTokenHighlight,
+        WikiLink,
         Placeholder.configure({
           placeholder: "Start with a title, then let markdown shortcuts shape the page.",
         }),
@@ -782,13 +784,14 @@ export const MarkdownEditor = ({
         },
         handleClick: (_view, _pos, event) => {
           const target = event.target;
-          const link = target instanceof HTMLElement ? target.closest("a") : null;
+          const link =
+            target instanceof HTMLElement ? target.closest("a, [data-wiki-link]") : null;
 
           if (!link) {
             return false;
           }
 
-          const href = link.getAttribute("href");
+          const href = link.getAttribute("href") ?? link.getAttribute("data-wiki-link");
           if (!href) {
             return false;
           }
@@ -807,13 +810,14 @@ export const MarkdownEditor = ({
         handleDOMEvents: {
           mouseover: (_view, event) => {
             const target = event.target;
-            const link = target instanceof HTMLElement ? target.closest("a") : null;
+            const link =
+              target instanceof HTMLElement ? target.closest("a, [data-wiki-link]") : null;
 
             if (!link) {
               return false;
             }
 
-            const href = link.getAttribute("href");
+            const href = link.getAttribute("href") ?? link.getAttribute("data-wiki-link");
             if (!href) {
               return false;
             }

--- a/apps/desktop/src/components/markdown-editor.tsx
+++ b/apps/desktop/src/components/markdown-editor.tsx
@@ -34,6 +34,7 @@ import { EditorToolbar } from "./editor-toolbar";
 import { EditorDialogs } from "./editor-dialogs";
 import { useUpdateStateFlags } from "./update-notification";
 import { SlashCommand } from "@/core/slash-command";
+import { WikiLinkSuggest } from "@/core/wiki-suggest";
 import { TableOfContents } from "./table-of-contents";
 import { TableControls } from "./table-controls";
 import { FindPanel } from "./find-panel";
@@ -760,6 +761,7 @@ export const MarkdownEditor = ({
         TableHeader,
         TableCell,
         SlashCommand,
+        WikiLinkSuggest,
         FindHighlightExtension,
         TaskTokenHighlight,
         WikiLink,

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -339,7 +339,7 @@ function serializeFrontmatter(frontmatter: Record<string, unknown>) {
 }
 
 function detectTags(body: string, existingTags: string[]) {
-  const existing = new Set(existingTags);
+  const existing = new Set(existingTags.map((tag) => normalizeTag(tag)));
   const counts = new Map<string, number>();
   const normalizedBody = body
     .replace(/```[\s\S]*?```/g, " ")
@@ -349,14 +349,15 @@ function detectTags(body: string, existingTags: string[]) {
 
   for (const match of normalizedBody.toLowerCase().matchAll(/[a-z][a-z0-9-]{5,}/g)) {
     const tag = normalizeTag(match[0]);
-    if (STOP_WORDS.has(tag) || existing.has(tag) || tag.endsWith("ing")) continue;
+    if (STOP_WORDS.has(tag) || tag.endsWith("ing")) continue;
     counts.set(tag, (counts.get(tag) ?? 0) + 1);
   }
   return Array.from(counts.entries())
     .filter(([tag, count]) => count >= 2 && !STOP_WORDS.has(tag))
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
     .slice(0, 5)
-    .map(([tag]) => tag);
+    .map(([tag]) => tag)
+    .filter((tag) => !existing.has(tag));
 }
 
 function hashText(value: string) {

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
+import { Popover } from "@base-ui/react/popover";
 import { parseDocument } from "yaml";
 
 import {
@@ -8,6 +9,7 @@ import {
 } from "@/core/frontmatter";
 import { getBaseName, getDirName } from "@/core/paths";
 import type { FileDocument } from "@/core/workspace";
+import { cn } from "@/core/utils";
 
 import {
   BookIcon,
@@ -114,14 +116,14 @@ const ICON_OPTIONS: IconOption[] = [
 ];
 
 const STATUS_TONE: Record<string, string> = {
-  "not started": "bg-muted text-muted-foreground",
-  active: "bg-primary/10 text-primary",
-  "in progress": "bg-primary/10 text-primary",
-  learning: "bg-accent text-accent-foreground",
-  blocked: "bg-destructive/10 text-destructive",
-  draft: "bg-muted text-foreground",
-  archived: "bg-muted text-muted-foreground",
-  paused: "bg-secondary text-secondary-foreground",
+  "not started": "text-muted-foreground",
+  active: "text-primary",
+  "in progress": "text-primary",
+  learning: "text-amber-500",
+  blocked: "text-destructive",
+  draft: "text-muted-foreground/80",
+  archived: "text-muted-foreground/60",
+  paused: "text-orange-500",
 };
 
 const TAG_TONES = [
@@ -142,6 +144,27 @@ const PROPERTY_TYPE_ICONS: Record<string, string> = {
   Text: "T",
   URL: "U",
 };
+
+type CalendarDay = {
+  day: number;
+  month: number;
+  year: number;
+};
+
+const MONTH_FORMATTER = new Intl.DateTimeFormat("en", { month: "long" });
+
+function formatDateForString(day: number, month: number, year: number) {
+  return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function parseInputDate(dateString: string): CalendarDay | null {
+  if (!dateString) return null;
+  const parts = dateString.split("-").map(Number);
+  if (parts.length === 3 && !isNaN(parts[0]) && !isNaN(parts[1]) && !isNaN(parts[2])) {
+    return { year: parts[0], month: parts[1] - 1, day: parts[2] };
+  }
+  return null;
+}
 
 function normalizeTag(input: string) {
   return input.trim().replace(/^#/, "").toLowerCase();
@@ -302,7 +325,7 @@ function FieldRow({
   children: ReactNode;
 }) {
   return (
-    <div className="group grid min-h-8 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
+    <div className="group grid min-h-[30px] grid-cols-[16px_68px_minmax(0,1fr)] items-center gap-2.5 px-1 text-[11px] leading-none">
       <span className="text-muted-foreground/75">{icon}</span>
       <span className="text-muted-foreground">{label}</span>
       <div className="min-w-0">{children}</div>
@@ -314,8 +337,48 @@ function CompactInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
       {...props}
-      className={`h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/40 focus:bg-background ${props.className ?? ""}`}
+      className={`h-7 w-full rounded-md border border-transparent bg-transparent px-1.5 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 hover:bg-muted/30 focus:border-primary/20 focus:bg-muted/50 ${props.className ?? ""}`}
     />
+  );
+}
+
+function BasePopover({
+  open,
+  onOpenChange,
+  trigger,
+  children,
+  className,
+  align = "end",
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: React.ReactElement;
+  children: ReactNode;
+  className?: string;
+  align?: "start" | "center" | "end";
+}) {
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger render={trigger} />
+      <Popover.Portal>
+        <Popover.Positioner
+          side="bottom"
+          align={align}
+          sideOffset={4}
+          className="isolate z-50 outline-none"
+        >
+          <Popover.Popup
+            className={cn(
+              "z-50 max-h-(--available-height) min-w-[200px] max-w-[calc(100vw-24px)] origin-(--transform-origin) overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+              "dark:bg-popover/90 dark:backdrop-blur-2xl",
+              className,
+            )}
+          >
+            {children}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 
@@ -327,6 +390,7 @@ function OptionPicker({
   allowCreate = true,
   onChange,
   renderTrigger,
+  align = "end",
 }: {
   value: string;
   options: SelectOption[];
@@ -335,6 +399,7 @@ function OptionPicker({
   allowCreate?: boolean;
   onChange: (value: string) => void;
   renderTrigger?: (option: SelectOption | null) => ReactNode;
+  align?: "start" | "center" | "end";
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -349,87 +414,212 @@ function OptionPicker({
   };
 
   return (
-    <div
-      className="relative min-w-0"
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setOpen(false);
-          setQuery("");
-        }
+    <BasePopover
+      align={align}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setQuery("");
       }}
+      trigger={
+        <button
+          type="button"
+          className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+        >
+          <span className="min-w-0 truncate">
+            {renderTrigger ? renderTrigger(selected) : selected?.label || value || placeholder}
+          </span>
+          <ArrowDownIcon size={11} className="shrink-0 opacity-40" />
+        </button>
+      }
     >
-      <button
-        type="button"
-        className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-muted/70 px-2 text-left text-xs text-foreground transition-colors hover:bg-muted focus:border-primary/40 focus:bg-background focus:outline-none"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={() => setOpen((current) => !current)}
-      >
-        <span className="min-w-0 truncate">
-          {renderTrigger ? renderTrigger(selected) : selected?.label || value || placeholder}
-        </span>
-        <ArrowDownIcon size={12} className="shrink-0 text-muted-foreground" />
-      </button>
-      {open ? (
-        <div className="absolute right-0 top-[calc(100%+4px)] z-30 w-[220px] overflow-hidden rounded-md border border-border bg-background shadow-lg">
-          <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
-            <SearchIcon size={12} className="text-muted-foreground" />
-            <input
-              autoFocus
-              value={query}
-              placeholder={searchPlaceholder}
-              className="h-6 min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  setOpen(false);
-                  setQuery("");
-                }
-                if (event.key === "Enter") {
-                  const first = filteredOptions[0];
-                  selectValue(first?.value ?? query.trim());
-                }
-              }}
-            />
-          </div>
-          <div className="max-h-52 overflow-y-auto py-1" role="listbox">
-            {filteredOptions.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
-                role="option"
-                aria-selected={option.value === value}
-                onClick={() => selectValue(option.value)}
-              >
-                <span className="grid h-4 w-4 shrink-0 place-items-center text-[10px] text-muted-foreground">
-                  {option.value === value ? <TickIcon size={12} /> : option.icon}
-                </span>
-                <span className={`min-w-0 truncate ${option.className ?? ""}`}>{option.label}</span>
-              </button>
-            ))}
-            {showCreate ? (
-              <>
-                {filteredOptions.length > 0 ? <div className="my-1 h-px bg-border" /> : null}
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted"
-                  onClick={() => selectValue(query.trim())}
-                >
-                  <PlusIcon size={12} />
-                  <span className="truncate">Create {query.trim()}</span>
-                </button>
-              </>
-            ) : null}
-            {filteredOptions.length === 0 && !showCreate ? (
-              <div className="px-2 py-3 text-center text-xs text-muted-foreground">No matches</div>
-            ) : null}
-          </div>
+      <div className="flex w-[220px] flex-col overflow-hidden">
+        <div className="flex items-center gap-1.5 border-b border-border/40 px-2.5 py-2">
+          <SearchIcon size={12} className="text-muted-foreground/60" />
+          <input
+            autoFocus
+            value={query}
+            placeholder={searchPlaceholder}
+            className="h-5 min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/50"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setOpen(false);
+              }
+              if (event.key === "Enter") {
+                const first = filteredOptions[0];
+                selectValue(first?.value ?? query.trim());
+              }
+            }}
+          />
         </div>
-      ) : null}
-    </div>
+        <div className="max-h-64 overflow-y-auto p-1" role="listbox">
+          {filteredOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground transition-colors",
+                option.value === value ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted",
+              )}
+              role="option"
+              aria-selected={option.value === value}
+              onClick={() => selectValue(option.value)}
+            >
+              <span className="grid h-3.5 w-3.5 shrink-0 place-items-center text-muted-foreground">
+                {option.value === value ? <TickIcon size={12} className="text-primary" /> : option.icon}
+              </span>
+              <span className={`min-w-0 truncate ${option.className ?? ""}`}>{option.label}</span>
+            </button>
+          ))}
+          {showCreate ? (
+            <>
+              {filteredOptions.length > 0 ? <div className="my-1 h-px bg-border/40" /> : null}
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted"
+                onClick={() => selectValue(query.trim())}
+              >
+                <PlusIcon size={12} />
+                <span className="truncate">Create "{query.trim()}"</span>
+              </button>
+            </>
+          ) : null}
+          {filteredOptions.length === 0 && !showCreate ? (
+            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground/60 italic">
+              No matches
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </BasePopover>
   );
 }
+function DatePicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (nextValue: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const parsedDay = useMemo(() => parseInputDate(value), [value]);
+  const [calendarMonth, setCalendarMonth] = useState(() => {
+    if (parsedDay) return new Date(parsedDay.year, parsedDay.month, 1);
+    return new Date();
+  });
+
+  const today = useMemo(() => {
+    const current = new Date();
+    return { day: current.getDate(), month: current.getMonth(), year: current.getFullYear() };
+  }, []);
+
+  const year = calendarMonth.getFullYear();
+  const month = calendarMonth.getMonth();
+  const firstWeekday = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const monthLabel = MONTH_FORMATTER.format(calendarMonth);
+
+  const emptyCells = Array.from({ length: firstWeekday }, (_, index) => index);
+
+  const handleShiftMonth = (offset: number) => {
+    setCalendarMonth((current) => {
+      const next = new Date(current);
+      next.setMonth(current.getMonth() + offset, 1);
+      return next;
+    });
+  };
+
+  const handleSelectDay = (day: number) => {
+    onChange(formatDateForString(day, month, year));
+    setOpen(false);
+  };
+
+  return (
+    <BasePopover
+      open={open}
+      onOpenChange={setOpen}
+      trigger={
+        <button
+          type="button"
+          className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+        >
+          <span className="min-w-0 truncate text-muted-foreground/70">
+            {value || "Set date..."}
+          </span>
+          <CalendarIcon size={11} className="shrink-0 opacity-40" />
+        </button>
+      }
+    >
+      <div className="w-52 p-2.5">
+        <div className="mb-2.5 flex items-center justify-between px-1">
+          <button
+            type="button"
+            onClick={() => handleShiftMonth(-1)}
+            className="grid h-6 w-6 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <span className="text-xs font-bold">‹</span>
+          </button>
+          <span className="text-[11px] font-semibold tracking-tight text-foreground">
+            {monthLabel} {year}
+          </span>
+          <button
+            type="button"
+            onClick={() => handleShiftMonth(1)}
+            className="grid h-6 w-6 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <span className="text-xs font-bold">›</span>
+          </button>
+        </div>
+        <div className="mb-1.5 grid grid-cols-7 gap-px text-center text-[10px] font-medium text-muted-foreground/60">
+          {["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((d) => (
+            <span key={d}>{d}</span>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-0.5 text-center">
+          {emptyCells.map((i) => (
+            <div key={`empty-${i}`} className="h-6" />
+          ))}
+          {Array.from({ length: daysInMonth }, (_, i) => i + 1).map((day) => {
+            const isToday = today.day === day && today.month === month && today.year === year;
+            const isSelected =
+              parsedDay?.day === day && parsedDay.month === month && parsedDay.year === year;
+            return (
+              <button
+                key={day}
+                type="button"
+                onClick={() => handleSelectDay(day)}
+                className={cn(
+                  "h-6 w-full rounded-md text-[10px] transition-colors font-medium",
+                  isSelected
+                    ? "bg-primary text-primary-foreground"
+                    : isToday
+                      ? "bg-primary/15 text-primary hover:bg-primary/25"
+                      : "hover:bg-muted text-foreground/80 hover:text-foreground",
+                )}
+              >
+                {day}
+              </button>
+            );
+          })}
+        </div>
+        {value && (
+          <button
+            type="button"
+            onClick={() => {
+              onChange("");
+              setOpen(false);
+            }}
+            className="mt-2.5 w-full rounded-md border border-border/40 bg-muted/10 py-1.5 text-[10px] font-medium text-muted-foreground/80 hover:bg-muted hover:text-foreground transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </BasePopover>
+  );
+}
+
 
 function TagPill({ tag, onRemove }: { tag: string; onRemove?: () => void }) {
   return (
@@ -473,85 +663,85 @@ function TagPicker({
     !options.some((tag) => tag.toLowerCase() === query.trim().toLowerCase());
 
   return (
-    <div
-      className="relative"
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setOpen(false);
-          setQuery("");
-        }
+    <BasePopover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setQuery("");
       }}
+      trigger={
+        <button
+          type="button"
+          className="grid h-5 w-5 place-items-center rounded-full bg-muted/50 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+          aria-label="Add tag"
+        >
+          <PlusIcon size={12} />
+        </button>
+      }
     >
-      <button
-        type="button"
-        className="text-muted-foreground transition-colors hover:text-primary"
-        aria-label="Add tag"
-        onClick={() => setOpen((current) => !current)}
-      >
-        <PlusIcon size={13} />
-      </button>
-      {open ? (
-        <div className="absolute right-0 top-[calc(100%+6px)] z-30 w-52 overflow-hidden rounded-md border border-border bg-background shadow-lg">
-          <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
-            <SearchIcon size={12} className="text-muted-foreground" />
-            <input
-              autoFocus
-              value={query}
-              placeholder="Type tag..."
-              className="h-6 min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Escape") setOpen(false);
-                if (event.key === "Enter" && query.trim()) {
+      <div className="flex w-56 flex-col overflow-hidden">
+        <div className="flex items-center gap-1.5 border-b border-border/40 px-2.5 py-2">
+          <SearchIcon size={12} className="text-muted-foreground/60" />
+          <input
+            autoFocus
+            value={query}
+            placeholder="Type tag..."
+            className="h-5 min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/50"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") setOpen(false);
+              if (event.key === "Enter" && query.trim()) {
+                onToggle(query.trim());
+                setQuery("");
+              }
+            }}
+          />
+        </div>
+        <div className="max-h-56 overflow-y-auto p-1">
+          {filtered.length > 0 ? (
+            <div>
+              <div className="px-2 py-1.5 text-[9px] font-semibold text-muted-foreground/60 uppercase tracking-wider">
+                Known Tags
+              </div>
+              {filtered.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors hover:bg-muted"
+                  onClick={() => onToggle(tag)}
+                >
+                  <span className="grid w-3.5 shrink-0 place-items-center text-primary">
+                    {selected.has(tag) ? <TickIcon size={12} /> : null}
+                  </span>
+                  <TagPill tag={tag} />
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {showCreate ? (
+            <>
+              {filtered.length > 0 ? <div className="my-1 h-px bg-border/40" /> : null}
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
+                onClick={() => {
                   onToggle(query.trim());
                   setQuery("");
-                }
-              }}
-            />
-          </div>
-          <div className="max-h-52 overflow-y-auto py-1">
-            {filtered.length > 0 ? (
-              <div>
-                <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground">
-                  From vault
-                </div>
-                {filtered.map((tag) => (
-                  <button
-                    key={tag}
-                    type="button"
-                    className="flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors hover:bg-muted"
-                    onClick={() => onToggle(tag)}
-                  >
-                    <span className="grid w-3 place-items-center text-primary">
-                      {selected.has(tag) ? <TickIcon size={11} /> : null}
-                    </span>
-                    <TagPill tag={tag} />
-                  </button>
-                ))}
-              </div>
-            ) : null}
-            {showCreate ? (
-              <>
-                {filtered.length > 0 ? <div className="my-1 h-px bg-border" /> : null}
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted"
-                  onClick={() => {
-                    onToggle(query.trim());
-                    setQuery("");
-                  }}
-                >
-                  Create <TagPill tag={query.trim()} />
-                </button>
-              </>
-            ) : null}
-            {filtered.length === 0 && !showCreate ? (
-              <div className="px-2 py-3 text-center text-xs text-muted-foreground">No tags</div>
-            ) : null}
-          </div>
+                }}
+              >
+                <span className="text-muted-foreground">Create</span>
+                <TagPill tag={query.trim()} />
+              </button>
+            </>
+          ) : null}
+          {filtered.length === 0 && !showCreate ? (
+            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground/60 italic">
+              No matching tags
+            </div>
+          ) : null}
         </div>
-      ) : null}
-    </div>
+      </div>
+    </BasePopover>
   );
 }
 
@@ -608,9 +798,13 @@ function PropertyValueEditor({
     );
   }
 
+  if (type === "Date") {
+    return <DatePicker value={value} onChange={onChange} />;
+  }
+
   return (
     <CompactInput
-      type={type === "Number" ? "number" : type === "Date" ? "date" : type === "URL" ? "url" : "text"}
+      type={type === "Number" ? "number" : type === "URL" ? "url" : "text"}
       value={value}
       placeholder="Value"
       onChange={(event) => onChange(event.target.value)}
@@ -629,7 +823,6 @@ export function NoteContextSidebar({
   const [newProperty, setNewProperty] = useState({ name: "", type: "Text", value: "" });
   const [newRelation, setNewRelation] = useState({ name: "Related to", note: "" });
   const [showAddProperty, setShowAddProperty] = useState(false);
-  const [editingRelationship, setEditingRelationship] = useState<string | null>(null);
 
   const parsed = useMemo(() => parseMarkdownFrontmatter(draftContent), [draftContent]);
   const frontmatter = useMemo(
@@ -669,16 +862,17 @@ export function NoteContextSidebar({
     icon: type === "None" ? <FileIcon size={12} /> : <SparklesIcon size={12} />,
     className: type === "None" ? "text-muted-foreground" : "text-primary",
   }));
-  const statusOptions = knownStatuses.map((status) => ({
-    value: status,
-    label: status,
-    icon: (
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${STATUS_TONE[status.toLowerCase()] ?? "bg-muted"}`}
-      />
-    ),
-    className: STATUS_TONE[status.toLowerCase()] ?? "bg-muted text-foreground",
-  }));
+  const statusOptions = knownStatuses.map((status) => {
+    const textClass = STATUS_TONE[status.toLowerCase()] ?? "text-muted-foreground";
+    // Transform 'text-blue-500' into 'bg-blue-500' to style the dot.
+    const bgClass = textClass.replace("text-", "bg-");
+    return {
+      value: status,
+      label: status,
+      icon: <span className={cn("h-1.5 w-1.5 rounded-full", bgClass)} />,
+      className: textClass,
+    };
+  });
   const iconOptions = ICON_OPTIONS.map((option) => ({
     value: option.key,
     label: option.label,
@@ -757,11 +951,9 @@ export function NoteContextSidebar({
               searchPlaceholder="Search types..."
               onChange={(value) => updateFrontmatter({ type: value === "None" ? "" : value })}
               renderTrigger={(option) => (
-                <span
-                  className={`inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? "bg-primary/10 text-primary"}`}
-                >
-                  {option?.icon}
-                  <span className="truncate">{option?.label ?? model.type}</span>
+                <span className="inline-flex items-center gap-1.5 text-foreground/80">
+                  <span className="opacity-70">{option?.icon}</span>
+                  <span className="truncate font-medium">{option?.label ?? model.type}</span>
                 </span>
               )}
             />
@@ -778,11 +970,11 @@ export function NoteContextSidebar({
               searchPlaceholder="Type status..."
               onChange={(value) => updateFrontmatter({ status: value === "None" ? "" : value })}
               renderTrigger={(option) => (
-                <span
-                  className={`inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? "bg-muted text-foreground"}`}
-                >
-                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                  <span className="truncate">{option?.label ?? model.status}</span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className={cn("h-1.5 w-1.5 rounded-full bg-current", option?.className?.replace('text-', 'bg-') || 'bg-muted-foreground')} />
+                  <span className={cn("truncate font-medium", option?.className || "text-foreground/80")}>
+                    {option?.label ?? model.status}
+                  </span>
                 </span>
               )}
             />
@@ -806,10 +998,9 @@ export function NoteContextSidebar({
           </FieldRow>
 
           <FieldRow icon={<CalendarIcon size={13} />} label="Date">
-            <CompactInput
-              type="date"
+            <DatePicker
               value={model.date}
-              onChange={(event) => updateFrontmatter({ date: event.target.value })}
+              onChange={(nextDate) => updateFrontmatter({ date: nextDate })}
             />
           </FieldRow>
 
@@ -821,12 +1012,108 @@ export function NoteContextSidebar({
               onChange={(event) => updateFrontmatter({ url: event.target.value })}
             />
           </FieldRow>
+
+          {/* Inline Custom Properties following URL */}
+          {model.customProperties.map((property, index) => (
+            <FieldRow
+              key={`${property.name}-${index}`}
+              icon={<span>{PROPERTY_TYPE_ICONS[property.type] ?? "T"}</span>}
+              label={property.name}
+            >
+              <div className="flex min-w-0 items-center gap-1">
+                <PropertyValueEditor
+                  type={property.type}
+                  value={property.value}
+                  statusOptions={statusOptions}
+                  tagOptions={knownTags}
+                  onChange={(value) => {
+                    const nextProperties = model.customProperties.map((entry, propertyIndex) =>
+                      propertyIndex === index ? { ...entry, value } : entry,
+                    );
+                    updateFrontmatter({ properties: nextProperties });
+                  }}
+                />
+                <button
+                  type="button"
+                  className="grid h-7 w-6 shrink-0 place-items-center text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                  aria-label={`Delete ${property.name}`}
+                  onClick={() =>
+                    updateFrontmatter({
+                      properties: model.customProperties.filter(
+                        (_entry, propertyIndex) => propertyIndex !== index,
+                      ),
+                    })
+                  }
+                >
+                  x
+                </button>
+              </div>
+            </FieldRow>
+          ))}
+
+          {!showAddProperty ? (
+            <button
+              type="button"
+              className="flex h-7 w-full items-center gap-2 px-1.5 text-left text-xs text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+              onClick={() => setShowAddProperty(true)}
+            >
+              <PlusIcon size={12} />
+              <span>Add property</span>
+            </button>
+          ) : (
+            <div className="grid grid-cols-[1fr_auto] gap-1.5 items-start mt-1 border border-border/30 p-1.5 rounded-md bg-muted/10">
+              <div className="grid grid-cols-2 gap-1.5">
+                <CompactInput
+                  value={newProperty.name}
+                  placeholder="Property name"
+                  autoFocus
+                  onChange={(event) =>
+                    setNewProperty((current) => ({ ...current, name: event.target.value }))
+                  }
+                />
+                <OptionPicker
+                  value={newProperty.type}
+                  options={propertyTypeOptions}
+                  placeholder="Type"
+                  searchPlaceholder="Type..."
+                  allowCreate={false}
+                  onChange={(value) => setNewProperty((current) => ({ ...current, type: value }))}
+                  renderTrigger={(option) => (
+                    <span className="inline-flex items-center gap-1 truncate">
+                      {option?.icon}
+                      {option?.label ?? newProperty.type}
+                    </span>
+                  )}
+                />
+              </div>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  className="grid h-7 w-7 place-items-center rounded-md bg-primary/10 text-primary hover:bg-primary/20"
+                  disabled={!newProperty.name.trim()}
+                  onClick={() => {
+                    addCustomProperty();
+                    setShowAddProperty(false);
+                  }}
+                >
+                  <TickIcon size={13} />
+                </button>
+                <button
+                  type="button"
+                  className="grid h-7 w-7 place-items-center rounded-md hover:bg-muted text-muted-foreground"
+                  onClick={() => setShowAddProperty(false)}
+                >
+                  <XIcon size={12} />
+                </button>
+              </div>
+            </div>
+          )}
         </section>
 
-        <div className="my-4 h-px bg-border/70" />
+        <div className="my-3 h-px bg-border/30" />
 
         <section>
-          <div className="mb-2 flex items-center justify-between gap-2 text-[11px] font-medium text-muted-foreground">
+          <div className="mb-2 flex items-center justify-between gap-2 text-[11px] font-medium text-muted-foreground/70">
             <span className="flex items-center gap-1.5">
               <DiscountTagIcon size={12} />
               Tags
@@ -845,7 +1132,7 @@ export function NoteContextSidebar({
               }}
             />
           </div>
-          <div className="mb-2 flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap gap-1.5 min-h-[24px]">
             {model.tags.length > 0 ? (
               model.tags.map((tag) => (
                 <TagPill
@@ -857,186 +1144,65 @@ export function NoteContextSidebar({
                 />
               ))
             ) : (
-              <span className="text-xs text-muted-foreground">No tags</span>
+              <span className="text-[10px] text-muted-foreground/40 italic">No tags yet</span>
             )}
           </div>
-          {model.suggestedTags.length > 0 ? (
-            <div className="mt-2 flex flex-wrap gap-1">
+          {model.suggestedTags.length > 0 && (
+            <div className="mt-2 pt-2 border-t border-border/20 flex flex-wrap gap-1">
+              <span className="w-full text-[9px] text-muted-foreground/60 uppercase tracking-wider">Suggested</span>
               {model.suggestedTags.map((tag) => (
                 <button
                   key={tag}
                   type="button"
-                  className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:text-primary"
+                  className="rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/70 bg-muted/50 transition-colors hover:bg-muted hover:text-foreground"
                   onClick={() => addTag(tag)}
                 >
                   + {tag}
                 </button>
               ))}
             </div>
-          ) : null}
-        </section>
-
-        <div className="my-4 h-px bg-border/70" />
-
-        <section>
-          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Properties</div>
-          <div className="space-y-1.5">
-            {model.customProperties.map((property, index) => (
-              <FieldRow
-                key={`${property.name}-${index}`}
-                icon={<span>{PROPERTY_TYPE_ICONS[property.type] ?? "T"}</span>}
-                label={property.name}
-              >
-                <div className="flex min-w-0 items-center gap-1">
-                  <PropertyValueEditor
-                    type={property.type}
-                  value={property.value}
-                    statusOptions={statusOptions}
-                    tagOptions={knownTags}
-                    onChange={(value) => {
-                      const nextProperties = model.customProperties.map((entry, propertyIndex) =>
-                        propertyIndex === index ? { ...entry, value } : entry,
-                      );
-                      updateFrontmatter({ properties: nextProperties });
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className="grid h-7 w-6 shrink-0 place-items-center text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-                    aria-label={`Delete ${property.name}`}
-                    onClick={() =>
-                      updateFrontmatter({
-                        properties: model.customProperties.filter(
-                          (_entry, propertyIndex) => propertyIndex !== index,
-                        ),
-                      })
-                    }
-                  >
-                    x
-                  </button>
-                </div>
-              </FieldRow>
-            ))}
-          </div>
-          {!showAddProperty ? (
-            <button
-              type="button"
-              className="mt-2 flex h-7 w-full items-center gap-2 rounded-md px-1.5 text-left text-xs text-muted-foreground/60 transition-colors hover:bg-muted hover:text-muted-foreground"
-              onClick={() => setShowAddProperty(true)}
-            >
-              <PlusIcon size={12} />
-              Add property
-            </button>
-          ) : (
-            <div className="mt-2 grid grid-cols-[minmax(0,1fr)_86px_minmax(0,1fr)_28px_28px] gap-1.5">
-              <CompactInput
-                value={newProperty.name}
-                placeholder="Property"
-                autoFocus
-                onChange={(event) =>
-                  setNewProperty((current) => ({ ...current, name: event.target.value }))
-                }
-                onKeyDown={(event) => {
-                  if (event.key === "Escape") setShowAddProperty(false);
-                  if (event.key === "Enter" && newProperty.name.trim()) addCustomProperty();
-                }}
-              />
-              <OptionPicker
-                value={newProperty.type}
-                options={propertyTypeOptions}
-                placeholder="Type"
-                searchPlaceholder="Type..."
-                allowCreate={false}
-                onChange={(value) => setNewProperty((current) => ({ ...current, type: value }))}
-                renderTrigger={(option) => (
-                  <span className="inline-flex items-center gap-1">
-                    {option?.icon}
-                    {option?.label ?? newProperty.type}
-                  </span>
-                )}
-              />
-              <PropertyValueEditor
-                type={newProperty.type}
-                value={newProperty.value}
-                statusOptions={statusOptions}
-                tagOptions={knownTags}
-                onChange={(value) => setNewProperty((current) => ({ ...current, value }))}
-              />
-              <button
-                type="button"
-                className="grid h-7 place-items-center rounded-md bg-primary text-primary-foreground disabled:bg-muted disabled:text-muted-foreground"
-                disabled={!newProperty.name.trim()}
-                onClick={() => {
-                  addCustomProperty();
-                  setShowAddProperty(false);
-                }}
-                aria-label="Add property"
-              >
-                <TickIcon size={13} />
-              </button>
-              <button
-                type="button"
-                className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => setShowAddProperty(false)}
-                aria-label="Cancel property"
-              >
-                <XIcon size={12} />
-              </button>
-            </div>
           )}
         </section>
 
-        <div className="my-4 h-px bg-border/70" />
+        <div className="my-3 h-px bg-border/30" />
 
         <section>
-          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Relationships</div>
-          <div className="space-y-2">
-            {DEFAULT_RELATIONSHIPS.map((relationshipName) => (
-              <div key={relationshipName}>
-                <div className="mb-1 text-[11px] text-muted-foreground">{relationshipName}</div>
-                {editingRelationship === relationshipName ? (
-                  <div className="grid grid-cols-[minmax(0,1fr)_28px] gap-1.5">
-                    <OptionPicker
-                      value=""
-                      options={noteTitleOptions}
-                      placeholder="Add note title"
-                      searchPlaceholder="Search notes..."
-                      onChange={(value) => {
-                        addRelationship(relationshipName, value);
-                        setEditingRelationship(null);
-                      }}
-                    />
-                    <button
-                      type="button"
-                      className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground"
-                      onClick={() => setEditingRelationship(null)}
-                      aria-label="Cancel relationship"
-                    >
-                      <XIcon size={12} />
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    className="h-7 w-full rounded-md border border-dashed border-border bg-background px-2 text-left text-xs text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
-                    onClick={() => setEditingRelationship(relationshipName)}
-                  >
-                    Add
-                  </button>
-                )}
-              </div>
-            ))}
+          <div className="mb-2 text-[11px] font-medium text-muted-foreground/70">Relationships</div>
+          <div className="space-y-1">
             {model.relationships.map((relationship, index) => (
               <div
                 key={`${relationship.name}-${relationship.note}-${index}`}
-                className="flex items-center justify-between gap-2 rounded-md bg-muted px-2 py-1.5 text-xs"
+                className="group grid grid-cols-[80px_minmax(0,1fr)_20px] gap-2 items-center p-1 rounded-md transition-colors hover:bg-muted/40 min-h-8"
               >
-                <span className="min-w-0 truncate text-muted-foreground">{relationship.name}</span>
-                <span className="min-w-0 truncate text-foreground">{relationship.note}</span>
+                <span className="truncate text-[10px] font-medium text-muted-foreground/70 px-1">
+                  {relationship.name}
+                </span>
+                <div className="truncate text-xs text-foreground/90 flex items-center gap-1.5">
+                  <FileIcon size={12} className="opacity-50 shrink-0" />
+                  <span className="truncate font-medium">{relationship.note}</span>
+                </div>
+                <button
+                  type="button"
+                  className="opacity-0 group-hover:opacity-100 grid h-5 w-5 place-items-center text-muted-foreground hover:text-destructive transition-opacity"
+                  aria-label="Remove relationship"
+                  onClick={() =>
+                    updateFrontmatter({
+                      relationships: model.relationships.filter((_, i) => i !== index),
+                    })
+                  }
+                >
+                  <XIcon size={12} />
+                </button>
               </div>
             ))}
-            <div className="grid grid-cols-[100px_minmax(0,1fr)_28px] gap-1.5">
+
+            {model.relationships.length === 0 && (
+               <div className="text-[10px] text-muted-foreground/40 italic px-1 mb-1">No relationships defined</div>
+            )}
+
+            <div className="mt-2 grid grid-cols-[85px_minmax(0,1fr)_28px] gap-1.5 items-center">
               <OptionPicker
+                align="start"
                 value={newRelation.name}
                 options={Array.from(
                   new Set([
@@ -1044,23 +1210,22 @@ export function NoteContextSidebar({
                     ...model.relationships.map((relationship) => relationship.name),
                   ]),
                 ).map((name) => ({ value: name, label: name }))}
-                placeholder="Relation"
-                searchPlaceholder="Relation..."
+                placeholder="Rel..."
+                searchPlaceholder="Search type..."
                 onChange={(value) => setNewRelation((current) => ({ ...current, name: value }))}
               />
               <OptionPicker
                 value={newRelation.note}
                 options={noteTitleOptions}
-                placeholder="Note title"
+                placeholder="Pick note..."
                 searchPlaceholder="Search notes..."
                 onChange={(value) => setNewRelation((current) => ({ ...current, note: value }))}
               />
               <button
                 type="button"
-                className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-primary disabled:opacity-50"
+                className="grid h-7 w-7 place-items-center rounded-md border border-border/50 text-muted-foreground hover:text-primary hover:border-primary/30 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                 disabled={!newRelation.name.trim() || !newRelation.note.trim()}
                 onClick={() => addRelationship(newRelation.name, newRelation.note)}
-                aria-label="Add relationship"
               >
                 <PlusIcon size={13} />
               </button>

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -1,18 +1,27 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { parseDocument } from "yaml";
 
-import { parseMarkdownFrontmatter } from "@/core/frontmatter";
-import { getBaseName, getDirName, getRelativePath } from "@/core/paths";
+import {
+  parseMarkdownFrontmatter,
+  serializeMarkdownFrontmatter,
+} from "@/core/frontmatter";
+import { getBaseName, getDirName } from "@/core/paths";
 import type { FileDocument } from "@/core/workspace";
-import type { OutlineItem } from "@/types/navigation";
 
 import {
+  BookIcon,
+  BriefcaseIcon,
   CalendarIcon,
+  CameraIcon,
   DiscountTagIcon,
   FileIcon,
+  HomeIcon,
+  IdeaIcon,
+  LeafIcon,
   LinkIcon,
-  OutlineIcon,
+  PlusIcon,
+  RocketIcon,
   SparklesIcon,
   XIcon,
 } from "./icons";
@@ -21,21 +30,88 @@ type NoteContextSidebarProps = {
   activeFile: FileDocument;
   draftContent: string;
   rootPath: string | null;
-  outlineItems: OutlineItem[];
-  wordCount: number;
-  readingTime: number;
   onClose: () => void;
-  onJumpToHeading: (id: string) => void;
+  onUpdateContent: (content: string) => void;
 };
 
-type ContextLink = {
+type CustomProperty = {
+  name: string;
+  type: string;
+  value: string;
+};
+
+type Relationship = {
+  name: string;
+  note: string;
+};
+
+type IconOption = {
+  key: string;
   label: string;
-  target: string;
+  icon: ReactNode;
 };
 
-const MARKDOWN_LINK_PATTERN = /!?\[([^\]\n]+)\]\(([^)\n]+)\)/g;
-const WIKI_LINK_PATTERN = /!?\[\[([^\]\n]+)\]\]/g;
-const INLINE_TAG_PATTERN = /(^|[\s([{])#([A-Za-z0-9][A-Za-z0-9_/-]*)\b/g;
+const DEFAULT_TYPES = ["None", "Note", "Essay", "Habit", "Recipe", "Meeting", "Project"];
+const DEFAULT_STATUSES = [
+  "None",
+  "Not Started",
+  "Active",
+  "In Progress",
+  "Learning",
+  "Blocked",
+  "Draft",
+  "Archived",
+  "Paused",
+];
+const PROPERTY_TYPES = ["Text", "Number", "Date", "Boolean", "Status", "URL", "Tags", "Color"];
+const DEFAULT_RELATIONSHIPS = ["Belongs to", "Related to", "Has"];
+const STOP_WORDS = new Set([
+  "about",
+  "after",
+  "again",
+  "also",
+  "because",
+  "before",
+  "between",
+  "could",
+  "every",
+  "from",
+  "have",
+  "into",
+  "notes",
+  "should",
+  "that",
+  "their",
+  "there",
+  "these",
+  "this",
+  "with",
+  "would",
+  "your",
+]);
+
+const ICON_OPTIONS: IconOption[] = [
+  { key: "none", label: "None", icon: <FileIcon size={13} /> },
+  { key: "spark", label: "Spark", icon: <SparklesIcon size={13} /> },
+  { key: "idea", label: "Idea", icon: <IdeaIcon size={13} /> },
+  { key: "book", label: "Book", icon: <BookIcon size={13} /> },
+  { key: "work", label: "Work", icon: <BriefcaseIcon size={13} /> },
+  { key: "home", label: "Home", icon: <HomeIcon size={13} /> },
+  { key: "leaf", label: "Leaf", icon: <LeafIcon size={13} /> },
+  { key: "camera", label: "Camera", icon: <CameraIcon size={13} /> },
+  { key: "rocket", label: "Rocket", icon: <RocketIcon size={13} /> },
+];
+
+const STATUS_TONE: Record<string, string> = {
+  "not started": "bg-muted text-muted-foreground",
+  active: "bg-primary/10 text-primary",
+  "in progress": "bg-primary/10 text-primary",
+  learning: "bg-accent text-accent-foreground",
+  blocked: "bg-destructive/10 text-destructive",
+  draft: "bg-muted text-foreground",
+  archived: "bg-muted text-muted-foreground",
+  paused: "bg-secondary text-secondary-foreground",
+};
 
 function normalizeTag(input: string) {
   return input.trim().replace(/^#/, "").toLowerCase();
@@ -63,159 +139,231 @@ function getFrontmatterRecord(frontmatterText: string | null) {
     : {};
 }
 
-function getMetadataString(frontmatter: Record<string, unknown>, key: string) {
-  const value = frontmatter[key];
-  if (typeof value === "string" && value.trim()) {
-    return value.trim();
-  }
-
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-
-  return null;
+function getString(value: unknown) {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
 }
 
-function getFrontmatterTags(value: unknown): string[] {
+function getStringArray(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.flatMap(getFrontmatterTags);
+    return value.flatMap(getStringArray);
   }
-
   if (typeof value === "string") {
     return value.split(/[,\s]+/).map(normalizeTag).filter(Boolean);
   }
-
   return [];
 }
 
-function collectInlineTags(body: string) {
-  const tags = new Set<string>();
-
-  for (const line of body.split("\n")) {
-    INLINE_TAG_PATTERN.lastIndex = 0;
-    for (const match of line.matchAll(INLINE_TAG_PATTERN)) {
-      const tag = normalizeTag(match[2] ?? "");
-      if (tag) {
-        tags.add(tag);
-      }
-    }
-  }
-
-  return Array.from(tags);
+function getCustomProperties(value: unknown): CustomProperty[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const name = getString(record.name).trim();
+    if (!name) return [];
+    return [{ name, type: getString(record.type) || "Text", value: getString(record.value) }];
+  });
 }
 
-function collectLinks(body: string) {
-  const links: ContextLink[] = [];
-
-  for (const line of body.split("\n")) {
-    MARKDOWN_LINK_PATTERN.lastIndex = 0;
-    for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
-      const target = (match[2] ?? "").trim();
-      if (target) {
-        links.push({ label: (match[1] ?? target).trim(), target });
-      }
-    }
-
-    WIKI_LINK_PATTERN.lastIndex = 0;
-    for (const match of line.matchAll(WIKI_LINK_PATTERN)) {
-      const rawTarget = (match[1] ?? "").trim();
-      const [target, alias] = rawTarget.split("|").map((part) => part.trim());
-      if (target) {
-        links.push({ label: alias || target, target });
-      }
-    }
-  }
-
-  return links.slice(0, 12);
+function getRelationships(value: unknown): Relationship[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const name = getString(record.name).trim();
+    const note = getString(record.note).trim();
+    if (!name || !note) return [];
+    return [{ name, note }];
+  });
 }
 
-function truncateMiddle(value: string, maxLength = 34) {
-  if (value.length <= maxLength) {
+function escapeYaml(value: string) {
+  if (!value) return '""';
+  if (/^[A-Za-z0-9_./@ -]+$/.test(value) && !/^(true|false|null|none)$/i.test(value)) {
     return value;
   }
-
-  const headLength = Math.ceil((maxLength - 1) / 2);
-  const tailLength = Math.floor((maxLength - 1) / 2);
-  return `${value.slice(0, headLength)}...${value.slice(-tailLength)}`;
+  return JSON.stringify(value);
 }
 
-function PropertyRow({
+function serializeValue(value: unknown, indent = ""): string[] {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return ["[]"];
+    return value.flatMap((entry) => {
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        const entries = Object.entries(entry as Record<string, unknown>);
+        if (entries.length === 0) return [`${indent}- {}`];
+        const [firstKey, firstValue] = entries[0];
+        return [
+          `${indent}- ${firstKey}: ${escapeYaml(String(firstValue ?? ""))}`,
+          ...entries
+            .slice(1)
+            .map(([key, nestedValue]) => `${indent}  ${key}: ${escapeYaml(String(nestedValue ?? ""))}`),
+        ];
+      }
+      return `${indent}- ${escapeYaml(String(entry ?? ""))}`;
+    });
+  }
+
+  return [escapeYaml(String(value ?? ""))];
+}
+
+function serializeFrontmatter(frontmatter: Record<string, unknown>) {
+  return Object.entries(frontmatter)
+    .filter(([, value]) => {
+      if (value === null || value === undefined) return false;
+      if (Array.isArray(value)) return value.length > 0;
+      return String(value).trim().length > 0;
+    })
+    .flatMap(([key, value]) => {
+      const lines = serializeValue(value, "  ");
+      if (lines.length === 1 && !lines[0].startsWith("  -")) {
+        return `${key}: ${lines[0]}`;
+      }
+      return [`${key}:`, ...lines];
+    })
+    .join("\n");
+}
+
+function detectTags(body: string, existingTags: string[]) {
+  const existing = new Set(existingTags);
+  const counts = new Map<string, number>();
+  for (const match of body.toLowerCase().matchAll(/[a-z][a-z0-9-]{3,}/g)) {
+    const tag = normalizeTag(match[0]);
+    if (STOP_WORDS.has(tag) || existing.has(tag)) continue;
+    counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 6)
+    .map(([tag]) => tag);
+}
+
+function FieldRow({
   icon,
   label,
-  value,
+  children,
 }: {
   icon: ReactNode;
   label: string;
-  value: ReactNode;
+  children: ReactNode;
 }) {
   return (
-    <div className="grid min-h-7 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
+    <div className="grid min-h-8 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
       <span className="text-muted-foreground/75">{icon}</span>
-      <span className="font-medium text-muted-foreground">{label}</span>
-      <span className="min-w-0 text-foreground">{value}</span>
+      <span className="text-muted-foreground">{label}</span>
+      <div className="min-w-0">{children}</div>
     </div>
+  );
+}
+
+function CompactInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={`h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/40 focus:bg-background ${props.className ?? ""}`}
+    />
+  );
+}
+
+function CompactSelect(props: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select
+      {...props}
+      className={`h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-foreground outline-none transition-colors focus:border-primary/40 focus:bg-background ${props.className ?? ""}`}
+    />
   );
 }
 
 export function NoteContextSidebar({
   activeFile,
   draftContent,
-  rootPath,
-  outlineItems,
-  wordCount,
-  readingTime,
+  rootPath: _rootPath,
   onClose,
-  onJumpToHeading,
+  onUpdateContent,
 }: NoteContextSidebarProps) {
-  const context = useMemo(() => {
-    const parsed = parseMarkdownFrontmatter(draftContent);
-    const frontmatter = getFrontmatterRecord(parsed.frontmatterText);
-    const frontmatterTags = [
-      ...getFrontmatterTags(frontmatter.tags),
-      ...getFrontmatterTags(frontmatter.tag),
-      ...getFrontmatterTags(frontmatter.keywords),
-    ];
-    const tags = Array.from(new Set([...frontmatterTags, ...collectInlineTags(parsed.body)]));
-    const links = collectLinks(parsed.body);
-    const type = getMetadataString(frontmatter, "type") ?? "Note";
-    const status = getMetadataString(frontmatter, "status") ?? "Evergreen";
-    const date =
-      getMetadataString(frontmatter, "date") ??
-      getMetadataString(frontmatter, "created") ??
-      getMetadataString(frontmatter, "updated") ??
-      null;
-    const noteId =
-      getMetadataString(frontmatter, "id") ??
-      getMetadataString(frontmatter, "note_id") ??
-      activeFile.path;
-    const sourceUrl =
-      getMetadataString(frontmatter, "url") ?? getMetadataString(frontmatter, "source");
+  const [newTag, setNewTag] = useState("");
+  const [newProperty, setNewProperty] = useState({ name: "", type: "Text", value: "" });
+  const [newRelation, setNewRelation] = useState({ name: "Related to", note: "" });
 
+  const parsed = useMemo(() => parseMarkdownFrontmatter(draftContent), [draftContent]);
+  const frontmatter = useMemo(
+    () => getFrontmatterRecord(parsed.frontmatterText),
+    [parsed.frontmatterText],
+  );
+  const model = useMemo(() => {
+    const tags = Array.from(
+      new Set([
+        ...getStringArray(frontmatter.tags),
+        ...getStringArray(frontmatter.tag),
+        ...getStringArray(frontmatter.keywords),
+      ]),
+    );
     return {
-      date,
-      links,
-      noteId,
-      sourceUrl,
-      status,
+      customProperties: getCustomProperties(frontmatter.properties),
+      date: getString(frontmatter.date),
+      icon: getString(frontmatter.icon) || "none",
+      relationships: getRelationships(frontmatter.relationships),
+      status: getString(frontmatter.status) || "None",
       tags,
-      type,
+      type: getString(frontmatter.type) || "None",
+      url: getString(frontmatter.url),
+      suggestedTags: detectTags(parsed.body, tags),
     };
-  }, [activeFile.path, draftContent]);
+  }, [frontmatter, parsed.body]);
 
-  const folderName = getBaseName(getDirName(activeFile.path));
-  const relativePath = getRelativePath(activeFile.path, rootPath);
-  const topHeadings = outlineItems.slice(0, 10);
+  const folderName = getBaseName(getDirName(activeFile.path)) || "Workspace";
+  const title = activeFile.name.replace(/\.md$/i, "");
+  const selectedIcon = ICON_OPTIONS.find((option) => option.key === model.icon) ?? ICON_OPTIONS[0];
+  const statusTone = STATUS_TONE[model.status.toLowerCase()] ?? "bg-muted text-foreground";
+  const knownTypes = Array.from(new Set([...DEFAULT_TYPES, model.type])).filter(Boolean);
+  const knownStatuses = Array.from(new Set([...DEFAULT_STATUSES, model.status])).filter(Boolean);
+  const knownTags = Array.from(new Set([...model.tags, ...model.suggestedTags])).sort();
+
+  const updateFrontmatter = (nextValues: Record<string, unknown>) => {
+    const nextFrontmatter = { ...frontmatter, ...nextValues };
+    onUpdateContent(
+      serializeMarkdownFrontmatter({
+        frontmatterText: serializeFrontmatter(nextFrontmatter),
+        body: parsed.body,
+      }),
+    );
+  };
+
+  const addTag = (tagInput: string) => {
+    const tag = normalizeTag(tagInput);
+    if (!tag || model.tags.includes(tag)) return;
+    updateFrontmatter({ tags: [...model.tags, tag] });
+    setNewTag("");
+  };
+
+  const addCustomProperty = () => {
+    const name = newProperty.name.trim();
+    if (!name) return;
+    updateFrontmatter({
+      properties: [...model.customProperties, { ...newProperty, name }],
+    });
+    setNewProperty({ name: "", type: "Text", value: "" });
+  };
+
+  const addRelationship = (nameInput: string, noteInput: string) => {
+    const name = nameInput.trim();
+    const note = noteInput.trim();
+    if (!name || !note) return;
+    updateFrontmatter({ relationships: [...model.relationships, { name, note }] });
+    setNewRelation({ name, note: "" });
+  };
 
   return (
     <aside className="flex h-full min-h-0 flex-col border-l border-border bg-background">
       <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/70 px-3">
         <div className="flex min-w-0 items-center gap-2">
-          <SparklesIcon size={14} className="text-primary" />
-          <span className="truncate text-xs font-semibold text-foreground">Context</span>
+          {model.icon !== "none" ? <span className="text-primary">{selectedIcon.icon}</span> : null}
+          <span className="truncate text-xs font-semibold text-foreground">{title}</span>
         </div>
         <button
           type="button"
-          className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
           aria-label="Close context sidebar"
           onClick={onClose}
         >
@@ -224,152 +372,261 @@ export function NoteContextSidebar({
       </header>
 
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-3">
-        <section className="space-y-2">
-          <PropertyRow
-            icon={<FileIcon size={13} />}
-            label="Type"
-            value={
-              <span className="inline-flex max-w-full items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                {context.type}
-              </span>
-            }
-          />
-          <PropertyRow
+        <section className="space-y-1.5">
+          <FieldRow icon={<FileIcon size={13} />} label="Type">
+            <input
+              list="glyph-note-types"
+              value={model.type}
+              onChange={(event) => updateFrontmatter({ type: event.target.value })}
+              className="h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-primary outline-none focus:border-primary/40 focus:bg-background"
+            />
+            <datalist id="glyph-note-types">
+              {knownTypes.map((type) => (
+                <option key={type} value={type} />
+              ))}
+            </datalist>
+          </FieldRow>
+
+          <FieldRow
             icon={<span className="block h-2.5 w-2.5 rounded-full border border-muted-foreground/70" />}
             label="Status"
-            value={
-              <span className="inline-flex max-w-full items-center rounded-md bg-accent px-2 py-0.5 text-xs font-medium text-accent-foreground">
-                {context.status}
-              </span>
-            }
-          />
-          <PropertyRow
-            icon={<CalendarIcon size={13} />}
-            label="Date"
-            value={<span className="text-muted-foreground">{context.date ?? "-"}</span>}
-          />
-          <PropertyRow
-            icon={<span className="font-mono text-[10px]">T</span>}
-            label="Note ID"
-            value={
-              <span title={context.noteId} className="block truncate text-muted-foreground">
-                {truncateMiddle(context.noteId)}
-              </span>
-            }
-          />
-          <PropertyRow
-            icon={<LinkIcon size={13} />}
-            label="URL"
-            value={
-              <span
-                title={context.sourceUrl ?? undefined}
-                className="block truncate text-muted-foreground"
-              >
-                {context.sourceUrl ? truncateMiddle(context.sourceUrl) : "-"}
-              </span>
-            }
-          />
-          <PropertyRow
-            icon={<OutlineIcon size={13} />}
-            label="Stats"
-            value={
-              <span className="text-muted-foreground">
-                {wordCount.toLocaleString()} words / {readingTime} min read
-              </span>
-            }
-          />
+          >
+            <input
+              list="glyph-note-statuses"
+              value={model.status}
+              onChange={(event) => updateFrontmatter({ status: event.target.value })}
+              className={`h-7 w-full rounded-md border border-transparent px-2 text-xs outline-none focus:border-primary/40 ${statusTone}`}
+            />
+            <datalist id="glyph-note-statuses">
+              {knownStatuses.map((status) => (
+                <option key={status} value={status} />
+              ))}
+            </datalist>
+          </FieldRow>
+
+          <FieldRow icon={<SparklesIcon size={13} />} label="Icon">
+            <CompactSelect
+              value={model.icon}
+              onChange={(event) => updateFrontmatter({ icon: event.target.value })}
+            >
+              {ICON_OPTIONS.map((option) => (
+                <option key={option.key} value={option.key}>
+                  {option.label}
+                </option>
+              ))}
+            </CompactSelect>
+          </FieldRow>
+
+          <FieldRow icon={<CalendarIcon size={13} />} label="Date">
+            <CompactInput
+              type="date"
+              value={model.date}
+              onChange={(event) => updateFrontmatter({ date: event.target.value })}
+            />
+          </FieldRow>
+
+          <FieldRow icon={<LinkIcon size={13} />} label="URL">
+            <CompactInput
+              type="url"
+              value={model.url}
+              placeholder="-"
+              onChange={(event) => updateFrontmatter({ url: event.target.value })}
+            />
+          </FieldRow>
         </section>
 
         <div className="my-4 h-px bg-border/70" />
 
         <section>
-          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Belongs to</div>
-          <div className="rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary">
-            {folderName || "Workspace"}
+          <div className="mb-2 flex items-center justify-between gap-2 text-[11px] font-medium text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <DiscountTagIcon size={12} />
+              Tags
+            </span>
+            <button
+              type="button"
+              className="text-muted-foreground transition-colors hover:text-primary"
+              aria-label="Add tag"
+              onClick={() => addTag(newTag || model.suggestedTags[0] || "")}
+            >
+              <PlusIcon size={13} />
+            </button>
           </div>
-          <div className="mt-1 truncate text-[11px] text-muted-foreground" title={relativePath}>
-            {relativePath}
-          </div>
-        </section>
-
-        <div className="my-4 h-px bg-border/70" />
-
-        <section>
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <span className="text-[11px] font-medium text-muted-foreground">Has Notes</span>
-            <span className="text-[10px] text-muted-foreground">{context.links.length}</span>
-          </div>
-          <div className="space-y-1.5">
-            {context.links.length > 0 ? (
-              context.links.map((link, index) => (
-                <div
-                  key={`${link.target}-${index}`}
-                  className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-primary/10 px-2 py-1.5 text-xs text-primary"
-                  title={link.target}
-                >
-                  <span className="truncate">{link.label}</span>
-                  <LinkIcon size={11} className="shrink-0 opacity-70" />
-                </div>
-              ))
-            ) : (
-              <div className="rounded-md border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
-                No linked notes yet
-              </div>
-            )}
-          </div>
-        </section>
-
-        <div className="my-4 h-px bg-border/70" />
-
-        <section>
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <span className="text-[11px] font-medium text-muted-foreground">Outline</span>
-            <span className="text-[10px] text-muted-foreground">{outlineItems.length}</span>
-          </div>
-          <div className="space-y-1">
-            {topHeadings.length > 0 ? (
-              topHeadings.map((heading) => (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {model.tags.length > 0 ? (
+              model.tags.map((tag) => (
                 <button
-                  key={heading.id}
-                  type="button"
-                  className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
-                  onClick={() => onJumpToHeading(heading.id)}
-                >
-                  <span className="w-5 shrink-0 text-[10px] font-semibold text-muted-foreground">
-                    H{heading.depth}
-                  </span>
-                  <span className="truncate">{heading.title}</span>
-                </button>
-              ))
-            ) : (
-              <div className="rounded-md border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
-                Add headings to grow structure
-              </div>
-            )}
-          </div>
-        </section>
-
-        <div className="my-4 h-px bg-border/70" />
-
-        <section>
-          <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
-            <DiscountTagIcon size={12} />
-            Tags
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            {context.tags.length > 0 ? (
-              context.tags.map((tag) => (
-                <span
                   key={tag}
-                  className="rounded-md bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground"
+                  type="button"
+                  className="rounded-md bg-primary/10 px-2 py-1 text-[11px] font-medium text-primary"
+                  onClick={() =>
+                    updateFrontmatter({ tags: model.tags.filter((current) => current !== tag) })
+                  }
                 >
                   #{tag}
-                </span>
+                </button>
               ))
             ) : (
               <span className="text-xs text-muted-foreground">No tags</span>
             )}
           </div>
+          <div className="flex gap-1.5">
+            <input
+              list="glyph-note-tags"
+              value={newTag}
+              placeholder="Add tag"
+              onChange={(event) => setNewTag(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") addTag(newTag);
+              }}
+              className="h-7 min-w-0 flex-1 rounded-md border border-dashed border-border bg-background px-2 text-xs outline-none focus:border-primary/40"
+            />
+            <button
+              type="button"
+              className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-primary"
+              onClick={() => addTag(newTag)}
+              aria-label="Save tag"
+            >
+              <PlusIcon size={13} />
+            </button>
+            <datalist id="glyph-note-tags">
+              {knownTags.map((tag) => (
+                <option key={tag} value={tag} />
+              ))}
+            </datalist>
+          </div>
+          {model.suggestedTags.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {model.suggestedTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:text-primary"
+                  onClick={() => addTag(tag)}
+                >
+                  + {tag}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Properties</div>
+          <div className="space-y-1.5">
+            {model.customProperties.map((property, index) => (
+              <FieldRow key={`${property.name}-${index}`} icon={<span>T</span>} label={property.name}>
+                <CompactInput
+                  value={property.value}
+                  onChange={(event) => {
+                    const nextProperties = model.customProperties.map((entry, propertyIndex) =>
+                      propertyIndex === index ? { ...entry, value: event.target.value } : entry,
+                    );
+                    updateFrontmatter({ properties: nextProperties });
+                  }}
+                />
+              </FieldRow>
+            ))}
+          </div>
+          <div className="mt-2 grid grid-cols-[minmax(0,1fr)_86px_minmax(0,1fr)_28px] gap-1.5">
+            <CompactInput
+              value={newProperty.name}
+              placeholder="Property"
+              onChange={(event) => setNewProperty((current) => ({ ...current, name: event.target.value }))}
+            />
+            <CompactSelect
+              value={newProperty.type}
+              onChange={(event) => setNewProperty((current) => ({ ...current, type: event.target.value }))}
+            >
+              {PROPERTY_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </CompactSelect>
+            <CompactInput
+              value={newProperty.value}
+              placeholder="Value"
+              onChange={(event) => setNewProperty((current) => ({ ...current, value: event.target.value }))}
+            />
+            <button
+              type="button"
+              className="grid h-7 place-items-center rounded-md bg-primary text-primary-foreground disabled:bg-muted disabled:text-muted-foreground"
+              disabled={!newProperty.name.trim()}
+              onClick={addCustomProperty}
+              aria-label="Add property"
+            >
+              <PlusIcon size={13} />
+            </button>
+          </div>
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Relationships</div>
+          <div className="space-y-2">
+            {DEFAULT_RELATIONSHIPS.map((relationshipName) => (
+              <div key={relationshipName}>
+                <div className="mb-1 text-[11px] text-muted-foreground">{relationshipName}</div>
+                <CompactInput
+                  list="glyph-note-relationships"
+                  placeholder="Add note title"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      addRelationship(relationshipName, event.currentTarget.value);
+                      event.currentTarget.value = "";
+                    }
+                  }}
+                />
+              </div>
+            ))}
+            {model.relationships.map((relationship, index) => (
+              <div
+                key={`${relationship.name}-${relationship.note}-${index}`}
+                className="flex items-center justify-between gap-2 rounded-md bg-muted px-2 py-1.5 text-xs"
+              >
+                <span className="min-w-0 truncate text-muted-foreground">{relationship.name}</span>
+                <span className="min-w-0 truncate text-foreground">{relationship.note}</span>
+              </div>
+            ))}
+            <div className="grid grid-cols-[100px_minmax(0,1fr)_28px] gap-1.5">
+              <CompactInput
+                list="glyph-relationship-names"
+                value={newRelation.name}
+                placeholder="Relationship"
+                onChange={(event) => setNewRelation((current) => ({ ...current, name: event.target.value }))}
+              />
+              <CompactInput
+                list="glyph-note-relationships"
+                value={newRelation.note}
+                placeholder="Note title"
+                onChange={(event) => setNewRelation((current) => ({ ...current, note: event.target.value }))}
+              />
+              <button
+                type="button"
+                className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-primary disabled:opacity-50"
+                disabled={!newRelation.name.trim() || !newRelation.note.trim()}
+                onClick={() => addRelationship(newRelation.name, newRelation.note)}
+                aria-label="Add relationship"
+              >
+                <PlusIcon size={13} />
+              </button>
+            </div>
+          </div>
+          <datalist id="glyph-relationship-names">
+            {[...DEFAULT_RELATIONSHIPS, ...model.relationships.map((relationship) => relationship.name)].map(
+              (name) => (
+                <option key={name} value={name} />
+              ),
+            )}
+          </datalist>
+          <datalist id="glyph-note-relationships">
+            <option value={title} />
+            <option value={folderName} />
+          </datalist>
         </section>
       </div>
     </aside>

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -16,13 +16,16 @@ import {
   CameraIcon,
   DiscountTagIcon,
   FileIcon,
+  ArrowDownIcon,
   HomeIcon,
   IdeaIcon,
   LeafIcon,
   LinkIcon,
   PlusIcon,
   RocketIcon,
+  SearchIcon,
   SparklesIcon,
+  TickIcon,
   XIcon,
 } from "./icons";
 
@@ -30,6 +33,7 @@ type NoteContextSidebarProps = {
   activeFile: FileDocument;
   draftContent: string;
   rootPath: string | null;
+  noteTitleSuggestions: string[];
   onClose: () => void;
   onUpdateContent: (content: string) => void;
 };
@@ -49,6 +53,13 @@ type IconOption = {
   key: string;
   label: string;
   icon: ReactNode;
+};
+
+type SelectOption = {
+  value: string;
+  label: string;
+  icon?: ReactNode;
+  className?: string;
 };
 
 const DEFAULT_TYPES = ["None", "Note", "Essay", "Habit", "Recipe", "Meeting", "Project"];
@@ -111,6 +122,25 @@ const STATUS_TONE: Record<string, string> = {
   draft: "bg-muted text-foreground",
   archived: "bg-muted text-muted-foreground",
   paused: "bg-secondary text-secondary-foreground",
+};
+
+const TAG_TONES = [
+  "bg-primary/10 text-primary",
+  "bg-accent text-accent-foreground",
+  "bg-secondary text-secondary-foreground",
+  "bg-muted text-foreground",
+  "bg-destructive/10 text-destructive",
+];
+
+const PROPERTY_TYPE_ICONS: Record<string, string> = {
+  Boolean: "O",
+  Color: "C",
+  Date: "D",
+  Number: "#",
+  Status: "S",
+  Tags: "#",
+  Text: "T",
+  URL: "U",
 };
 
 function normalizeTag(input: string) {
@@ -239,6 +269,29 @@ function detectTags(body: string, existingTags: string[]) {
     .map(([tag]) => tag);
 }
 
+function hashText(value: string) {
+  let hash = 0;
+  for (const character of value) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+  return hash;
+}
+
+function getTagTone(tag: string) {
+  return TAG_TONES[hashText(tag) % TAG_TONES.length];
+}
+
+function isCreateOptionVisible(query: string, options: SelectOption[]) {
+  const trimmed = query.trim();
+  return trimmed.length > 0 && !options.some((option) => option.value.toLowerCase() === trimmed.toLowerCase());
+}
+
+function filterOptions(options: SelectOption[], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return options;
+  return options.filter((option) => option.label.toLowerCase().includes(normalizedQuery));
+}
+
 function FieldRow({
   icon,
   label,
@@ -249,7 +302,7 @@ function FieldRow({
   children: ReactNode;
 }) {
   return (
-    <div className="grid min-h-8 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
+    <div className="group grid min-h-8 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
       <span className="text-muted-foreground/75">{icon}</span>
       <span className="text-muted-foreground">{label}</span>
       <div className="min-w-0">{children}</div>
@@ -266,11 +319,301 @@ function CompactInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
   );
 }
 
-function CompactSelect(props: React.SelectHTMLAttributes<HTMLSelectElement>) {
+function OptionPicker({
+  value,
+  options,
+  placeholder,
+  searchPlaceholder,
+  allowCreate = true,
+  onChange,
+  renderTrigger,
+}: {
+  value: string;
+  options: SelectOption[];
+  placeholder: string;
+  searchPlaceholder: string;
+  allowCreate?: boolean;
+  onChange: (value: string) => void;
+  renderTrigger?: (option: SelectOption | null) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const selected = options.find((option) => option.value === value) ?? null;
+  const filteredOptions = filterOptions(options, query);
+  const showCreate = allowCreate && isCreateOptionVisible(query, options);
+
+  const selectValue = (nextValue: string) => {
+    onChange(nextValue);
+    setQuery("");
+    setOpen(false);
+  };
+
   return (
-    <select
-      {...props}
-      className={`h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-foreground outline-none transition-colors focus:border-primary/40 focus:bg-background ${props.className ?? ""}`}
+    <div
+      className="relative min-w-0"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+          setQuery("");
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-muted/70 px-2 text-left text-xs text-foreground transition-colors hover:bg-muted focus:border-primary/40 focus:bg-background focus:outline-none"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="min-w-0 truncate">
+          {renderTrigger ? renderTrigger(selected) : selected?.label || value || placeholder}
+        </span>
+        <ArrowDownIcon size={12} className="shrink-0 text-muted-foreground" />
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-[calc(100%+4px)] z-30 w-[220px] overflow-hidden rounded-md border border-border bg-background shadow-lg">
+          <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+            <SearchIcon size={12} className="text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              placeholder={searchPlaceholder}
+              className="h-6 min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setOpen(false);
+                  setQuery("");
+                }
+                if (event.key === "Enter") {
+                  const first = filteredOptions[0];
+                  selectValue(first?.value ?? query.trim());
+                }
+              }}
+            />
+          </div>
+          <div className="max-h-52 overflow-y-auto py-1" role="listbox">
+            {filteredOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
+                role="option"
+                aria-selected={option.value === value}
+                onClick={() => selectValue(option.value)}
+              >
+                <span className="grid h-4 w-4 shrink-0 place-items-center text-[10px] text-muted-foreground">
+                  {option.value === value ? <TickIcon size={12} /> : option.icon}
+                </span>
+                <span className={`min-w-0 truncate ${option.className ?? ""}`}>{option.label}</span>
+              </button>
+            ))}
+            {showCreate ? (
+              <>
+                {filteredOptions.length > 0 ? <div className="my-1 h-px bg-border" /> : null}
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted"
+                  onClick={() => selectValue(query.trim())}
+                >
+                  <PlusIcon size={12} />
+                  <span className="truncate">Create {query.trim()}</span>
+                </button>
+              </>
+            ) : null}
+            {filteredOptions.length === 0 && !showCreate ? (
+              <div className="px-2 py-3 text-center text-xs text-muted-foreground">No matches</div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function TagPill({ tag, onRemove }: { tag: string; onRemove?: () => void }) {
+  return (
+    <span
+      className={`group/tag inline-flex max-w-[140px] items-center overflow-hidden rounded-full px-2 py-0.5 text-[10px] font-semibold ${getTagTone(tag)}`}
+      title={tag}
+    >
+      <span className="min-w-0 truncate">{tag}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          className="ml-0.5 max-w-0 overflow-hidden text-current opacity-0 transition-all group-hover/tag:max-w-3 group-hover/tag:opacity-80"
+          onClick={onRemove}
+          aria-label={`Remove ${tag}`}
+        >
+          x
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+function TagPicker({
+  tags,
+  suggestions,
+  onToggle,
+}: {
+  tags: string[];
+  suggestions: string[];
+  onToggle: (tag: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const selected = new Set(tags);
+  const options = Array.from(new Set([...tags, ...suggestions])).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const filtered = options.filter((tag) => tag.toLowerCase().includes(query.trim().toLowerCase()));
+  const showCreate =
+    query.trim().length > 0 &&
+    !options.some((tag) => tag.toLowerCase() === query.trim().toLowerCase());
+
+  return (
+    <div
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+          setQuery("");
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="text-muted-foreground transition-colors hover:text-primary"
+        aria-label="Add tag"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <PlusIcon size={13} />
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-[calc(100%+6px)] z-30 w-52 overflow-hidden rounded-md border border-border bg-background shadow-lg">
+          <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+            <SearchIcon size={12} className="text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              placeholder="Type tag..."
+              className="h-6 min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") setOpen(false);
+                if (event.key === "Enter" && query.trim()) {
+                  onToggle(query.trim());
+                  setQuery("");
+                }
+              }}
+            />
+          </div>
+          <div className="max-h-52 overflow-y-auto py-1">
+            {filtered.length > 0 ? (
+              <div>
+                <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground">
+                  From vault
+                </div>
+                {filtered.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    className="flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors hover:bg-muted"
+                    onClick={() => onToggle(tag)}
+                  >
+                    <span className="grid w-3 place-items-center text-primary">
+                      {selected.has(tag) ? <TickIcon size={11} /> : null}
+                    </span>
+                    <TagPill tag={tag} />
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            {showCreate ? (
+              <>
+                {filtered.length > 0 ? <div className="my-1 h-px bg-border" /> : null}
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted"
+                  onClick={() => {
+                    onToggle(query.trim());
+                    setQuery("");
+                  }}
+                >
+                  Create <TagPill tag={query.trim()} />
+                </button>
+              </>
+            ) : null}
+            {filtered.length === 0 && !showCreate ? (
+              <div className="px-2 py-3 text-center text-xs text-muted-foreground">No tags</div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PropertyValueEditor({
+  type,
+  value,
+  statusOptions,
+  tagOptions,
+  onChange,
+}: {
+  type: string;
+  value: string;
+  statusOptions: SelectOption[];
+  tagOptions: string[];
+  onChange: (value: string) => void;
+}) {
+  if (type === "Boolean") {
+    const isTrue = value.toLowerCase() === "true";
+    return (
+      <button
+        type="button"
+        className="h-7 rounded-md bg-muted/70 px-2 text-xs text-foreground transition-colors hover:bg-muted"
+        onClick={() => onChange(isTrue ? "false" : "true")}
+      >
+        {isTrue ? "Yes" : "No"}
+      </button>
+    );
+  }
+
+  if (type === "Status") {
+    return (
+      <OptionPicker
+        value={value}
+        options={statusOptions}
+        placeholder="Status"
+        searchPlaceholder="Type status..."
+        onChange={onChange}
+        renderTrigger={(option) => (
+          <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? ""}`}>
+            {option?.label || value || "Status"}
+          </span>
+        )}
+      />
+    );
+  }
+
+  if (type === "Tags") {
+    return (
+      <CompactInput
+        value={value}
+        placeholder={tagOptions.slice(0, 2).join(", ") || "tag1, tag2"}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <CompactInput
+      type={type === "Number" ? "number" : type === "Date" ? "date" : type === "URL" ? "url" : "text"}
+      value={value}
+      placeholder="Value"
+      onChange={(event) => onChange(event.target.value)}
     />
   );
 }
@@ -279,12 +622,14 @@ export function NoteContextSidebar({
   activeFile,
   draftContent,
   rootPath: _rootPath,
+  noteTitleSuggestions,
   onClose,
   onUpdateContent,
 }: NoteContextSidebarProps) {
-  const [newTag, setNewTag] = useState("");
   const [newProperty, setNewProperty] = useState({ name: "", type: "Text", value: "" });
   const [newRelation, setNewRelation] = useState({ name: "Related to", note: "" });
+  const [showAddProperty, setShowAddProperty] = useState(false);
+  const [editingRelationship, setEditingRelationship] = useState<string | null>(null);
 
   const parsed = useMemo(() => parseMarkdownFrontmatter(draftContent), [draftContent]);
   const frontmatter = useMemo(
@@ -315,10 +660,42 @@ export function NoteContextSidebar({
   const folderName = getBaseName(getDirName(activeFile.path)) || "Workspace";
   const title = activeFile.name.replace(/\.md$/i, "");
   const selectedIcon = ICON_OPTIONS.find((option) => option.key === model.icon) ?? ICON_OPTIONS[0];
-  const statusTone = STATUS_TONE[model.status.toLowerCase()] ?? "bg-muted text-foreground";
   const knownTypes = Array.from(new Set([...DEFAULT_TYPES, model.type])).filter(Boolean);
   const knownStatuses = Array.from(new Set([...DEFAULT_STATUSES, model.status])).filter(Boolean);
   const knownTags = Array.from(new Set([...model.tags, ...model.suggestedTags])).sort();
+  const typeOptions = knownTypes.map((type) => ({
+    value: type,
+    label: type,
+    icon: type === "None" ? <FileIcon size={12} /> : <SparklesIcon size={12} />,
+    className: type === "None" ? "text-muted-foreground" : "text-primary",
+  }));
+  const statusOptions = knownStatuses.map((status) => ({
+    value: status,
+    label: status,
+    icon: (
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${STATUS_TONE[status.toLowerCase()] ?? "bg-muted"}`}
+      />
+    ),
+    className: STATUS_TONE[status.toLowerCase()] ?? "bg-muted text-foreground",
+  }));
+  const iconOptions = ICON_OPTIONS.map((option) => ({
+    value: option.key,
+    label: option.label,
+    icon: option.icon,
+  }));
+  const propertyTypeOptions = PROPERTY_TYPES.map((type) => ({
+    value: type,
+    label: type,
+    icon: <span className="text-[10px]">{PROPERTY_TYPE_ICONS[type]}</span>,
+  }));
+  const noteTitleOptions = Array.from(new Set([title, folderName, ...noteTitleSuggestions]))
+    .filter(Boolean)
+    .map((noteTitle) => ({
+      value: noteTitle,
+      label: noteTitle,
+      icon: <FileIcon size={12} />,
+    }));
 
   const updateFrontmatter = (nextValues: Record<string, unknown>) => {
     const nextFrontmatter = { ...frontmatter, ...nextValues };
@@ -334,7 +711,6 @@ export function NoteContextSidebar({
     const tag = normalizeTag(tagInput);
     if (!tag || model.tags.includes(tag)) return;
     updateFrontmatter({ tags: [...model.tags, tag] });
-    setNewTag("");
   };
 
   const addCustomProperty = () => {
@@ -374,47 +750,59 @@ export function NoteContextSidebar({
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-3">
         <section className="space-y-1.5">
           <FieldRow icon={<FileIcon size={13} />} label="Type">
-            <input
-              list="glyph-note-types"
+            <OptionPicker
               value={model.type}
-              onChange={(event) => updateFrontmatter({ type: event.target.value })}
-              className="h-7 w-full rounded-md border border-transparent bg-muted/70 px-2 text-xs text-primary outline-none focus:border-primary/40 focus:bg-background"
+              options={typeOptions}
+              placeholder="None"
+              searchPlaceholder="Search types..."
+              onChange={(value) => updateFrontmatter({ type: value === "None" ? "" : value })}
+              renderTrigger={(option) => (
+                <span
+                  className={`inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? "bg-primary/10 text-primary"}`}
+                >
+                  {option?.icon}
+                  <span className="truncate">{option?.label ?? model.type}</span>
+                </span>
+              )}
             />
-            <datalist id="glyph-note-types">
-              {knownTypes.map((type) => (
-                <option key={type} value={type} />
-              ))}
-            </datalist>
           </FieldRow>
 
           <FieldRow
             icon={<span className="block h-2.5 w-2.5 rounded-full border border-muted-foreground/70" />}
             label="Status"
           >
-            <input
-              list="glyph-note-statuses"
+            <OptionPicker
               value={model.status}
-              onChange={(event) => updateFrontmatter({ status: event.target.value })}
-              className={`h-7 w-full rounded-md border border-transparent px-2 text-xs outline-none focus:border-primary/40 ${statusTone}`}
+              options={statusOptions}
+              placeholder="None"
+              searchPlaceholder="Type status..."
+              onChange={(value) => updateFrontmatter({ status: value === "None" ? "" : value })}
+              renderTrigger={(option) => (
+                <span
+                  className={`inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? "bg-muted text-foreground"}`}
+                >
+                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                  <span className="truncate">{option?.label ?? model.status}</span>
+                </span>
+              )}
             />
-            <datalist id="glyph-note-statuses">
-              {knownStatuses.map((status) => (
-                <option key={status} value={status} />
-              ))}
-            </datalist>
           </FieldRow>
 
           <FieldRow icon={<SparklesIcon size={13} />} label="Icon">
-            <CompactSelect
+            <OptionPicker
               value={model.icon}
-              onChange={(event) => updateFrontmatter({ icon: event.target.value })}
-            >
-              {ICON_OPTIONS.map((option) => (
-                <option key={option.key} value={option.key}>
-                  {option.label}
-                </option>
-              ))}
-            </CompactSelect>
+              options={iconOptions}
+              placeholder="None"
+              searchPlaceholder="Search icons..."
+              allowCreate={false}
+              onChange={(value) => updateFrontmatter({ icon: value === "none" ? "" : value })}
+              renderTrigger={(option) => (
+                <span className="inline-flex max-w-full items-center gap-1">
+                  <span className="text-primary">{option?.icon}</span>
+                  <span className="truncate text-muted-foreground">{option?.label ?? "None"}</span>
+                </span>
+              )}
+            />
           </FieldRow>
 
           <FieldRow icon={<CalendarIcon size={13} />} label="Date">
@@ -443,57 +831,34 @@ export function NoteContextSidebar({
               <DiscountTagIcon size={12} />
               Tags
             </span>
-            <button
-              type="button"
-              className="text-muted-foreground transition-colors hover:text-primary"
-              aria-label="Add tag"
-              onClick={() => addTag(newTag || model.suggestedTags[0] || "")}
-            >
-              <PlusIcon size={13} />
-            </button>
+            <TagPicker
+              tags={model.tags}
+              suggestions={knownTags}
+              onToggle={(tag) => {
+                const normalizedTag = normalizeTag(tag);
+                if (!normalizedTag) return;
+                updateFrontmatter({
+                  tags: model.tags.includes(normalizedTag)
+                    ? model.tags.filter((current) => current !== normalizedTag)
+                    : [...model.tags, normalizedTag],
+                });
+              }}
+            />
           </div>
           <div className="mb-2 flex flex-wrap gap-1.5">
             {model.tags.length > 0 ? (
               model.tags.map((tag) => (
-                <button
+                <TagPill
                   key={tag}
-                  type="button"
-                  className="rounded-md bg-primary/10 px-2 py-1 text-[11px] font-medium text-primary"
-                  onClick={() =>
+                  tag={tag}
+                  onRemove={() =>
                     updateFrontmatter({ tags: model.tags.filter((current) => current !== tag) })
                   }
-                >
-                  #{tag}
-                </button>
+                />
               ))
             ) : (
               <span className="text-xs text-muted-foreground">No tags</span>
             )}
-          </div>
-          <div className="flex gap-1.5">
-            <input
-              list="glyph-note-tags"
-              value={newTag}
-              placeholder="Add tag"
-              onChange={(event) => setNewTag(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") addTag(newTag);
-              }}
-              className="h-7 min-w-0 flex-1 rounded-md border border-dashed border-border bg-background px-2 text-xs outline-none focus:border-primary/40"
-            />
-            <button
-              type="button"
-              className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-primary"
-              onClick={() => addTag(newTag)}
-              aria-label="Save tag"
-            >
-              <PlusIcon size={13} />
-            </button>
-            <datalist id="glyph-note-tags">
-              {knownTags.map((tag) => (
-                <option key={tag} value={tag} />
-              ))}
-            </datalist>
           </div>
           {model.suggestedTags.length > 0 ? (
             <div className="mt-2 flex flex-wrap gap-1">
@@ -517,50 +882,108 @@ export function NoteContextSidebar({
           <div className="mb-2 text-[11px] font-medium text-muted-foreground">Properties</div>
           <div className="space-y-1.5">
             {model.customProperties.map((property, index) => (
-              <FieldRow key={`${property.name}-${index}`} icon={<span>T</span>} label={property.name}>
-                <CompactInput
+              <FieldRow
+                key={`${property.name}-${index}`}
+                icon={<span>{PROPERTY_TYPE_ICONS[property.type] ?? "T"}</span>}
+                label={property.name}
+              >
+                <div className="flex min-w-0 items-center gap-1">
+                  <PropertyValueEditor
+                    type={property.type}
                   value={property.value}
-                  onChange={(event) => {
-                    const nextProperties = model.customProperties.map((entry, propertyIndex) =>
-                      propertyIndex === index ? { ...entry, value: event.target.value } : entry,
-                    );
-                    updateFrontmatter({ properties: nextProperties });
-                  }}
-                />
+                    statusOptions={statusOptions}
+                    tagOptions={knownTags}
+                    onChange={(value) => {
+                      const nextProperties = model.customProperties.map((entry, propertyIndex) =>
+                        propertyIndex === index ? { ...entry, value } : entry,
+                      );
+                      updateFrontmatter({ properties: nextProperties });
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="grid h-7 w-6 shrink-0 place-items-center text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                    aria-label={`Delete ${property.name}`}
+                    onClick={() =>
+                      updateFrontmatter({
+                        properties: model.customProperties.filter(
+                          (_entry, propertyIndex) => propertyIndex !== index,
+                        ),
+                      })
+                    }
+                  >
+                    x
+                  </button>
+                </div>
               </FieldRow>
             ))}
           </div>
-          <div className="mt-2 grid grid-cols-[minmax(0,1fr)_86px_minmax(0,1fr)_28px] gap-1.5">
-            <CompactInput
-              value={newProperty.name}
-              placeholder="Property"
-              onChange={(event) => setNewProperty((current) => ({ ...current, name: event.target.value }))}
-            />
-            <CompactSelect
-              value={newProperty.type}
-              onChange={(event) => setNewProperty((current) => ({ ...current, type: event.target.value }))}
-            >
-              {PROPERTY_TYPES.map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </CompactSelect>
-            <CompactInput
-              value={newProperty.value}
-              placeholder="Value"
-              onChange={(event) => setNewProperty((current) => ({ ...current, value: event.target.value }))}
-            />
+          {!showAddProperty ? (
             <button
               type="button"
-              className="grid h-7 place-items-center rounded-md bg-primary text-primary-foreground disabled:bg-muted disabled:text-muted-foreground"
-              disabled={!newProperty.name.trim()}
-              onClick={addCustomProperty}
-              aria-label="Add property"
+              className="mt-2 flex h-7 w-full items-center gap-2 rounded-md px-1.5 text-left text-xs text-muted-foreground/60 transition-colors hover:bg-muted hover:text-muted-foreground"
+              onClick={() => setShowAddProperty(true)}
             >
-              <PlusIcon size={13} />
+              <PlusIcon size={12} />
+              Add property
             </button>
-          </div>
+          ) : (
+            <div className="mt-2 grid grid-cols-[minmax(0,1fr)_86px_minmax(0,1fr)_28px_28px] gap-1.5">
+              <CompactInput
+                value={newProperty.name}
+                placeholder="Property"
+                autoFocus
+                onChange={(event) =>
+                  setNewProperty((current) => ({ ...current, name: event.target.value }))
+                }
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") setShowAddProperty(false);
+                  if (event.key === "Enter" && newProperty.name.trim()) addCustomProperty();
+                }}
+              />
+              <OptionPicker
+                value={newProperty.type}
+                options={propertyTypeOptions}
+                placeholder="Type"
+                searchPlaceholder="Type..."
+                allowCreate={false}
+                onChange={(value) => setNewProperty((current) => ({ ...current, type: value }))}
+                renderTrigger={(option) => (
+                  <span className="inline-flex items-center gap-1">
+                    {option?.icon}
+                    {option?.label ?? newProperty.type}
+                  </span>
+                )}
+              />
+              <PropertyValueEditor
+                type={newProperty.type}
+                value={newProperty.value}
+                statusOptions={statusOptions}
+                tagOptions={knownTags}
+                onChange={(value) => setNewProperty((current) => ({ ...current, value }))}
+              />
+              <button
+                type="button"
+                className="grid h-7 place-items-center rounded-md bg-primary text-primary-foreground disabled:bg-muted disabled:text-muted-foreground"
+                disabled={!newProperty.name.trim()}
+                onClick={() => {
+                  addCustomProperty();
+                  setShowAddProperty(false);
+                }}
+                aria-label="Add property"
+              >
+                <TickIcon size={13} />
+              </button>
+              <button
+                type="button"
+                className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => setShowAddProperty(false)}
+                aria-label="Cancel property"
+              >
+                <XIcon size={12} />
+              </button>
+            </div>
+          )}
         </section>
 
         <div className="my-4 h-px bg-border/70" />
@@ -571,16 +994,36 @@ export function NoteContextSidebar({
             {DEFAULT_RELATIONSHIPS.map((relationshipName) => (
               <div key={relationshipName}>
                 <div className="mb-1 text-[11px] text-muted-foreground">{relationshipName}</div>
-                <CompactInput
-                  list="glyph-note-relationships"
-                  placeholder="Add note title"
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      addRelationship(relationshipName, event.currentTarget.value);
-                      event.currentTarget.value = "";
-                    }
-                  }}
-                />
+                {editingRelationship === relationshipName ? (
+                  <div className="grid grid-cols-[minmax(0,1fr)_28px] gap-1.5">
+                    <OptionPicker
+                      value=""
+                      options={noteTitleOptions}
+                      placeholder="Add note title"
+                      searchPlaceholder="Search notes..."
+                      onChange={(value) => {
+                        addRelationship(relationshipName, value);
+                        setEditingRelationship(null);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="grid h-7 place-items-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground"
+                      onClick={() => setEditingRelationship(null)}
+                      aria-label="Cancel relationship"
+                    >
+                      <XIcon size={12} />
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="h-7 w-full rounded-md border border-dashed border-border bg-background px-2 text-left text-xs text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+                    onClick={() => setEditingRelationship(relationshipName)}
+                  >
+                    Add
+                  </button>
+                )}
               </div>
             ))}
             {model.relationships.map((relationship, index) => (
@@ -593,17 +1036,24 @@ export function NoteContextSidebar({
               </div>
             ))}
             <div className="grid grid-cols-[100px_minmax(0,1fr)_28px] gap-1.5">
-              <CompactInput
-                list="glyph-relationship-names"
+              <OptionPicker
                 value={newRelation.name}
-                placeholder="Relationship"
-                onChange={(event) => setNewRelation((current) => ({ ...current, name: event.target.value }))}
+                options={Array.from(
+                  new Set([
+                    ...DEFAULT_RELATIONSHIPS,
+                    ...model.relationships.map((relationship) => relationship.name),
+                  ]),
+                ).map((name) => ({ value: name, label: name }))}
+                placeholder="Relation"
+                searchPlaceholder="Relation..."
+                onChange={(value) => setNewRelation((current) => ({ ...current, name: value }))}
               />
-              <CompactInput
-                list="glyph-note-relationships"
+              <OptionPicker
                 value={newRelation.note}
+                options={noteTitleOptions}
                 placeholder="Note title"
-                onChange={(event) => setNewRelation((current) => ({ ...current, note: event.target.value }))}
+                searchPlaceholder="Search notes..."
+                onChange={(value) => setNewRelation((current) => ({ ...current, note: value }))}
               />
               <button
                 type="button"
@@ -616,17 +1066,6 @@ export function NoteContextSidebar({
               </button>
             </div>
           </div>
-          <datalist id="glyph-relationship-names">
-            {[...DEFAULT_RELATIONSHIPS, ...model.relationships.map((relationship) => relationship.name)].map(
-              (name) => (
-                <option key={name} value={name} />
-              ),
-            )}
-          </datalist>
-          <datalist id="glyph-note-relationships">
-            <option value={title} />
-            <option value={folderName} />
-          </datalist>
         </section>
       </div>
     </aside>

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -1137,14 +1137,6 @@ export function NoteContextSidebar({
 
   return (
     <aside className="flex h-full min-h-0 flex-col border-l border-border bg-background">
-      <button
-        type="button"
-        className="absolute right-2 top-2 z-10 grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
-        aria-label="Close context sidebar"
-        onClick={onClose}
-      >
-        <XIcon size={14} />
-      </button>
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-4">
         <section className="space-y-1.5">
           <FieldRow icon={<FileIcon size={13} />} label="Type">

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -43,6 +43,12 @@ import {
 type NoteContextSidebarProps = {
   activeFile: FileDocument;
   draftContent: string;
+  metadataOptions: {
+    statuses: string[];
+    tags: string[];
+    types: string[];
+  };
+  backlinks: Array<{ path: string; title: string; icon: string | null }>;
   rootPath: string | null;
   noteTitleSuggestions: Array<{ title: string; icon: string | null; path: string | null }>;
   onClose: () => void;
@@ -86,6 +92,7 @@ const STOP_WORDS = new Set([
   "after",
   "again",
   "always",
+  "around",
   "being",
   "also",
   "because",
@@ -94,6 +101,8 @@ const STOP_WORDS = new Set([
   "could",
   "doing",
   "every",
+  "field",
+  "fields",
   "from",
   "have",
   "never",
@@ -107,6 +116,8 @@ const STOP_WORDS = new Set([
   "more",
   "notes",
   "only",
+  "option",
+  "options",
   "right",
   "should",
   "that",
@@ -115,6 +126,10 @@ const STOP_WORDS = new Set([
   "these",
   "this",
   "with",
+  "workspace",
+  "workspaces",
+  "worskpace",
+  "worskpaces",
   "would",
   "your",
 ]);
@@ -332,9 +347,9 @@ function detectTags(body: string, existingTags: string[]) {
     .replace(/\[[^\]]+\]\([^)]+\)/g, " ")
     .replace(/https?:\/\/\S+/g, " ");
 
-  for (const match of normalizedBody.toLowerCase().matchAll(/[a-z][a-z0-9-]{4,}/g)) {
+  for (const match of normalizedBody.toLowerCase().matchAll(/[a-z][a-z0-9-]{5,}/g)) {
     const tag = normalizeTag(match[0]);
-    if (STOP_WORDS.has(tag) || existing.has(tag)) continue;
+    if (STOP_WORDS.has(tag) || existing.has(tag) || tag.endsWith("ing")) continue;
     counts.set(tag, (counts.get(tag) ?? 0) + 1);
   }
   return Array.from(counts.entries())
@@ -492,6 +507,7 @@ function OptionPicker({
   align = "end",
   widthClassName = "w-[200px]",
   defaultOpen = false,
+  onClear,
 }: {
   value: string;
   options: SelectOption[];
@@ -503,10 +519,12 @@ function OptionPicker({
   align?: "start" | "center" | "end";
   widthClassName?: string;
   defaultOpen?: boolean;
+  onClear?: () => void;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
   const selected = options.find((option) => option.value === value) ?? null;
+  const isClearable = Boolean(onClear && value && value !== "None");
   const filteredOptions = filterOptions(options, query);
   const showCreate = allowCreate && isCreateOptionVisible(query, options);
 
@@ -527,12 +545,35 @@ function OptionPicker({
       trigger={
         <button
           type="button"
-          className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+          className="group/field-trigger flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
         >
           <span className="min-w-0 truncate">
             {renderTrigger ? renderTrigger(selected) : selected?.label || value || placeholder}
           </span>
-          <ArrowDownIcon size={11} className="shrink-0 opacity-40" />
+          {isClearable ? (
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="Clear value"
+              className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/field-trigger:opacity-100"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onClear?.();
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onClear?.();
+                }
+              }}
+            >
+              <XIcon size={11} />
+            </span>
+          ) : (
+            <ArrowDownIcon size={11} className="shrink-0 opacity-40" />
+          )}
         </button>
       }
     >
@@ -563,7 +604,7 @@ function OptionPicker({
               type="button"
               className={cn(
                 "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground transition-colors",
-                option.value === value ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted",
+                option.value === value ? "text-primary font-medium" : "hover:bg-muted",
               )}
               role="option"
               aria-selected={option.value === value}
@@ -645,12 +686,37 @@ function DatePicker({
       trigger={
         <button
           type="button"
-          className="flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+          className="group/field-trigger flex h-7 w-full min-w-0 items-center justify-between gap-1 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
         >
           <span className="min-w-0 truncate text-muted-foreground/70">
             {value || "Set date..."}
           </span>
-          <CalendarIcon size={11} className="shrink-0 opacity-40" />
+          {value ? (
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="Clear date"
+              className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/field-trigger:opacity-100"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onChange("");
+                setOpen(false);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onChange("");
+                  setOpen(false);
+                }
+              }}
+            >
+              <XIcon size={11} />
+            </span>
+          ) : (
+            <CalendarIcon size={11} className="shrink-0 opacity-40" />
+          )}
         </button>
       }
     >
@@ -764,7 +830,7 @@ function IconPicker({
         <button
           type="button"
           aria-haspopup="menu"
-          className="flex h-7 w-full min-w-0 items-center gap-2 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+          className="group/field-trigger flex h-7 w-full min-w-0 items-center gap-2 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
         >
           {selected ? (
             <span className="text-primary">{selected.icon}</span>
@@ -772,12 +838,35 @@ function IconPicker({
             <span className="h-3.5 w-3.5 shrink-0" />
           )}
           <span className="min-w-0 flex-1 truncate">{selected?.label ?? "None"}</span>
-          <span className="text-muted-foreground">›</span>
+          {selected ? (
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="Clear icon"
+              className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/field-trigger:opacity-100"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onChange("none");
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onChange("none");
+                }
+              }}
+            >
+              <XIcon size={11} />
+            </span>
+          ) : (
+            <span className="text-muted-foreground">›</span>
+          )}
         </button>
       }
     >
       <div className="w-[180px] p-1.5">
-        <div className="mb-1 grid grid-cols-5 gap-1.5">
+        <div className="grid grid-cols-5 gap-1.5">
           {ICON_OPTIONS.filter((option) => option.key !== "none").map((option) => (
             <Tooltip key={option.key}>
               <TooltipTrigger asChild>
@@ -800,16 +889,6 @@ function IconPicker({
             </Tooltip>
           ))}
         </div>
-        <button
-          type="button"
-          onClick={() => {
-            onChange("none");
-            setOpen(false);
-          }}
-          className="mt-1 flex h-7 w-full items-center justify-center rounded-md text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          None
-        </button>
       </div>
     </BasePopover>
   );
@@ -955,6 +1034,8 @@ function RelationshipNoteChip({
 export function NoteContextSidebar({
   activeFile,
   draftContent,
+  metadataOptions,
+  backlinks,
   rootPath: _rootPath,
   noteTitleSuggestions,
   onClose,
@@ -992,10 +1073,9 @@ export function NoteContextSidebar({
 
   const folderName = getBaseName(getDirName(activeFile.path)) || "Workspace";
   const title = activeFile.name.replace(/\.md$/i, "");
-  const selectedIcon = ICON_OPTIONS.find((option) => option.key === model.icon) ?? ICON_OPTIONS[0];
-  const knownTypes = Array.from(new Set([...DEFAULT_TYPES, model.type])).filter(Boolean);
-  const knownStatuses = Array.from(new Set([...DEFAULT_STATUSES, model.status])).filter(Boolean);
-  const knownTags = Array.from(new Set([...model.tags, ...model.suggestedTags])).sort();
+  const knownTypes = Array.from(new Set([...DEFAULT_TYPES, ...metadataOptions.types, model.type])).filter(Boolean);
+  const knownStatuses = Array.from(new Set([...DEFAULT_STATUSES, ...metadataOptions.statuses, model.status])).filter(Boolean);
+  const knownTags = Array.from(new Set([...metadataOptions.tags, ...model.tags, ...model.suggestedTags])).sort();
   const typeOptions = knownTypes.map((type) => ({
     value: type,
     label: type,
@@ -1057,22 +1137,15 @@ export function NoteContextSidebar({
 
   return (
     <aside className="flex h-full min-h-0 flex-col border-l border-border bg-background">
-      <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/70 px-3">
-        <div className="flex min-w-0 items-center gap-2">
-          {model.icon !== "none" ? <span className="text-primary">{selectedIcon.icon}</span> : null}
-          <span className="truncate text-xs font-semibold text-foreground">{title}</span>
-        </div>
-        <button
-          type="button"
-          className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
-          aria-label="Close context sidebar"
-          onClick={onClose}
-        >
-          <XIcon size={14} />
-        </button>
-      </header>
-
-      <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      <button
+        type="button"
+        className="absolute right-2 top-2 z-10 grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+        aria-label="Close context sidebar"
+        onClick={onClose}
+      >
+        <XIcon size={14} />
+      </button>
+      <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-4">
         <section className="space-y-1.5">
           <FieldRow icon={<FileIcon size={13} />} label="Type">
             <OptionPicker
@@ -1081,6 +1154,7 @@ export function NoteContextSidebar({
               placeholder="None"
               searchPlaceholder="Search types..."
               onChange={(value) => updateFrontmatter({ type: value === "None" ? "" : value })}
+              onClear={() => updateFrontmatter({ type: "" })}
               renderTrigger={(option) => (
                 <span className="inline-flex items-center gap-1.5 text-foreground/80">
                   <span className="opacity-70">{option?.icon}</span>
@@ -1100,6 +1174,7 @@ export function NoteContextSidebar({
               placeholder="None"
               searchPlaceholder="Type status..."
               onChange={(value) => updateFrontmatter({ status: value === "None" ? "" : value })}
+              onClear={() => updateFrontmatter({ status: "" })}
               renderTrigger={(option) => (
                 <span className="inline-flex items-center gap-1.5">
                   <span className={cn("h-1.5 w-1.5 rounded-full", getStatusStyle(option?.value ?? model.status).dot)} />
@@ -1126,24 +1201,34 @@ export function NoteContextSidebar({
           </FieldRow>
 
           <FieldRow icon={<LinkIcon size={13} />} label="URL">
-            <div className="flex min-w-0 items-center gap-1">
-              <CompactInput
-                type="url"
-                value={model.url}
-                placeholder="-"
-                className={model.url ? "text-primary" : ""}
-                onChange={(event) => updateFrontmatter({ url: event.target.value })}
-              />
+            <div className="group/field-trigger flex min-w-0 items-center gap-1">
               {model.url ? (
                 <a
                   href={model.url}
                   target="_blank"
                   rel="noreferrer"
-                  className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-primary transition-colors hover:bg-primary/10"
-                  aria-label="Open URL"
+                  className="min-w-0 flex-1 truncate rounded-md px-1.5 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10 hover:text-primary/80"
+                  title={model.url}
                 >
-                  <LinkIcon size={13} />
+                  {model.url}
                 </a>
+              ) : (
+              <CompactInput
+                type="url"
+                value={model.url}
+                placeholder="-"
+                onChange={(event) => updateFrontmatter({ url: event.target.value })}
+              />
+              )}
+              {model.url ? (
+                <button
+                  type="button"
+                  className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/field-trigger:opacity-100"
+                  aria-label="Clear URL"
+                  onClick={() => updateFrontmatter({ url: "" })}
+                >
+                  <XIcon size={11} />
+                </button>
               ) : null}
             </div>
           </FieldRow>
@@ -1369,6 +1454,36 @@ export function NoteContextSidebar({
               >
                 + Add relationship
               </button>
+            )}
+          </div>
+        </section>
+
+        <div className="my-3 h-px bg-border/30" />
+
+        <section>
+          <div className="mb-2 flex items-center justify-between gap-2 text-[11px] font-medium text-muted-foreground/70">
+            <span>Backlinks</span>
+            <span className="text-[10px] tabular-nums text-muted-foreground/50">
+              {backlinks.length}
+            </span>
+          </div>
+          <div className="space-y-1.5">
+            {backlinks.length > 0 ? (
+              backlinks.map((backlink) => (
+                <button
+                  key={backlink.path}
+                  type="button"
+                  className="flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-md bg-muted/50 px-2.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
+                  onClick={() => onOpenNote(backlink.path)}
+                >
+                  <NoteGlyph iconKey={backlink.icon} />
+                  <span className="min-w-0 flex-1 truncate font-medium">{backlink.title}</span>
+                </button>
+              ))
+            ) : (
+              <div className="rounded-md border border-dashed border-border px-2.5 py-2 text-xs text-muted-foreground/50">
+                No backlinks yet
+              </div>
             )}
           </div>
         </section>

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -1,0 +1,377 @@
+import { useMemo } from "react";
+import type { ReactNode } from "react";
+import { parseDocument } from "yaml";
+
+import { parseMarkdownFrontmatter } from "@/core/frontmatter";
+import { getBaseName, getDirName, getRelativePath } from "@/core/paths";
+import type { FileDocument } from "@/core/workspace";
+import type { OutlineItem } from "@/types/navigation";
+
+import {
+  CalendarIcon,
+  DiscountTagIcon,
+  FileIcon,
+  LinkIcon,
+  OutlineIcon,
+  SparklesIcon,
+  XIcon,
+} from "./icons";
+
+type NoteContextSidebarProps = {
+  activeFile: FileDocument;
+  draftContent: string;
+  rootPath: string | null;
+  outlineItems: OutlineItem[];
+  wordCount: number;
+  readingTime: number;
+  onClose: () => void;
+  onJumpToHeading: (id: string) => void;
+};
+
+type ContextLink = {
+  label: string;
+  target: string;
+};
+
+const MARKDOWN_LINK_PATTERN = /!?\[([^\]\n]+)\]\(([^)\n]+)\)/g;
+const WIKI_LINK_PATTERN = /!?\[\[([^\]\n]+)\]\]/g;
+const INLINE_TAG_PATTERN = /(^|[\s([{])#([A-Za-z0-9][A-Za-z0-9_/-]*)\b/g;
+
+function normalizeTag(input: string) {
+  return input.trim().replace(/^#/, "").toLowerCase();
+}
+
+function getFrontmatterRecord(frontmatterText: string | null) {
+  if (!frontmatterText) {
+    return {};
+  }
+
+  const document = parseDocument(frontmatterText, {
+    merge: true,
+    prettyErrors: false,
+    strict: false,
+    uniqueKeys: false,
+  });
+
+  if (document.errors.length > 0) {
+    return {};
+  }
+
+  const parsed = document.toJSON();
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}
+
+function getMetadataString(frontmatter: Record<string, unknown>, key: string) {
+  const value = frontmatter[key];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return null;
+}
+
+function getFrontmatterTags(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(getFrontmatterTags);
+  }
+
+  if (typeof value === "string") {
+    return value.split(/[,\s]+/).map(normalizeTag).filter(Boolean);
+  }
+
+  return [];
+}
+
+function collectInlineTags(body: string) {
+  const tags = new Set<string>();
+
+  for (const line of body.split("\n")) {
+    INLINE_TAG_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(INLINE_TAG_PATTERN)) {
+      const tag = normalizeTag(match[2] ?? "");
+      if (tag) {
+        tags.add(tag);
+      }
+    }
+  }
+
+  return Array.from(tags);
+}
+
+function collectLinks(body: string) {
+  const links: ContextLink[] = [];
+
+  for (const line of body.split("\n")) {
+    MARKDOWN_LINK_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
+      const target = (match[2] ?? "").trim();
+      if (target) {
+        links.push({ label: (match[1] ?? target).trim(), target });
+      }
+    }
+
+    WIKI_LINK_PATTERN.lastIndex = 0;
+    for (const match of line.matchAll(WIKI_LINK_PATTERN)) {
+      const rawTarget = (match[1] ?? "").trim();
+      const [target, alias] = rawTarget.split("|").map((part) => part.trim());
+      if (target) {
+        links.push({ label: alias || target, target });
+      }
+    }
+  }
+
+  return links.slice(0, 12);
+}
+
+function truncateMiddle(value: string, maxLength = 34) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  const headLength = Math.ceil((maxLength - 1) / 2);
+  const tailLength = Math.floor((maxLength - 1) / 2);
+  return `${value.slice(0, headLength)}...${value.slice(-tailLength)}`;
+}
+
+function PropertyRow({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="grid min-h-7 grid-cols-[18px_72px_minmax(0,1fr)] items-center gap-2 text-xs">
+      <span className="text-muted-foreground/75">{icon}</span>
+      <span className="font-medium text-muted-foreground">{label}</span>
+      <span className="min-w-0 text-foreground">{value}</span>
+    </div>
+  );
+}
+
+export function NoteContextSidebar({
+  activeFile,
+  draftContent,
+  rootPath,
+  outlineItems,
+  wordCount,
+  readingTime,
+  onClose,
+  onJumpToHeading,
+}: NoteContextSidebarProps) {
+  const context = useMemo(() => {
+    const parsed = parseMarkdownFrontmatter(draftContent);
+    const frontmatter = getFrontmatterRecord(parsed.frontmatterText);
+    const frontmatterTags = [
+      ...getFrontmatterTags(frontmatter.tags),
+      ...getFrontmatterTags(frontmatter.tag),
+      ...getFrontmatterTags(frontmatter.keywords),
+    ];
+    const tags = Array.from(new Set([...frontmatterTags, ...collectInlineTags(parsed.body)]));
+    const links = collectLinks(parsed.body);
+    const type = getMetadataString(frontmatter, "type") ?? "Note";
+    const status = getMetadataString(frontmatter, "status") ?? "Evergreen";
+    const date =
+      getMetadataString(frontmatter, "date") ??
+      getMetadataString(frontmatter, "created") ??
+      getMetadataString(frontmatter, "updated") ??
+      null;
+    const noteId =
+      getMetadataString(frontmatter, "id") ??
+      getMetadataString(frontmatter, "note_id") ??
+      activeFile.path;
+    const sourceUrl =
+      getMetadataString(frontmatter, "url") ?? getMetadataString(frontmatter, "source");
+
+    return {
+      date,
+      links,
+      noteId,
+      sourceUrl,
+      status,
+      tags,
+      type,
+    };
+  }, [activeFile.path, draftContent]);
+
+  const folderName = getBaseName(getDirName(activeFile.path));
+  const relativePath = getRelativePath(activeFile.path, rootPath);
+  const topHeadings = outlineItems.slice(0, 10);
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col border-l border-border bg-background">
+      <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/70 px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <SparklesIcon size={14} className="text-primary" />
+          <span className="truncate text-xs font-semibold text-foreground">Context</span>
+        </div>
+        <button
+          type="button"
+          className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="Close context sidebar"
+          onClick={onClose}
+        >
+          <XIcon size={14} />
+        </button>
+      </header>
+
+      <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        <section className="space-y-2">
+          <PropertyRow
+            icon={<FileIcon size={13} />}
+            label="Type"
+            value={
+              <span className="inline-flex max-w-full items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                {context.type}
+              </span>
+            }
+          />
+          <PropertyRow
+            icon={<span className="block h-2.5 w-2.5 rounded-full border border-muted-foreground/70" />}
+            label="Status"
+            value={
+              <span className="inline-flex max-w-full items-center rounded-md bg-accent px-2 py-0.5 text-xs font-medium text-accent-foreground">
+                {context.status}
+              </span>
+            }
+          />
+          <PropertyRow
+            icon={<CalendarIcon size={13} />}
+            label="Date"
+            value={<span className="text-muted-foreground">{context.date ?? "-"}</span>}
+          />
+          <PropertyRow
+            icon={<span className="font-mono text-[10px]">T</span>}
+            label="Note ID"
+            value={
+              <span title={context.noteId} className="block truncate text-muted-foreground">
+                {truncateMiddle(context.noteId)}
+              </span>
+            }
+          />
+          <PropertyRow
+            icon={<LinkIcon size={13} />}
+            label="URL"
+            value={
+              <span
+                title={context.sourceUrl ?? undefined}
+                className="block truncate text-muted-foreground"
+              >
+                {context.sourceUrl ? truncateMiddle(context.sourceUrl) : "-"}
+              </span>
+            }
+          />
+          <PropertyRow
+            icon={<OutlineIcon size={13} />}
+            label="Stats"
+            value={
+              <span className="text-muted-foreground">
+                {wordCount.toLocaleString()} words / {readingTime} min read
+              </span>
+            }
+          />
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 text-[11px] font-medium text-muted-foreground">Belongs to</div>
+          <div className="rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary">
+            {folderName || "Workspace"}
+          </div>
+          <div className="mt-1 truncate text-[11px] text-muted-foreground" title={relativePath}>
+            {relativePath}
+          </div>
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-[11px] font-medium text-muted-foreground">Has Notes</span>
+            <span className="text-[10px] text-muted-foreground">{context.links.length}</span>
+          </div>
+          <div className="space-y-1.5">
+            {context.links.length > 0 ? (
+              context.links.map((link, index) => (
+                <div
+                  key={`${link.target}-${index}`}
+                  className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-primary/10 px-2 py-1.5 text-xs text-primary"
+                  title={link.target}
+                >
+                  <span className="truncate">{link.label}</span>
+                  <LinkIcon size={11} className="shrink-0 opacity-70" />
+                </div>
+              ))
+            ) : (
+              <div className="rounded-md border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
+                No linked notes yet
+              </div>
+            )}
+          </div>
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-[11px] font-medium text-muted-foreground">Outline</span>
+            <span className="text-[10px] text-muted-foreground">{outlineItems.length}</span>
+          </div>
+          <div className="space-y-1">
+            {topHeadings.length > 0 ? (
+              topHeadings.map((heading) => (
+                <button
+                  key={heading.id}
+                  type="button"
+                  className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted"
+                  onClick={() => onJumpToHeading(heading.id)}
+                >
+                  <span className="w-5 shrink-0 text-[10px] font-semibold text-muted-foreground">
+                    H{heading.depth}
+                  </span>
+                  <span className="truncate">{heading.title}</span>
+                </button>
+              ))
+            ) : (
+              <div className="rounded-md border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
+                Add headings to grow structure
+              </div>
+            )}
+          </div>
+        </section>
+
+        <div className="my-4 h-px bg-border/70" />
+
+        <section>
+          <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+            <DiscountTagIcon size={12} />
+            Tags
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {context.tags.length > 0 ? (
+              context.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-md bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground"
+                >
+                  #{tag}
+                </span>
+              ))
+            ) : (
+              <span className="text-xs text-muted-foreground">No tags</span>
+            )}
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -13,21 +13,29 @@ import { cn } from "@/core/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import {
+  ArchiveIcon,
+  ArrowDownIcon,
   BookIcon,
   BriefcaseIcon,
   CalendarIcon,
   CameraIcon,
   DiscountTagIcon,
   FileIcon,
-  ArrowDownIcon,
+  GlobeIcon,
   HomeIcon,
+  HonourStarIcon,
   IdeaIcon,
+  LayersIcon,
   LeafIcon,
   LinkIcon,
+  MonitorIcon,
+  MoonIcon,
+  NotebookIcon,
   PlusIcon,
   RocketIcon,
   SearchIcon,
   SparklesIcon,
+  SunIcon,
   TickIcon,
   XIcon,
 } from "./icons";
@@ -36,15 +44,10 @@ type NoteContextSidebarProps = {
   activeFile: FileDocument;
   draftContent: string;
   rootPath: string | null;
-  noteTitleSuggestions: Array<{ title: string; icon: string | null }>;
+  noteTitleSuggestions: Array<{ title: string; icon: string | null; path: string | null }>;
   onClose: () => void;
+  onOpenNote: (path: string) => void;
   onUpdateContent: (content: string) => void;
-};
-
-type CustomProperty = {
-  name: string;
-  type: string;
-  value: string;
 };
 
 type Relationship = {
@@ -77,7 +80,6 @@ const DEFAULT_STATUSES = [
   "Archived",
   "Paused",
 ];
-const PROPERTY_TYPES = ["Text", "Number", "Date", "Boolean", "Status", "URL", "Tags", "Color"];
 const DEFAULT_RELATIONSHIPS = ["Belongs to", "Related to", "Has"];
 const STOP_WORDS = new Set([
   "about",
@@ -123,10 +125,21 @@ const ICON_OPTIONS: IconOption[] = [
   { key: "idea", label: "Idea", icon: <IdeaIcon size={13} /> },
   { key: "book", label: "Book", icon: <BookIcon size={13} /> },
   { key: "work", label: "Work", icon: <BriefcaseIcon size={13} /> },
+  { key: "calendar", label: "Calendar", icon: <CalendarIcon size={13} /> },
+  { key: "tag", label: "Tag", icon: <DiscountTagIcon size={13} /> },
+  { key: "archive", label: "Archive", icon: <ArchiveIcon size={13} /> },
   { key: "home", label: "Home", icon: <HomeIcon size={13} /> },
+  { key: "globe", label: "Globe", icon: <GlobeIcon size={13} /> },
+  { key: "layers", label: "Layers", icon: <LayersIcon size={13} /> },
+  { key: "notebook", label: "Notebook", icon: <NotebookIcon size={13} /> },
+  { key: "star", label: "Star", icon: <HonourStarIcon size={13} /> },
   { key: "leaf", label: "Leaf", icon: <LeafIcon size={13} /> },
   { key: "camera", label: "Camera", icon: <CameraIcon size={13} /> },
   { key: "rocket", label: "Rocket", icon: <RocketIcon size={13} /> },
+  { key: "file", label: "File", icon: <FileIcon size={13} /> },
+  { key: "sun", label: "Sun", icon: <SunIcon size={13} /> },
+  { key: "moon", label: "Moon", icon: <MoonIcon size={13} /> },
+  { key: "monitor", label: "Monitor", icon: <MonitorIcon size={13} /> },
 ];
 
 const STATUS_STYLES: Record<string, { dot: string; text: string; chip: string }> = {
@@ -187,17 +200,6 @@ const TAG_TONES = [
   "bg-lime-500/10 text-lime-700 dark:text-lime-300",
   "bg-orange-500/10 text-orange-700 dark:text-orange-300",
 ];
-
-const PROPERTY_TYPE_ICONS: Record<string, ReactNode> = {
-  Boolean: <span className="h-3 w-3 rounded-full border border-current" />,
-  Color: <span className="h-3 w-3 rounded-full bg-primary/70" />,
-  Date: <CalendarIcon size={12} />,
-  Number: <span className="font-mono text-[10px]">#</span>,
-  Status: <span className="h-2.5 w-2.5 rounded-full bg-primary/70" />,
-  Tags: <DiscountTagIcon size={12} />,
-  Text: <span className="font-mono text-[10px]">T</span>,
-  URL: <LinkIcon size={12} />,
-};
 
 type CalendarDay = {
   day: number;
@@ -260,17 +262,6 @@ function getStringArray(value: unknown): string[] {
     return value.split(/[,\s]+/).map(normalizeTag).filter(Boolean);
   }
   return [];
-}
-
-function getCustomProperties(value: unknown): CustomProperty[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
-    const record = entry as Record<string, unknown>;
-    const name = getString(record.name).trim();
-    if (!name) return [];
-    return [{ name, type: getString(record.type) || "Text", value: getString(record.value) }];
-  });
 }
 
 function getRelationships(value: unknown): Relationship[] {
@@ -349,7 +340,7 @@ function detectTags(body: string, existingTags: string[]) {
   return Array.from(counts.entries())
     .filter(([tag, count]) => count >= 2 && !STOP_WORDS.has(tag))
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
-    .slice(0, 4)
+    .slice(0, 5)
     .map(([tag]) => tag);
 }
 
@@ -392,12 +383,23 @@ function NoteGlyph({ iconKey, fallbackClassName }: { iconKey?: string | null; fa
 
 function getSuggestionIcon(
   note: string,
-  noteTitleSuggestions: Array<{ title: string; icon: string | null }>,
+  noteTitleSuggestions: Array<{ title: string; icon: string | null; path: string | null }>,
 ) {
   return (
     noteTitleSuggestions.find(
       (entry) => entry.title.toLowerCase() === note.toLowerCase(),
     )?.icon ?? null
+  );
+}
+
+function getSuggestionPath(
+  note: string,
+  noteTitleSuggestions: Array<{ title: string; icon: string | null; path: string | null }>,
+) {
+  return (
+    noteTitleSuggestions.find(
+      (entry) => entry.title.toLowerCase() === note.toLowerCase(),
+    )?.path ?? null
   );
 }
 
@@ -489,6 +491,7 @@ function OptionPicker({
   renderTrigger,
   align = "end",
   widthClassName = "w-[200px]",
+  defaultOpen = false,
 }: {
   value: string;
   options: SelectOption[];
@@ -499,8 +502,9 @@ function OptionPicker({
   renderTrigger?: (option: SelectOption | null) => ReactNode;
   align?: "start" | "center" | "end";
   widthClassName?: string;
+  defaultOpen?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
   const selected = options.find((option) => option.value === value) ?? null;
   const filteredOptions = filterOptions(options, query);
@@ -568,7 +572,7 @@ function OptionPicker({
               <span className="grid h-3.5 w-3.5 shrink-0 place-items-center text-muted-foreground">
                 {option.value === value ? <TickIcon size={12} className="text-primary" /> : option.icon}
               </span>
-              <span className={`min-w-0 truncate ${option.className ?? ""}`}>{option.label}</span>
+              <span className={cn("min-w-0 truncate", option.className)}>{option.label}</span>
             </button>
           ))}
           {showCreate ? (
@@ -772,7 +776,7 @@ function IconPicker({
         </button>
       }
     >
-      <div className="w-[168px] p-1.5">
+      <div className="w-[180px] p-1.5">
         <div className="mb-1 grid grid-cols-5 gap-1.5">
           {ICON_OPTIONS.filter((option) => option.key !== "none").map((option) => (
             <Tooltip key={option.key}>
@@ -785,7 +789,7 @@ function IconPicker({
                   }}
                   className={cn(
                     "grid h-7 w-7 place-items-center rounded-md border border-transparent text-muted-foreground transition-colors hover:border-border hover:text-foreground",
-                    value === option.key ? "bg-muted text-primary" : "",
+                    value === option.key ? "text-primary" : "",
                   )}
                   aria-label={`Use ${option.label} icon`}
                 >
@@ -841,7 +845,7 @@ function TagPicker({
       trigger={
         <button
           type="button"
-          className="grid h-5 w-5 place-items-center rounded-full bg-muted/50 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+          className="grid h-5 w-5 place-items-center rounded-full text-muted-foreground transition-colors hover:text-primary"
           aria-label="Add tag"
         >
           <PlusIcon size={12} />
@@ -914,86 +918,28 @@ function TagPicker({
   );
 }
 
-function PropertyValueEditor({
-  type,
-  value,
-  statusOptions,
-  tagOptions,
-  onChange,
-}: {
-  type: string;
-  value: string;
-  statusOptions: SelectOption[];
-  tagOptions: string[];
-  onChange: (value: string) => void;
-}) {
-  if (type === "Boolean") {
-    const isTrue = value.toLowerCase() === "true";
-    return (
-      <button
-        type="button"
-        className="h-7 rounded-md bg-muted/70 px-2 text-xs text-foreground transition-colors hover:bg-muted"
-        onClick={() => onChange(isTrue ? "false" : "true")}
-      >
-        {isTrue ? "Yes" : "No"}
-      </button>
-    );
-  }
-
-  if (type === "Status") {
-    return (
-      <OptionPicker
-        value={value}
-        options={statusOptions}
-        placeholder="Status"
-        searchPlaceholder="Type status..."
-        onChange={onChange}
-        renderTrigger={(option) => (
-          <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${option?.className ?? ""}`}>
-            {option?.label || value || "Status"}
-          </span>
-        )}
-      />
-    );
-  }
-
-  if (type === "Tags") {
-    return (
-      <CompactInput
-        value={value}
-        placeholder={tagOptions.slice(0, 2).join(", ") || "tag1, tag2"}
-        onChange={(event) => onChange(event.target.value)}
-      />
-    );
-  }
-
-  if (type === "Date") {
-    return <DatePicker value={value} onChange={onChange} />;
-  }
-
-  return (
-    <CompactInput
-      type={type === "Number" ? "number" : type === "URL" ? "url" : "text"}
-      value={value}
-      placeholder="Value"
-      onChange={(event) => onChange(event.target.value)}
-    />
-  );
-}
-
 function RelationshipNoteChip({
   note,
   icon,
+  onOpen,
   onRemove,
 }: {
   note: string;
   icon: string | null;
+  onOpen?: () => void;
   onRemove: () => void;
 }) {
   return (
     <div className="group/relationship-note flex min-h-8 items-center gap-2 rounded-md bg-muted/70 px-2.5 text-xs text-foreground transition-colors hover:bg-muted">
-      <NoteGlyph iconKey={icon} />
-      <span className="min-w-0 flex-1 truncate font-medium">{note}</span>
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
+        onClick={onOpen}
+        disabled={!onOpen}
+      >
+        <NoteGlyph iconKey={icon} />
+        <span className="min-w-0 flex-1 truncate font-medium">{note}</span>
+      </button>
       <button
         type="button"
         className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/relationship-note:opacity-100"
@@ -1012,11 +958,10 @@ export function NoteContextSidebar({
   rootPath: _rootPath,
   noteTitleSuggestions,
   onClose,
+  onOpenNote,
   onUpdateContent,
 }: NoteContextSidebarProps) {
-  const [newProperty, setNewProperty] = useState({ name: "", type: "Text", value: "" });
   const [newRelation, setNewRelation] = useState({ name: "", note: "" });
-  const [showAddProperty, setShowAddProperty] = useState(false);
   const [editingRelationshipName, setEditingRelationshipName] = useState<string | null>(null);
   const [showCustomRelationship, setShowCustomRelationship] = useState(false);
 
@@ -1034,7 +979,6 @@ export function NoteContextSidebar({
       ]),
     );
     return {
-      customProperties: getCustomProperties(frontmatter.properties),
       date: getString(frontmatter.date),
       icon: getString(frontmatter.icon) || "none",
       relationships: getRelationships(frontmatter.relationships),
@@ -1064,25 +1008,16 @@ export function NoteContextSidebar({
       value: status,
       label: status,
       icon: <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} />,
-      className: style.chip,
+      className: style.text,
     };
   });
-  const propertyTypeOptions = PROPERTY_TYPES.map((type) => ({
-    value: type,
-    label: type,
-    icon: (
-      <span className="grid h-4 w-4 shrink-0 place-items-center text-muted-foreground">
-        {PROPERTY_TYPE_ICONS[type]}
-      </span>
-    ),
-  }));
   const noteTitleOptions = [
-    { title, icon: model.icon === "none" ? null : model.icon },
-    { title: folderName, icon: null },
+    { title, icon: model.icon === "none" ? null : model.icon, path: activeFile.path },
+    { title: folderName, icon: null, path: null },
     ...noteTitleSuggestions,
   ]
     .filter((entry) => entry.title)
-    .reduce<Array<{ title: string; icon: string | null }>>((accumulator, entry) => {
+    .reduce<Array<{ title: string; icon: string | null; path: string | null }>>((accumulator, entry) => {
       if (!accumulator.some((existing) => existing.title.toLowerCase() === entry.title.toLowerCase())) {
         accumulator.push(entry);
       }
@@ -1108,15 +1043,6 @@ export function NoteContextSidebar({
     const tag = normalizeTag(tagInput);
     if (!tag || model.tags.includes(tag)) return;
     updateFrontmatter({ tags: [...model.tags, tag] });
-  };
-
-  const addCustomProperty = () => {
-    const name = newProperty.name.trim();
-    if (!name) return;
-    updateFrontmatter({
-      properties: [...model.customProperties, { ...newProperty, name }],
-    });
-    setNewProperty({ name: "", type: "Text", value: "" });
   };
 
   const addRelationship = (nameInput: string, noteInput: string) => {
@@ -1221,103 +1147,6 @@ export function NoteContextSidebar({
               ) : null}
             </div>
           </FieldRow>
-
-          {/* Inline Custom Properties following URL */}
-          {model.customProperties.map((property, index) => (
-            <FieldRow
-              key={`${property.name}-${index}`}
-              icon={PROPERTY_TYPE_ICONS[property.type] ?? PROPERTY_TYPE_ICONS.Text}
-              label={property.name}
-            >
-              <div className="flex min-w-0 items-center gap-1">
-                <PropertyValueEditor
-                  type={property.type}
-                  value={property.value}
-                  statusOptions={statusOptions}
-                  tagOptions={knownTags}
-                  onChange={(value) => {
-                    const nextProperties = model.customProperties.map((entry, propertyIndex) =>
-                      propertyIndex === index ? { ...entry, value } : entry,
-                    );
-                    updateFrontmatter({ properties: nextProperties });
-                  }}
-                />
-                <button
-                  type="button"
-                  className="grid h-7 w-6 shrink-0 place-items-center text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-                  aria-label={`Delete ${property.name}`}
-                  onClick={() =>
-                    updateFrontmatter({
-                      properties: model.customProperties.filter(
-                        (_entry, propertyIndex) => propertyIndex !== index,
-                      ),
-                    })
-                  }
-                >
-                  x
-                </button>
-              </div>
-            </FieldRow>
-          ))}
-
-          {!showAddProperty ? (
-            <button
-              type="button"
-              className="flex h-7 w-full items-center gap-2 px-1.5 text-left text-xs text-muted-foreground/50 transition-colors hover:text-muted-foreground"
-              onClick={() => setShowAddProperty(true)}
-            >
-              <PlusIcon size={12} />
-              <span>Add property</span>
-            </button>
-          ) : (
-            <div className="grid grid-cols-[1fr_auto] gap-1.5 items-start mt-1 border border-border/30 p-1.5 rounded-md bg-muted/10">
-              <div className="grid grid-cols-2 gap-1.5">
-                <CompactInput
-                  value={newProperty.name}
-                  placeholder="Property name"
-                  autoFocus
-                  onChange={(event) =>
-                    setNewProperty((current) => ({ ...current, name: event.target.value }))
-                  }
-                />
-                <OptionPicker
-                  value={newProperty.type}
-                  options={propertyTypeOptions}
-                  placeholder="Type"
-                  searchPlaceholder="Type..."
-                  allowCreate={false}
-                  widthClassName="w-[148px]"
-                  onChange={(value) => setNewProperty((current) => ({ ...current, type: value }))}
-                  renderTrigger={(option) => (
-                    <span className="inline-flex items-center gap-1 truncate">
-                      {option?.icon}
-                      {option?.label ?? newProperty.type}
-                    </span>
-                  )}
-                />
-              </div>
-              <div className="flex gap-1">
-                <button
-                  type="button"
-                  className="grid h-7 w-7 place-items-center rounded-md bg-primary/10 text-primary hover:bg-primary/20"
-                  disabled={!newProperty.name.trim()}
-                  onClick={() => {
-                    addCustomProperty();
-                    setShowAddProperty(false);
-                  }}
-                >
-                  <TickIcon size={13} />
-                </button>
-                <button
-                  type="button"
-                  className="grid h-7 w-7 place-items-center rounded-md hover:bg-muted text-muted-foreground"
-                  onClick={() => setShowAddProperty(false)}
-                >
-                  <XIcon size={12} />
-                </button>
-              </div>
-            </div>
-          )}
         </section>
 
         <div className="my-3 h-px bg-border/30" />
@@ -1397,11 +1226,13 @@ export function NoteContextSidebar({
                   </div>
                   {matchingRelationships.map((relationship) => {
                     const iconKey = getSuggestionIcon(relationship.note, noteTitleSuggestions);
+                    const notePath = getSuggestionPath(relationship.note, noteTitleSuggestions);
                     return (
                       <RelationshipNoteChip
                         key={`${relationship.name}-${relationship.note}-${relationship.index}`}
                         note={relationship.note}
                         icon={iconKey}
+                        onOpen={notePath ? () => onOpenNote(notePath) : undefined}
                         onRemove={() =>
                           updateFrontmatter({
                             relationships: model.relationships.filter(
@@ -1420,6 +1251,7 @@ export function NoteContextSidebar({
                         placeholder="Add note title"
                         searchPlaceholder="Search notes..."
                         onChange={(value) => addRelationship(relationshipName, value)}
+                        defaultOpen
                         renderTrigger={() => <span className="text-muted-foreground">Add</span>}
                       />
                       <button
@@ -1465,11 +1297,13 @@ export function NoteContextSidebar({
                     <div className="text-xs text-muted-foreground">{group.name}</div>
                     {group.items.map((relationship) => {
                       const iconKey = getSuggestionIcon(relationship.note, noteTitleSuggestions);
+                      const notePath = getSuggestionPath(relationship.note, noteTitleSuggestions);
                       return (
                         <RelationshipNoteChip
                           key={`${relationship.name}-${relationship.note}-${relationship.index}`}
                           note={relationship.note}
                           icon={iconKey}
+                          onOpen={notePath ? () => onOpenNote(notePath) : undefined}
                           onRemove={() =>
                             updateFrontmatter({
                               relationships: model.relationships.filter(

--- a/apps/desktop/src/components/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/note-context-sidebar.tsx
@@ -10,6 +10,7 @@ import {
 import { getBaseName, getDirName } from "@/core/paths";
 import type { FileDocument } from "@/core/workspace";
 import { cn } from "@/core/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import {
   BookIcon,
@@ -35,7 +36,7 @@ type NoteContextSidebarProps = {
   activeFile: FileDocument;
   draftContent: string;
   rootPath: string | null;
-  noteTitleSuggestions: string[];
+  noteTitleSuggestions: Array<{ title: string; icon: string | null }>;
   onClose: () => void;
   onUpdateContent: (content: string) => void;
 };
@@ -64,7 +65,7 @@ type SelectOption = {
   className?: string;
 };
 
-const DEFAULT_TYPES = ["None", "Note", "Essay", "Habit", "Recipe", "Meeting", "Project"];
+const DEFAULT_TYPES = ["None"];
 const DEFAULT_STATUSES = [
   "None",
   "Not Started",
@@ -82,16 +83,29 @@ const STOP_WORDS = new Set([
   "about",
   "after",
   "again",
+  "always",
+  "being",
   "also",
   "because",
   "before",
   "between",
   "could",
+  "doing",
   "every",
   "from",
   "have",
+  "never",
+  "what",
+  "when",
+  "where",
+  "which",
+  "while",
   "into",
+  "make",
+  "more",
   "notes",
+  "only",
+  "right",
   "should",
   "that",
   "their",
@@ -104,7 +118,7 @@ const STOP_WORDS = new Set([
 ]);
 
 const ICON_OPTIONS: IconOption[] = [
-  { key: "none", label: "None", icon: <FileIcon size={13} /> },
+  { key: "none", label: "None", icon: null },
   { key: "spark", label: "Spark", icon: <SparklesIcon size={13} /> },
   { key: "idea", label: "Idea", icon: <IdeaIcon size={13} /> },
   { key: "book", label: "Book", icon: <BookIcon size={13} /> },
@@ -115,34 +129,74 @@ const ICON_OPTIONS: IconOption[] = [
   { key: "rocket", label: "Rocket", icon: <RocketIcon size={13} /> },
 ];
 
-const STATUS_TONE: Record<string, string> = {
-  "not started": "text-muted-foreground",
-  active: "text-primary",
-  "in progress": "text-primary",
-  learning: "text-amber-500",
-  blocked: "text-destructive",
-  draft: "text-muted-foreground/80",
-  archived: "text-muted-foreground/60",
-  paused: "text-orange-500",
+const STATUS_STYLES: Record<string, { dot: string; text: string; chip: string }> = {
+  none: {
+    dot: "bg-muted-foreground/50",
+    text: "text-muted-foreground",
+    chip: "bg-muted text-muted-foreground",
+  },
+  "not started": {
+    dot: "bg-slate-500",
+    text: "text-slate-600 dark:text-slate-300",
+    chip: "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  },
+  active: {
+    dot: "bg-emerald-500",
+    text: "text-emerald-700 dark:text-emerald-300",
+    chip: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  },
+  "in progress": {
+    dot: "bg-violet-500",
+    text: "text-violet-700 dark:text-violet-300",
+    chip: "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  },
+  learning: {
+    dot: "bg-sky-500",
+    text: "text-sky-700 dark:text-sky-300",
+    chip: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  },
+  blocked: {
+    dot: "bg-red-500",
+    text: "text-red-700 dark:text-red-300",
+    chip: "bg-red-500/10 text-red-700 dark:text-red-300",
+  },
+  draft: {
+    dot: "bg-amber-500",
+    text: "text-amber-700 dark:text-amber-300",
+    chip: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  },
+  archived: {
+    dot: "bg-zinc-500",
+    text: "text-zinc-600 dark:text-zinc-300",
+    chip: "bg-zinc-500/10 text-zinc-700 dark:text-zinc-300",
+  },
+  paused: {
+    dot: "bg-orange-500",
+    text: "text-orange-700 dark:text-orange-300",
+    chip: "bg-orange-500/10 text-orange-700 dark:text-orange-300",
+  },
 };
 
 const TAG_TONES = [
-  "bg-primary/10 text-primary",
-  "bg-accent text-accent-foreground",
-  "bg-secondary text-secondary-foreground",
-  "bg-muted text-foreground",
-  "bg-destructive/10 text-destructive",
+  "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  "bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+  "bg-lime-500/10 text-lime-700 dark:text-lime-300",
+  "bg-orange-500/10 text-orange-700 dark:text-orange-300",
 ];
 
-const PROPERTY_TYPE_ICONS: Record<string, string> = {
-  Boolean: "O",
-  Color: "C",
-  Date: "D",
-  Number: "#",
-  Status: "S",
-  Tags: "#",
-  Text: "T",
-  URL: "U",
+const PROPERTY_TYPE_ICONS: Record<string, ReactNode> = {
+  Boolean: <span className="h-3 w-3 rounded-full border border-current" />,
+  Color: <span className="h-3 w-3 rounded-full bg-primary/70" />,
+  Date: <CalendarIcon size={12} />,
+  Number: <span className="font-mono text-[10px]">#</span>,
+  Status: <span className="h-2.5 w-2.5 rounded-full bg-primary/70" />,
+  Tags: <DiscountTagIcon size={12} />,
+  Text: <span className="font-mono text-[10px]">T</span>,
+  URL: <LinkIcon size={12} />,
 };
 
 type CalendarDay = {
@@ -281,14 +335,21 @@ function serializeFrontmatter(frontmatter: Record<string, unknown>) {
 function detectTags(body: string, existingTags: string[]) {
   const existing = new Set(existingTags);
   const counts = new Map<string, number>();
-  for (const match of body.toLowerCase().matchAll(/[a-z][a-z0-9-]{3,}/g)) {
+  const normalizedBody = body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/\[[^\]]+\]\([^)]+\)/g, " ")
+    .replace(/https?:\/\/\S+/g, " ");
+
+  for (const match of normalizedBody.toLowerCase().matchAll(/[a-z][a-z0-9-]{4,}/g)) {
     const tag = normalizeTag(match[0]);
     if (STOP_WORDS.has(tag) || existing.has(tag)) continue;
     counts.set(tag, (counts.get(tag) ?? 0) + 1);
   }
   return Array.from(counts.entries())
+    .filter(([tag, count]) => count >= 2 && !STOP_WORDS.has(tag))
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
-    .slice(0, 6)
+    .slice(0, 4)
     .map(([tag]) => tag);
 }
 
@@ -302,6 +363,42 @@ function hashText(value: string) {
 
 function getTagTone(tag: string) {
   return TAG_TONES[hashText(tag) % TAG_TONES.length];
+}
+
+function getStatusStyle(status: string) {
+  return (
+    STATUS_STYLES[status.toLowerCase()] ?? {
+      dot: TAG_TONES[hashText(status) % TAG_TONES.length].split(" ")[0] ?? "bg-primary/10",
+      text: TAG_TONES[hashText(status) % TAG_TONES.length].split(" ").slice(1).join(" "),
+      chip: TAG_TONES[hashText(status) % TAG_TONES.length],
+    }
+  );
+}
+
+function getIconOption(iconKey: string | null | undefined) {
+  if (!iconKey) return null;
+  const option = ICON_OPTIONS.find((entry) => entry.key === iconKey);
+  return option?.key === "none" ? null : option;
+}
+
+function NoteGlyph({ iconKey, fallbackClassName }: { iconKey?: string | null; fallbackClassName?: string }) {
+  const icon = getIconOption(iconKey);
+  return icon ? (
+    <span className="grid h-4 w-4 shrink-0 place-items-center text-primary">{icon.icon}</span>
+  ) : (
+    <FileIcon size={13} className={cn("shrink-0", fallbackClassName ?? "text-muted-foreground/50")} />
+  );
+}
+
+function getSuggestionIcon(
+  note: string,
+  noteTitleSuggestions: Array<{ title: string; icon: string | null }>,
+) {
+  return (
+    noteTitleSuggestions.find(
+      (entry) => entry.title.toLowerCase() === note.toLowerCase(),
+    )?.icon ?? null
+  );
 }
 
 function isCreateOptionVisible(query: string, options: SelectOption[]) {
@@ -369,7 +466,7 @@ function BasePopover({
         >
           <Popover.Popup
             className={cn(
-              "z-50 max-h-(--available-height) min-w-[200px] max-w-[calc(100vw-24px)] origin-(--transform-origin) overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+              "z-50 max-h-(--available-height) max-w-[calc(100vw-24px)] origin-(--transform-origin) overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
               "dark:bg-popover/90 dark:backdrop-blur-2xl",
               className,
             )}
@@ -391,6 +488,7 @@ function OptionPicker({
   onChange,
   renderTrigger,
   align = "end",
+  widthClassName = "w-[200px]",
 }: {
   value: string;
   options: SelectOption[];
@@ -400,6 +498,7 @@ function OptionPicker({
   onChange: (value: string) => void;
   renderTrigger?: (option: SelectOption | null) => ReactNode;
   align?: "start" | "center" | "end";
+  widthClassName?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -433,7 +532,7 @@ function OptionPicker({
         </button>
       }
     >
-      <div className="flex w-[220px] flex-col overflow-hidden">
+      <div className={cn("flex flex-col overflow-hidden", widthClassName)}>
         <div className="flex items-center gap-1.5 border-b border-border/40 px-2.5 py-2">
           <SearchIcon size={12} className="text-muted-foreground/60" />
           <input
@@ -642,6 +741,76 @@ function TagPill({ tag, onRemove }: { tag: string; onRemove?: () => void }) {
   );
 }
 
+function IconPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = getIconOption(value);
+
+  return (
+    <BasePopover
+      align="end"
+      open={open}
+      onOpenChange={setOpen}
+      trigger={
+        <button
+          type="button"
+          aria-haspopup="menu"
+          className="flex h-7 w-full min-w-0 items-center gap-2 rounded-md border border-transparent bg-transparent px-1 text-left text-xs text-foreground transition-colors hover:bg-muted/50 focus:border-primary/20 focus:bg-muted/50 focus:outline-none"
+        >
+          {selected ? (
+            <span className="text-primary">{selected.icon}</span>
+          ) : (
+            <span className="h-3.5 w-3.5 shrink-0" />
+          )}
+          <span className="min-w-0 flex-1 truncate">{selected?.label ?? "None"}</span>
+          <span className="text-muted-foreground">›</span>
+        </button>
+      }
+    >
+      <div className="w-[168px] p-1.5">
+        <div className="mb-1 grid grid-cols-5 gap-1.5">
+          {ICON_OPTIONS.filter((option) => option.key !== "none").map((option) => (
+            <Tooltip key={option.key}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange(option.key);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "grid h-7 w-7 place-items-center rounded-md border border-transparent text-muted-foreground transition-colors hover:border-border hover:text-foreground",
+                    value === option.key ? "bg-muted text-primary" : "",
+                  )}
+                  aria-label={`Use ${option.label} icon`}
+                >
+                  {option.icon}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{option.label}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onChange("none");
+            setOpen(false);
+          }}
+          className="mt-1 flex h-7 w-full items-center justify-center rounded-md text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          None
+        </button>
+      </div>
+    </BasePopover>
+  );
+}
+
 function TagPicker({
   tags,
   suggestions,
@@ -812,6 +981,31 @@ function PropertyValueEditor({
   );
 }
 
+function RelationshipNoteChip({
+  note,
+  icon,
+  onRemove,
+}: {
+  note: string;
+  icon: string | null;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="group/relationship-note flex min-h-8 items-center gap-2 rounded-md bg-muted/70 px-2.5 text-xs text-foreground transition-colors hover:bg-muted">
+      <NoteGlyph iconKey={icon} />
+      <span className="min-w-0 flex-1 truncate font-medium">{note}</span>
+      <button
+        type="button"
+        className="grid h-5 w-5 shrink-0 place-items-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/relationship-note:opacity-100"
+        aria-label={`Remove ${note}`}
+        onClick={onRemove}
+      >
+        <XIcon size={12} />
+      </button>
+    </div>
+  );
+}
+
 export function NoteContextSidebar({
   activeFile,
   draftContent,
@@ -821,8 +1015,10 @@ export function NoteContextSidebar({
   onUpdateContent,
 }: NoteContextSidebarProps) {
   const [newProperty, setNewProperty] = useState({ name: "", type: "Text", value: "" });
-  const [newRelation, setNewRelation] = useState({ name: "Related to", note: "" });
+  const [newRelation, setNewRelation] = useState({ name: "", note: "" });
   const [showAddProperty, setShowAddProperty] = useState(false);
+  const [editingRelationshipName, setEditingRelationshipName] = useState<string | null>(null);
+  const [showCustomRelationship, setShowCustomRelationship] = useState(false);
 
   const parsed = useMemo(() => parseMarkdownFrontmatter(draftContent), [draftContent]);
   const frontmatter = useMemo(
@@ -863,32 +1059,39 @@ export function NoteContextSidebar({
     className: type === "None" ? "text-muted-foreground" : "text-primary",
   }));
   const statusOptions = knownStatuses.map((status) => {
-    const textClass = STATUS_TONE[status.toLowerCase()] ?? "text-muted-foreground";
-    // Transform 'text-blue-500' into 'bg-blue-500' to style the dot.
-    const bgClass = textClass.replace("text-", "bg-");
+    const style = getStatusStyle(status);
     return {
       value: status,
       label: status,
-      icon: <span className={cn("h-1.5 w-1.5 rounded-full", bgClass)} />,
-      className: textClass,
+      icon: <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} />,
+      className: style.chip,
     };
   });
-  const iconOptions = ICON_OPTIONS.map((option) => ({
-    value: option.key,
-    label: option.label,
-    icon: option.icon,
-  }));
   const propertyTypeOptions = PROPERTY_TYPES.map((type) => ({
     value: type,
     label: type,
-    icon: <span className="text-[10px]">{PROPERTY_TYPE_ICONS[type]}</span>,
+    icon: (
+      <span className="grid h-4 w-4 shrink-0 place-items-center text-muted-foreground">
+        {PROPERTY_TYPE_ICONS[type]}
+      </span>
+    ),
   }));
-  const noteTitleOptions = Array.from(new Set([title, folderName, ...noteTitleSuggestions]))
-    .filter(Boolean)
-    .map((noteTitle) => ({
-      value: noteTitle,
-      label: noteTitle,
-      icon: <FileIcon size={12} />,
+  const noteTitleOptions = [
+    { title, icon: model.icon === "none" ? null : model.icon },
+    { title: folderName, icon: null },
+    ...noteTitleSuggestions,
+  ]
+    .filter((entry) => entry.title)
+    .reduce<Array<{ title: string; icon: string | null }>>((accumulator, entry) => {
+      if (!accumulator.some((existing) => existing.title.toLowerCase() === entry.title.toLowerCase())) {
+        accumulator.push(entry);
+      }
+      return accumulator;
+    }, [])
+    .map((entry) => ({
+      value: entry.title,
+      label: entry.title,
+      icon: <NoteGlyph iconKey={entry.icon} />,
     }));
 
   const updateFrontmatter = (nextValues: Record<string, unknown>) => {
@@ -921,7 +1124,9 @@ export function NoteContextSidebar({
     const note = noteInput.trim();
     if (!name || !note) return;
     updateFrontmatter({ relationships: [...model.relationships, { name, note }] });
-    setNewRelation({ name, note: "" });
+    setNewRelation({ name: "", note: "" });
+    setEditingRelationshipName(null);
+    setShowCustomRelationship(false);
   };
 
   return (
@@ -971,8 +1176,8 @@ export function NoteContextSidebar({
               onChange={(value) => updateFrontmatter({ status: value === "None" ? "" : value })}
               renderTrigger={(option) => (
                 <span className="inline-flex items-center gap-1.5">
-                  <span className={cn("h-1.5 w-1.5 rounded-full bg-current", option?.className?.replace('text-', 'bg-') || 'bg-muted-foreground')} />
-                  <span className={cn("truncate font-medium", option?.className || "text-foreground/80")}>
+                  <span className={cn("h-1.5 w-1.5 rounded-full", getStatusStyle(option?.value ?? model.status).dot)} />
+                  <span className={cn("truncate font-medium", getStatusStyle(option?.value ?? model.status).text)}>
                     {option?.label ?? model.status}
                   </span>
                 </span>
@@ -981,19 +1186,9 @@ export function NoteContextSidebar({
           </FieldRow>
 
           <FieldRow icon={<SparklesIcon size={13} />} label="Icon">
-            <OptionPicker
+            <IconPicker
               value={model.icon}
-              options={iconOptions}
-              placeholder="None"
-              searchPlaceholder="Search icons..."
-              allowCreate={false}
               onChange={(value) => updateFrontmatter({ icon: value === "none" ? "" : value })}
-              renderTrigger={(option) => (
-                <span className="inline-flex max-w-full items-center gap-1">
-                  <span className="text-primary">{option?.icon}</span>
-                  <span className="truncate text-muted-foreground">{option?.label ?? "None"}</span>
-                </span>
-              )}
             />
           </FieldRow>
 
@@ -1005,19 +1200,33 @@ export function NoteContextSidebar({
           </FieldRow>
 
           <FieldRow icon={<LinkIcon size={13} />} label="URL">
-            <CompactInput
-              type="url"
-              value={model.url}
-              placeholder="-"
-              onChange={(event) => updateFrontmatter({ url: event.target.value })}
-            />
+            <div className="flex min-w-0 items-center gap-1">
+              <CompactInput
+                type="url"
+                value={model.url}
+                placeholder="-"
+                className={model.url ? "text-primary" : ""}
+                onChange={(event) => updateFrontmatter({ url: event.target.value })}
+              />
+              {model.url ? (
+                <a
+                  href={model.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-primary transition-colors hover:bg-primary/10"
+                  aria-label="Open URL"
+                >
+                  <LinkIcon size={13} />
+                </a>
+              ) : null}
+            </div>
           </FieldRow>
 
           {/* Inline Custom Properties following URL */}
           {model.customProperties.map((property, index) => (
             <FieldRow
               key={`${property.name}-${index}`}
-              icon={<span>{PROPERTY_TYPE_ICONS[property.type] ?? "T"}</span>}
+              icon={PROPERTY_TYPE_ICONS[property.type] ?? PROPERTY_TYPE_ICONS.Text}
               label={property.name}
             >
               <div className="flex min-w-0 items-center gap-1">
@@ -1077,6 +1286,7 @@ export function NoteContextSidebar({
                   placeholder="Type"
                   searchPlaceholder="Type..."
                   allowCreate={false}
+                  widthClassName="w-[148px]"
                   onChange={(value) => setNewProperty((current) => ({ ...current, type: value }))}
                   renderTrigger={(option) => (
                     <span className="inline-flex items-center gap-1 truncate">
@@ -1168,68 +1378,164 @@ export function NoteContextSidebar({
 
         <section>
           <div className="mb-2 text-[11px] font-medium text-muted-foreground/70">Relationships</div>
-          <div className="space-y-1">
-            {model.relationships.map((relationship, index) => (
-              <div
-                key={`${relationship.name}-${relationship.note}-${index}`}
-                className="group grid grid-cols-[80px_minmax(0,1fr)_20px] gap-2 items-center p-1 rounded-md transition-colors hover:bg-muted/40 min-h-8"
-              >
-                <span className="truncate text-[10px] font-medium text-muted-foreground/70 px-1">
-                  {relationship.name}
-                </span>
-                <div className="truncate text-xs text-foreground/90 flex items-center gap-1.5">
-                  <FileIcon size={12} className="opacity-50 shrink-0" />
-                  <span className="truncate font-medium">{relationship.note}</span>
+          <div className="space-y-3">
+            {DEFAULT_RELATIONSHIPS.map((relationshipName) => {
+              const matchingRelationships = model.relationships
+                .map((relationship, index) => ({ ...relationship, index }))
+                .filter((relationship) => relationship.name === relationshipName);
+              return (
+                <div key={relationshipName} className="space-y-1.5">
+                  <div
+                    className={cn(
+                      "text-xs",
+                      matchingRelationships.length > 0
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/45",
+                    )}
+                  >
+                    {relationshipName}
+                  </div>
+                  {matchingRelationships.map((relationship) => {
+                    const iconKey = getSuggestionIcon(relationship.note, noteTitleSuggestions);
+                    return (
+                      <RelationshipNoteChip
+                        key={`${relationship.name}-${relationship.note}-${relationship.index}`}
+                        note={relationship.note}
+                        icon={iconKey}
+                        onRemove={() =>
+                          updateFrontmatter({
+                            relationships: model.relationships.filter(
+                              (_entry, index) => index !== relationship.index,
+                            ),
+                          })
+                        }
+                      />
+                    );
+                  })}
+                  {editingRelationshipName === relationshipName ? (
+                    <div className="grid grid-cols-[minmax(0,1fr)_28px] gap-1.5">
+                      <OptionPicker
+                        value=""
+                        options={noteTitleOptions}
+                        placeholder="Add note title"
+                        searchPlaceholder="Search notes..."
+                        onChange={(value) => addRelationship(relationshipName, value)}
+                        renderTrigger={() => <span className="text-muted-foreground">Add</span>}
+                      />
+                      <button
+                        type="button"
+                        className="grid h-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                        onClick={() => setEditingRelationshipName(null)}
+                        aria-label="Cancel relationship"
+                      >
+                        <XIcon size={12} />
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="h-8 w-full rounded-md border border-dashed border-border bg-background px-3 text-left text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                      onClick={() => setEditingRelationshipName(relationshipName)}
+                    >
+                      Add
+                    </button>
+                  )}
                 </div>
+              );
+            })}
+
+            {model.relationships
+              .map((relationship, index) => ({ ...relationship, index }))
+              .filter((relationship) => !DEFAULT_RELATIONSHIPS.includes(relationship.name))
+              .reduce<Array<{ name: string; items: Array<Relationship & { index: number }> }>>(
+                (groups, relationship) => {
+                  const group = groups.find((entry) => entry.name === relationship.name);
+                  if (group) {
+                    group.items.push(relationship);
+                  } else {
+                    groups.push({ name: relationship.name, items: [relationship] });
+                  }
+                  return groups;
+                },
+                [],
+              )
+              .map((group) => {
+                return (
+                  <div key={group.name} className="space-y-1.5">
+                    <div className="text-xs text-muted-foreground">{group.name}</div>
+                    {group.items.map((relationship) => {
+                      const iconKey = getSuggestionIcon(relationship.note, noteTitleSuggestions);
+                      return (
+                        <RelationshipNoteChip
+                          key={`${relationship.name}-${relationship.note}-${relationship.index}`}
+                          note={relationship.note}
+                          icon={iconKey}
+                          onRemove={() =>
+                            updateFrontmatter({
+                              relationships: model.relationships.filter(
+                                (_entry, index) => index !== relationship.index,
+                              ),
+                            })
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                );
+              })}
+
+            {showCustomRelationship ? (
+              <div className="grid grid-cols-[100px_minmax(0,1fr)_28px_28px] gap-1.5 items-center">
+                <OptionPicker
+                  align="start"
+                  value={newRelation.name}
+                  options={Array.from(
+                    new Set([
+                      ...DEFAULT_RELATIONSHIPS,
+                      ...model.relationships.map((relationship) => relationship.name),
+                    ]),
+                  ).map((name) => ({ value: name, label: name }))}
+                  placeholder="Name"
+                  searchPlaceholder="Relationship name..."
+                  allowCreate
+                  widthClassName="w-[156px]"
+                  onChange={(value) => setNewRelation((current) => ({ ...current, name: value }))}
+                />
+                <OptionPicker
+                  value={newRelation.note}
+                  options={noteTitleOptions}
+                  placeholder="Note title"
+                  searchPlaceholder="Search notes..."
+                  onChange={(value) => setNewRelation((current) => ({ ...current, note: value }))}
+                />
                 <button
                   type="button"
-                  className="opacity-0 group-hover:opacity-100 grid h-5 w-5 place-items-center text-muted-foreground hover:text-destructive transition-opacity"
-                  aria-label="Remove relationship"
-                  onClick={() =>
-                    updateFrontmatter({
-                      relationships: model.relationships.filter((_, i) => i !== index),
-                    })
-                  }
+                  className="grid h-7 w-7 place-items-center rounded-md border border-border/50 text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary disabled:cursor-not-allowed disabled:opacity-30"
+                  disabled={!newRelation.name.trim() || !newRelation.note.trim()}
+                  onClick={() => addRelationship(newRelation.name, newRelation.note)}
+                >
+                  <TickIcon size={13} />
+                </button>
+                <button
+                  type="button"
+                  className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={() => {
+                    setShowCustomRelationship(false);
+                    setNewRelation({ name: "", note: "" });
+                  }}
                 >
                   <XIcon size={12} />
                 </button>
               </div>
-            ))}
-
-            {model.relationships.length === 0 && (
-               <div className="text-[10px] text-muted-foreground/40 italic px-1 mb-1">No relationships defined</div>
-            )}
-
-            <div className="mt-2 grid grid-cols-[85px_minmax(0,1fr)_28px] gap-1.5 items-center">
-              <OptionPicker
-                align="start"
-                value={newRelation.name}
-                options={Array.from(
-                  new Set([
-                    ...DEFAULT_RELATIONSHIPS,
-                    ...model.relationships.map((relationship) => relationship.name),
-                  ]),
-                ).map((name) => ({ value: name, label: name }))}
-                placeholder="Rel..."
-                searchPlaceholder="Search type..."
-                onChange={(value) => setNewRelation((current) => ({ ...current, name: value }))}
-              />
-              <OptionPicker
-                value={newRelation.note}
-                options={noteTitleOptions}
-                placeholder="Pick note..."
-                searchPlaceholder="Search notes..."
-                onChange={(value) => setNewRelation((current) => ({ ...current, note: value }))}
-              />
+            ) : (
               <button
                 type="button"
-                className="grid h-7 w-7 place-items-center rounded-md border border-border/50 text-muted-foreground hover:text-primary hover:border-primary/30 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                disabled={!newRelation.name.trim() || !newRelation.note.trim()}
-                onClick={() => addRelationship(newRelation.name, newRelation.note)}
+                className="mt-1 h-8 w-full rounded-md border border-border bg-background text-xs text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary"
+                onClick={() => setShowCustomRelationship(true)}
               >
-                <PlusIcon size={13} />
+                + Add relationship
               </button>
-            </div>
+            )}
           </div>
         </section>
       </div>

--- a/apps/desktop/src/components/notes/notes-browser-pane.tsx
+++ b/apps/desktop/src/components/notes/notes-browser-pane.tsx
@@ -1,8 +1,13 @@
 import { useState } from "react";
 import type { DragEvent } from "react";
-import { createPortal } from "react-dom";
 
 import { cn } from "@/core/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { NoteBrowserEntry, NoteCollectionAccentKey } from "@/core/workspace";
 
 import {
@@ -187,16 +192,10 @@ export function NotesBrowserPane({
   onDeleteNote,
   onReorderNote,
 }: NotesBrowserPaneProps) {
-  const [actionMenu, setActionMenu] = useState<{
-    entry: NoteBrowserEntry;
-    left: number;
-    top: number;
-  } | null>(null);
   const [dragTarget, setDragTarget] = useState<{
     path: string;
     position: "before" | "after";
   } | null>(null);
-  const closeActionMenu = () => setActionMenu(null);
 
   return (
     <>
@@ -289,41 +288,103 @@ export function NotesBrowserPane({
                         {entry.title}
                       </span>
                       <span className="flex h-5 shrink-0 items-center">
-                        <button
-                          type="button"
-                          draggable={false}
-                          className="grid h-5 w-5 place-items-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-                          aria-label="Note actions"
-                          onPointerDownCapture={(event) => {
-                            event.stopPropagation();
-                            const rect = event.currentTarget.getBoundingClientRect();
-                            setActionMenu({
-                              entry,
-                              left: rect.left,
-                              top: rect.bottom + 6,
-                            });
-                          }}
-                          onMouseDown={(event) => {
-                            event.stopPropagation();
-                            const rect = event.currentTarget.getBoundingClientRect();
-                            setActionMenu({
-                              entry,
-                              left: rect.left,
-                              top: rect.bottom + 6,
-                            });
-                          }}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            const rect = event.currentTarget.getBoundingClientRect();
-                            setActionMenu({
-                              entry,
-                              left: rect.left,
-                              top: rect.bottom + 6,
-                            });
-                          }}
-                        >
-                          <MoreVerticalIcon size={14} />
-                        </button>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            draggable={false}
+                            className="grid h-5 w-5 place-items-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
+                            aria-label="Note actions"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                            }}
+                            onPointerDown={(event) => {
+                              event.stopPropagation();
+                            }}
+                            onMouseDown={(event) => {
+                              event.stopPropagation();
+                            }}
+                          >
+                            <MoreVerticalIcon size={14} />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-52">
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onCopyNote?.(entry);
+                              }}
+                            >
+                              <LinkIcon size={14} className="opacity-70" />
+                              Copy as Markdown
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onCopyNotePath?.(entry);
+                              }}
+                            >
+                              <LinkIcon size={14} className="opacity-70" />
+                              Copy note path
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onRevealNote?.(entry);
+                              }}
+                            >
+                              <FileManagerLogo label="Reveal in Finder" size={14} className="opacity-70" />
+                              Reveal in Finder
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onExportNote?.(entry);
+                              }}
+                            >
+                              <FileDownIcon size={14} className="opacity-70" />
+                              Export as PDF
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onTogglePinnedNote?.(entry);
+                              }}
+                            >
+                              {isNotePinned?.(entry) ? (
+                                <PinOffIcon size={14} className="opacity-70" />
+                              ) : (
+                                <PinIcon size={14} className="opacity-70" />
+                              )}
+                              {isNotePinned?.(entry) ? "Unpin note" : "Pin note"}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onRenameNote?.(entry);
+                              }}
+                            >
+                              <PencilIcon size={14} className="opacity-70" />
+                              Rename
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onRemoveNote?.(entry);
+                              }}
+                            >
+                              <XIcon size={14} className="opacity-70" />
+                              Remove
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onDeleteNote?.(entry);
+                              }}
+                            >
+                              <TrashIcon size={14} className="opacity-70" />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       </span>
                     </span>
                     {entry.excerpt && isActive ? (
@@ -352,116 +413,6 @@ export function NotesBrowserPane({
           )}
         </div>
       </aside>
-      {actionMenu
-        ? createPortal(
-            <>
-              <button
-                type="button"
-                aria-label="Close note actions"
-                className="fixed inset-0 z-40 cursor-default bg-transparent"
-                onClick={closeActionMenu}
-              />
-              <div
-                className="fixed z-50 w-52 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg"
-                style={{ left: actionMenu.left, top: actionMenu.top }}
-              >
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onCopyNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <LinkIcon size={14} className="opacity-70" />
-                  Copy as Markdown
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onCopyNotePath?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <LinkIcon size={14} className="opacity-70" />
-                  Copy note path
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onRevealNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <FileManagerLogo label="Reveal in Finder" size={14} className="opacity-70" />
-                  Reveal in Finder
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onExportNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <FileDownIcon size={14} className="opacity-70" />
-                  Export as PDF
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onTogglePinnedNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  {isNotePinned?.(actionMenu.entry) ? (
-                    <PinOffIcon size={14} className="opacity-70" />
-                  ) : (
-                    <PinIcon size={14} className="opacity-70" />
-                  )}
-                  {isNotePinned?.(actionMenu.entry) ? "Unpin note" : "Pin note"}
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onRenameNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <PencilIcon size={14} className="opacity-70" />
-                  Rename
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden hover:bg-accent"
-                  onClick={() => {
-                    onRemoveNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <XIcon size={14} className="opacity-70" />
-                  Remove
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-destructive outline-hidden hover:bg-destructive/10 [&_svg]:text-destructive"
-                  onClick={() => {
-                    onDeleteNote?.(actionMenu.entry);
-                    closeActionMenu();
-                  }}
-                >
-                  <TrashIcon size={14} className="opacity-70" />
-                  Delete
-                </button>
-              </div>
-            </>,
-            document.body,
-          )
-        : null}
     </>
   );
 }

--- a/apps/desktop/src/components/notes/notes-browser-pane.tsx
+++ b/apps/desktop/src/components/notes/notes-browser-pane.tsx
@@ -11,12 +11,20 @@ import {
 import type { NoteBrowserEntry, NoteCollectionAccentKey } from "@/core/workspace";
 
 import {
+  BookIcon,
+  BriefcaseIcon,
+  CameraIcon,
   FileDownIcon,
+  HomeIcon,
+  IdeaIcon,
+  LeafIcon,
   LinkIcon,
   MoreVerticalIcon,
   PencilIcon,
   PinIcon,
   PinOffIcon,
+  RocketIcon,
+  SparklesIcon,
   TrashIcon,
   XIcon,
 } from "../icons";
@@ -124,6 +132,30 @@ type NotesBrowserPaneProps = {
 const SKELETON_COUNT = 5;
 const NOTE_BROWSER_DRAG_MIME = "application/x-glyph-note-browser-entry";
 let globalDraggedNotePath: string | null = null;
+
+const NOTE_ICON_RENDERERS = {
+  book: BookIcon,
+  camera: CameraIcon,
+  home: HomeIcon,
+  idea: IdeaIcon,
+  leaf: LeafIcon,
+  rocket: RocketIcon,
+  spark: SparklesIcon,
+  work: BriefcaseIcon,
+};
+
+function NoteEntryIcon({ icon }: { icon: string | null }) {
+  if (!icon || icon === "none") {
+    return null;
+  }
+
+  const Icon = NOTE_ICON_RENDERERS[icon as keyof typeof NOTE_ICON_RENDERERS];
+  if (!Icon) {
+    return null;
+  }
+
+  return <Icon size={14} className="mt-0.5 shrink-0 text-primary" />;
+}
 
 function getDropPosition(event: DragEvent<HTMLElement>) {
   const rect = event.currentTarget.getBoundingClientRect();
@@ -284,8 +316,11 @@ export function NotesBrowserPane({
                 >
                   <span className="min-w-0 flex-1">
                     <span className="flex items-start justify-between gap-2">
-                      <span className="line-clamp-1 min-w-0 text-sm font-medium text-foreground break-all">
-                        {entry.title}
+                      <span className="flex min-w-0 items-start gap-1.5">
+                        <NoteEntryIcon icon={entry.icon} />
+                        <span className="line-clamp-1 min-w-0 text-sm font-medium text-foreground break-all">
+                          {entry.title}
+                        </span>
                       </span>
                       <span className="flex h-5 shrink-0 items-center">
                         <DropdownMenu>

--- a/apps/desktop/src/components/notes/notes-browser-pane.tsx
+++ b/apps/desktop/src/components/notes/notes-browser-pane.tsx
@@ -11,20 +11,31 @@ import {
 import type { NoteBrowserEntry, NoteCollectionAccentKey } from "@/core/workspace";
 
 import {
+  ArchiveIcon,
   BookIcon,
   BriefcaseIcon,
+  CalendarIcon,
   CameraIcon,
+  DiscountTagIcon,
   FileDownIcon,
+  FileIcon,
+  GlobeIcon,
   HomeIcon,
+  HonourStarIcon,
   IdeaIcon,
+  LayersIcon,
   LeafIcon,
   LinkIcon,
+  MonitorIcon,
+  MoonIcon,
+  NotebookIcon,
   MoreVerticalIcon,
   PencilIcon,
   PinIcon,
   PinOffIcon,
   RocketIcon,
   SparklesIcon,
+  SunIcon,
   TrashIcon,
   XIcon,
 } from "../icons";
@@ -134,13 +145,24 @@ const NOTE_BROWSER_DRAG_MIME = "application/x-glyph-note-browser-entry";
 let globalDraggedNotePath: string | null = null;
 
 const NOTE_ICON_RENDERERS = {
+  archive: ArchiveIcon,
   book: BookIcon,
+  calendar: CalendarIcon,
   camera: CameraIcon,
+  file: FileIcon,
+  globe: GlobeIcon,
   home: HomeIcon,
   idea: IdeaIcon,
+  layers: LayersIcon,
   leaf: LeafIcon,
+  monitor: MonitorIcon,
+  moon: MoonIcon,
+  notebook: NotebookIcon,
   rocket: RocketIcon,
   spark: SparklesIcon,
+  star: HonourStarIcon,
+  sun: SunIcon,
+  tag: DiscountTagIcon,
   work: BriefcaseIcon,
 };
 

--- a/apps/desktop/src/components/settings-panel.tsx
+++ b/apps/desktop/src/components/settings-panel.tsx
@@ -3,13 +3,6 @@ import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 import {
@@ -21,7 +14,6 @@ import {
   MODIFIER_TOKENS,
 } from "@/core/shortcuts";
 
-import type { ThemeMode } from "@/core/workspace";
 import type { SettingsPanelProps } from "../types/settings-panel";
 import { GearIcon, SearchIcon, ShortcutIcon } from "./icons";
 
@@ -31,7 +23,6 @@ export const SettingsPanel = ({
   appInfo,
   onClose,
   onChooseFolder,
-  onChangeMode,
   onChangeShortcuts,
 }: SettingsPanelProps) => {
   const [activeTab, setActiveTab] = useState("general");
@@ -255,27 +246,6 @@ export const SettingsPanel = ({
                     </div>
                   </div>
 
-                  <div className="flex flex-col justify-between gap-4 border-b border-border/40 py-4 sm:flex-row sm:items-center sm:gap-8">
-                    <div className="shrink-0 space-y-1">
-                      <p className="text-sm font-medium">Appearance</p>
-                      <p className="text-xs text-muted-foreground">
-                        Customise how Glyph looks on your device
-                      </p>
-                    </div>
-                    <Select
-                      value={settings.themeMode}
-                      onValueChange={(value) => onChangeMode(value as ThemeMode)}
-                    >
-                      <SelectTrigger className="w-[140px]" aria-label="Theme mode">
-                        <SelectValue placeholder="Theme" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="light">Light</SelectItem>
-                        <SelectItem value="dark">Dark</SelectItem>
-                        <SelectItem value="system">System</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
                 </div>
               </div>
             </div>

--- a/apps/desktop/src/components/sidebar/note-collection-row.tsx
+++ b/apps/desktop/src/components/sidebar/note-collection-row.tsx
@@ -34,13 +34,17 @@ import {
   GlobeIcon,
   HomeIcon,
   HonourStarIcon,
+  IdeaIcon,
   LayersIcon,
   LeafIcon,
+  MonitorIcon,
+  MoonIcon,
   NotebookIcon,
   PencilIcon,
   PlusIcon,
   RocketIcon,
   SparklesIcon,
+  SunIcon,
   TrashIcon,
   XIcon,
 } from "../icons";
@@ -195,6 +199,11 @@ const ICONS: Record<NoteCollectionIconKey, ComponentType<{ size?: number; classN
   camera: CameraIcon,
   notebook: NotebookIcon,
   star: HonourStarIcon,
+  idea: IdeaIcon,
+  file: FileIcon,
+  sun: SunIcon,
+  moon: MoonIcon,
+  monitor: MonitorIcon,
 };
 
 /** Human-readable label for each accent color key */
@@ -233,6 +242,11 @@ const ICON_LABELS: Record<NoteCollectionIconKey, string> = {
   camera: "Camera",
   notebook: "Notebook",
   star: "Star",
+  idea: "Idea",
+  file: "File",
+  sun: "Sun",
+  moon: "Moon",
+  monitor: "Monitor",
 };
 
 type NoteCollectionRowProps = {

--- a/apps/desktop/src/components/theme-toggle.tsx
+++ b/apps/desktop/src/components/theme-toggle.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from "react";
+import { SunIcon, MoonIcon, MonitorIcon } from "./icons";
+import type { ThemeMode } from "@/core/workspace";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
+
+type ThemeToggleProps = {
+  themeMode: ThemeMode;
+  onChangeTheme: (mode: ThemeMode) => void;
+};
+
+export function ThemeToggle({ themeMode, onChangeTheme }: ThemeToggleProps) {
+  const handleToggle = useCallback(() => {
+    if (themeMode === "light") {
+      onChangeTheme("dark");
+    } else if (themeMode === "dark") {
+      onChangeTheme("system");
+    } else {
+      onChangeTheme("light");
+    }
+  }, [themeMode, onChangeTheme]);
+
+  const { Icon, label } = useMemo(() => {
+    switch (themeMode) {
+      case "light":
+        return { Icon: SunIcon, label: "Light" };
+      case "dark":
+        return { Icon: MoonIcon, label: "Dark" };
+      case "system":
+        return { Icon: MonitorIcon, label: "System" };
+      default:
+        return { Icon: MonitorIcon, label: "System" };
+    }
+  }, [themeMode]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleToggle}
+          className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-95"
+          aria-label={`Change theme (currently ${label})`}
+        >
+          <Icon size={14} strokeWidth={1.5} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {label} Theme
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/desktop/src/components/tiptap-extension/wiki-link.ts
+++ b/apps/desktop/src/components/tiptap-extension/wiki-link.ts
@@ -1,0 +1,68 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+const WIKI_LINK_PATTERN = /!?\[\[([^\]\n]+)\]\]/g;
+
+function parseWikiLink(rawTarget: string) {
+  const [target, alias] = rawTarget.split("|").map((part) => part.trim());
+  if (!target) {
+    return null;
+  }
+
+  return {
+    href: `[[${target}]]`,
+    label: alias || target,
+    target,
+  };
+}
+
+function buildWikiLinkDecorations(doc: Parameters<DecorationSet["map"]>[1]) {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, position) => {
+    if (!node.isText || !node.text) {
+      return;
+    }
+
+    WIKI_LINK_PATTERN.lastIndex = 0;
+    for (const match of node.text.matchAll(WIKI_LINK_PATTERN)) {
+      const rawTarget = match[1] ?? "";
+      const parsed = parseWikiLink(rawTarget);
+      if (!parsed || match.index === undefined) {
+        continue;
+      }
+
+      const from = position + match.index;
+      const to = from + match[0].length;
+      decorations.push(
+        Decoration.inline(from, to, {
+          "aria-label": `Open ${parsed.label}`,
+          class: "wiki-link",
+          "data-wiki-link": parsed.href,
+          role: "link",
+          title: parsed.label,
+        }),
+      );
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const WikiLink = Extension.create({
+  name: "wikiLink",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("wikiLink"),
+        props: {
+          decorations(state) {
+            return buildWikiLinkDecorations(state.doc);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/apps/desktop/src/components/tiptap-extension/wiki-link.ts
+++ b/apps/desktop/src/components/tiptap-extension/wiki-link.ts
@@ -6,14 +6,14 @@ const WIKI_LINK_PATTERN = /!?\[\[([^\]\n]+)\]\]/g;
 
 function parseWikiLink(rawTarget: string) {
   const [target, alias] = rawTarget.split("|").map((part) => part.trim());
-  if (!target) {
+  if (!rawTarget.trim()) {
     return null;
   }
 
   return {
-    href: `[[${target}]]`,
-    label: alias || target,
-    target,
+    href: `[[${rawTarget}]]`,
+    label: alias || target || rawTarget,
+    target: rawTarget,
   };
 }
 

--- a/apps/desktop/src/components/wiki-suggest-list.tsx
+++ b/apps/desktop/src/components/wiki-suggest-list.tsx
@@ -1,0 +1,144 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { WikiSuggestItem, WikiSuggestListHandle, WikiSuggestListProps } from "../types/wiki-suggest";
+import {
+  SparklesIcon,
+  IdeaIcon,
+  BookIcon,
+  BriefcaseIcon,
+  CalendarIcon,
+  DiscountTagIcon,
+  ArchiveIcon,
+  HomeIcon,
+  GlobeIcon,
+  LayersIcon,
+  NotebookIcon,
+  HonourStarIcon,
+  LeafIcon,
+  CameraIcon,
+  RocketIcon,
+  SunIcon,
+  MoonIcon,
+  MonitorIcon,
+  FileIcon,
+} from "./icons";
+
+const ICONS_MAP: Record<string, React.ComponentType<any>> = {
+  spark: SparklesIcon,
+  idea: IdeaIcon,
+  book: BookIcon,
+  work: BriefcaseIcon,
+  calendar: CalendarIcon,
+  tag: DiscountTagIcon,
+  archive: ArchiveIcon,
+  home: HomeIcon,
+  globe: GlobeIcon,
+  layers: LayersIcon,
+  notebook: NotebookIcon,
+  star: HonourStarIcon,
+  leaf: LeafIcon,
+  camera: CameraIcon,
+  rocket: RocketIcon,
+  sun: SunIcon,
+  moon: MoonIcon,
+  monitor: MonitorIcon,
+};
+
+function LocalNoteIcon({ iconKey }: { iconKey?: string | null }) {
+  const IconComponent = iconKey ? ICONS_MAP[iconKey] : null;
+  if (IconComponent) {
+    return <IconComponent size={14} className="text-primary shrink-0" />;
+  }
+  return <FileIcon size={14} className="text-muted-foreground/50 shrink-0" />;
+}
+
+export const WikiSuggestList = forwardRef<WikiSuggestListHandle, WikiSuggestListProps>(
+  ({ items, onSelect }, ref) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const prevItemsLengthRef = useRef(items.length);
+    const selectedRef = useRef<HTMLButtonElement | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      if (items.length !== prevItemsLengthRef.current) {
+        prevItemsLengthRef.current = items.length;
+        setSelectedIndex(0);
+      }
+    }, [items.length]);
+
+    useEffect(() => {
+      selectedRef.current?.scrollIntoView({ block: "nearest" });
+    }, [selectedIndex]);
+
+    const handleSelectionChange = useCallback((index: number) => {
+      setSelectedIndex(index);
+    }, []);
+
+    const selectItem = useCallback(
+      (index: number) => {
+        const item = items[index];
+        if (item) onSelect(item);
+      },
+      [items, onSelect],
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: (event: KeyboardEvent) => {
+          if (event.key === "ArrowUp") {
+            if (items.length === 0) return false;
+            setSelectedIndex((i) => (i + items.length - 1) % items.length);
+            return true;
+          }
+          if (event.key === "ArrowDown") {
+            if (items.length === 0) return false;
+            setSelectedIndex((i) => (i + 1) % items.length);
+            return true;
+          }
+          if (event.key === "Enter" || event.key === "Tab") {
+            selectItem(selectedIndex);
+            return true;
+          }
+          return false;
+        },
+      }),
+      [items.length, selectedIndex, selectItem],
+    );
+
+    if (items.length === 0) {
+      return (
+        <div className="slash-panel" role="listbox" aria-label="Note suggestions">
+          <p className="slash-empty">No notes found</p>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={containerRef} className="slash-panel" role="listbox" aria-label="Note suggestions">
+        {items.map((item: WikiSuggestItem, index: number) => {
+          const isSelected = index === selectedIndex;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              ref={isSelected ? selectedRef : null}
+              className={`slash-row${isSelected ? " slash-row--selected" : ""}`}
+              onClick={() => selectItem(index)}
+              onMouseEnter={() => handleSelectionChange(index)}
+              style={{ gap: "10px" }}
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <LocalNoteIcon iconKey={item.icon} />
+                <span className="slash-row-label flex-1 truncate">{item.title}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+WikiSuggestList.displayName = "WikiSuggestList";

--- a/apps/desktop/src/core/note-collections.ts
+++ b/apps/desktop/src/core/note-collections.ts
@@ -48,6 +48,11 @@ export const NOTE_COLLECTION_ICON_KEYS: NoteCollectionIconKey[] = [
   "camera",
   "notebook",
   "star",
+  "idea",
+  "file",
+  "sun",
+  "moon",
+  "monitor",
 ];
 
 export type NoteCollectionItem = {

--- a/apps/desktop/src/core/shortcuts.ts
+++ b/apps/desktop/src/core/shortcuts.ts
@@ -23,7 +23,8 @@ export type ShortcutId =
   | "split-down"
   | "close-pane"
   | "focus-next-pane"
-  | "focus-previous-pane";
+  | "focus-previous-pane"
+  | "toggle-note-context";
 
 export type ShortcutDefinition = ShortcutSetting & {
   id: ShortcutId;
@@ -126,6 +127,11 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "save", label: "Save", keys: `${MODIFIER_TOKENS.cmdOrCtrl} S` },
   { id: "settings", label: "Settings", keys: `${MODIFIER_TOKENS.cmdOrCtrl} ,` },
   { id: "toggle-sidebar", label: "Toggle Sidebar", keys: `${MODIFIER_TOKENS.cmdOrCtrl} \\` },
+  {
+    id: "toggle-note-context",
+    label: "Toggle Note Context",
+    keys: `${MODIFIER_TOKENS.cmdOrCtrl} .`,
+  },
   {
     id: "navigate-back",
     label: "Navigate Back",

--- a/apps/desktop/src/core/slash-command.ts
+++ b/apps/desktop/src/core/slash-command.ts
@@ -5,6 +5,7 @@ import Suggestion, {
   type SuggestionProps,
 } from "@tiptap/suggestion";
 import { ReactRenderer } from "@tiptap/react";
+import { PluginKey } from "@tiptap/pm/state";
 import tippy, { type Instance, type Props } from "tippy.js";
 import "tippy.js/dist/tippy.css";
 import { SlashCommandList } from "../components/slash-command-list";
@@ -14,6 +15,8 @@ import type {
   SlashCommandWithKey,
 } from "../types/slash-command";
 import { MODIFIER_TOKENS } from "./shortcuts";
+
+export const SlashCommandPluginKey = new PluginKey("slash-command");
 
 /**
  * Hardcoded TipTap/StarterKit default shortcuts displayed as hints in the
@@ -354,6 +357,12 @@ const slashSuggestion: Omit<SuggestionOptions<SlashCommandWithKey>, "editor"> = 
 export const SlashCommand = Extension.create({
   name: "slash-command",
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...slashSuggestion })];
+    return [
+      Suggestion({
+        pluginKey: SlashCommandPluginKey,
+        editor: this.editor,
+        ...slashSuggestion,
+      }),
+    ];
   },
 });

--- a/apps/desktop/src/core/wiki-suggest.ts
+++ b/apps/desktop/src/core/wiki-suggest.ts
@@ -8,6 +8,7 @@ import { ReactRenderer } from "@tiptap/react";
 import tippy, { type Instance, type Props } from "tippy.js";
 import "tippy.js/dist/tippy.css";
 import { PluginKey } from "@tiptap/pm/state";
+import { useWorkspaceStore } from "@/store/workspace";
 import { WikiSuggestList } from "../components/wiki-suggest-list";
 import type {
   WikiSuggestItem,
@@ -36,10 +37,7 @@ const runCommand = ({
 
 const getSuggestionItems = async ({ query }: { query: string }): Promise<WikiSuggestItem[]> => {
   try {
-    const glyph = window.glyph;
-    if (!glyph) return [];
-
-    const index = await glyph.getKnowledgeIndex();
+    const index = useWorkspaceStore.getState().knowledgeIndex;
     if (!index || !index.notes) return [];
 
     const items: WikiSuggestItem[] = index.notes.map((note) => ({

--- a/apps/desktop/src/core/wiki-suggest.ts
+++ b/apps/desktop/src/core/wiki-suggest.ts
@@ -1,0 +1,135 @@
+import { Extension } from "@tiptap/core";
+import Suggestion, {
+  type SuggestionKeyDownProps,
+  type SuggestionOptions,
+  type SuggestionProps,
+} from "@tiptap/suggestion";
+import { ReactRenderer } from "@tiptap/react";
+import tippy, { type Instance, type Props } from "tippy.js";
+import "tippy.js/dist/tippy.css";
+import { WikiSuggestList } from "../components/wiki-suggest-list";
+import type {
+  WikiSuggestItem,
+  WikiSuggestListHandle,
+} from "../types/wiki-suggest";
+
+const runCommand = ({
+  editor,
+  range,
+  props,
+}: {
+  editor: SuggestionProps<WikiSuggestItem>["editor"];
+  range: SuggestionProps<WikiSuggestItem>["range"];
+  props: WikiSuggestItem;
+}) => {
+  // Insert standard wikilink syntax, overwriting the typed trigger [[query
+  editor
+    .chain()
+    .focus()
+    .deleteRange(range)
+    .insertContent(`[[${props.title}]] `)
+    .run();
+};
+
+const getSuggestionItems = async ({ query }: { query: string }): Promise<WikiSuggestItem[]> => {
+  try {
+    const glyph = window.glyph;
+    if (!glyph) return [];
+
+    const index = await glyph.getKnowledgeIndex();
+    if (!index || !index.notes) return [];
+
+    const items: WikiSuggestItem[] = index.notes.map((note) => ({
+      id: note.path,
+      title: note.title,
+      path: note.path,
+      icon: (note.frontmatter?.icon as string) || null,
+    }));
+
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      // Limit initial list to a few items
+      return items.slice(0, 20);
+    }
+
+    return items
+      .filter((item) => item.title.toLowerCase().includes(normalizedQuery))
+      .slice(0, 20);
+  } catch (error) {
+    console.error("Failed to fetch wiki-link suggestions:", error);
+    return [];
+  }
+};
+
+const wikiSuggestion: Omit<SuggestionOptions<WikiSuggestItem>, "editor"> = {
+  char: "[[",
+  allowSpaces: true,
+  startOfLine: false,
+  allowedPrefixes: [" ", "\n", "\t"],
+  items: getSuggestionItems,
+  command: runCommand,
+  render: () => {
+    let component: ReactRenderer<WikiSuggestListHandle> | null = null;
+    let popup: Instance<Props> | null = null;
+
+    return {
+      onStart: (props: SuggestionProps<WikiSuggestItem>) => {
+        component = new ReactRenderer(WikiSuggestList, {
+          props: {
+            items: props.items,
+            onSelect: (item: WikiSuggestItem) => props.command(item),
+          },
+          editor: props.editor,
+        });
+
+        if (!props.clientRect) {
+          return;
+        }
+
+        popup = tippy(document.body, {
+          getReferenceClientRect: () => props.clientRect?.() ?? new DOMRect(),
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "bottom-start",
+          theme: "slash-menu", // Reuse same styling theme
+        });
+      },
+      onUpdate: (props: SuggestionProps<WikiSuggestItem>) => {
+        component?.updateProps({
+          items: props.items,
+          onSelect: (item: WikiSuggestItem) => props.command(item),
+        });
+
+        if (!props.clientRect) {
+          return;
+        }
+
+        popup?.setProps({
+          getReferenceClientRect: () => props.clientRect?.() ?? new DOMRect(),
+        });
+      },
+      onKeyDown: (props: SuggestionKeyDownProps) => {
+        if (props.event.key === "Escape") {
+          popup?.hide();
+          return true;
+        }
+
+        return component?.ref?.onKeyDown(props.event) ?? false;
+      },
+      onExit: () => {
+        popup?.destroy();
+        component?.destroy();
+      },
+    };
+  },
+};
+
+export const WikiLinkSuggest = Extension.create({
+  name: "wiki-link-suggest",
+  addProseMirrorPlugins() {
+    return [Suggestion({ editor: this.editor, ...wikiSuggestion })];
+  },
+});

--- a/apps/desktop/src/core/wiki-suggest.ts
+++ b/apps/desktop/src/core/wiki-suggest.ts
@@ -7,11 +7,14 @@ import Suggestion, {
 import { ReactRenderer } from "@tiptap/react";
 import tippy, { type Instance, type Props } from "tippy.js";
 import "tippy.js/dist/tippy.css";
+import { PluginKey } from "@tiptap/pm/state";
 import { WikiSuggestList } from "../components/wiki-suggest-list";
 import type {
   WikiSuggestItem,
   WikiSuggestListHandle,
 } from "../types/wiki-suggest";
+
+export const WikiLinkSuggestPluginKey = new PluginKey("wiki-link-suggest");
 
 const runCommand = ({
   editor,
@@ -130,6 +133,12 @@ const wikiSuggestion: Omit<SuggestionOptions<WikiSuggestItem>, "editor"> = {
 export const WikiLinkSuggest = Extension.create({
   name: "wiki-link-suggest",
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...wikiSuggestion })];
+    return [
+      Suggestion({
+        pluginKey: WikiLinkSuggestPluginKey,
+        editor: this.editor,
+        ...wikiSuggestion,
+      }),
+    ];
   },
 });

--- a/apps/desktop/src/core/workspace.ts
+++ b/apps/desktop/src/core/workspace.ts
@@ -106,7 +106,12 @@ export type NoteCollectionIconKey =
   | "home"
   | "camera"
   | "notebook"
-  | "star";
+  | "star"
+  | "idea"
+  | "file"
+  | "sun"
+  | "moon"
+  | "monitor";
 
 export type NoteFolderAppearance = {
   accent: NoteCollectionAccentKey;

--- a/apps/desktop/src/core/workspace.ts
+++ b/apps/desktop/src/core/workspace.ts
@@ -118,6 +118,7 @@ export type NoteFolderAppearanceMap = Record<string, Partial<NoteFolderAppearanc
 export type NoteBrowserEntry = {
   path: string;
   title: string;
+  icon: string | null;
   excerpt: string;
   modifiedAt: string | null;
   createdAt: string | null;

--- a/apps/desktop/src/core/workspace.ts
+++ b/apps/desktop/src/core/workspace.ts
@@ -125,6 +125,48 @@ export type NoteBrowserEntry = {
   wordCount: number;
 };
 
+export type NoteKnowledgeHeading = {
+  id: string;
+  level: number;
+  title: string;
+  line: number;
+};
+
+export type NoteKnowledgeTag = {
+  name: string;
+  line: number;
+};
+
+export type NoteKnowledgeLink = {
+  kind: "markdown" | "wiki";
+  target: string;
+  label: string;
+  resolvedPath: string | null;
+  line: number;
+};
+
+export type NoteKnowledgeDocument = {
+  path: string;
+  title: string;
+  excerpt: string;
+  frontmatter: Record<string, unknown>;
+  tags: NoteKnowledgeTag[];
+  headings: NoteKnowledgeHeading[];
+  links: NoteKnowledgeLink[];
+  backlinks: string[];
+  modifiedAt: string | null;
+  createdAt: string | null;
+  sizeBytes: number;
+  wordCount: number;
+};
+
+export type NoteKnowledgeIndexSnapshot = {
+  workspaceRoot: string | null;
+  notes: NoteKnowledgeDocument[];
+  tags: Array<{ name: string; count: number }>;
+  generatedAt: string;
+};
+
 export type ThemeMode = "light" | "dark" | "system";
 
 export type ShortcutSetting = {

--- a/apps/desktop/src/hooks/use-desktop-app-controller.ts
+++ b/apps/desktop/src/hooks/use-desktop-app-controller.ts
@@ -157,6 +157,7 @@ type UseDesktopAppControllerOptions = {
   sessionReady?: boolean;
   onRestoreSkill?: (path: string) => Promise<void>;
   onRestoreTasks?: () => void;
+  onToggleNoteContext?: () => void;
 };
 
 export const useDesktopAppController = (
@@ -168,6 +169,7 @@ export const useDesktopAppController = (
     sessionReady = true,
     onRestoreSkill,
     onRestoreTasks,
+    onToggleNoteContext,
   }: UseDesktopAppControllerOptions = {},
 ) => {
   const {
@@ -2201,6 +2203,7 @@ export const useDesktopAppController = (
     editorScale,
     navigateBack,
     navigateForward,
+    toggleNoteContext: () => onToggleNoteContext?.(),
   });
 
   // Boot sequence

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -36,6 +36,7 @@ type UseKeyboardShortcutsOptions = {
   editorScale: number;
   navigateBack: () => Promise<void>;
   navigateForward: () => Promise<void>;
+  toggleNoteContext: () => void;
 };
 
 export function useKeyboardShortcuts({
@@ -71,6 +72,7 @@ export function useKeyboardShortcuts({
   editorScale,
   navigateBack,
   navigateForward,
+  toggleNoteContext,
 }: UseKeyboardShortcutsOptions) {
   useEffect(() => {
     const onKeyDown = async (event: KeyboardEvent) => {
@@ -163,6 +165,7 @@ export function useKeyboardShortcuts({
 
       const globalShortcutIds = new Set([
         "toggle-sidebar",
+        "toggle-note-context",
         "command-palette",
         "find-in-note",
         "settings",
@@ -191,6 +194,9 @@ export function useKeyboardShortcuts({
         switch (globalShortcut.id) {
           case "toggle-sidebar":
             setIsSidebarCollapsed((prev) => !prev);
+            break;
+          case "toggle-note-context":
+            toggleNoteContext();
             break;
           case "command-palette":
             setIsPaletteOpen((value) => !value);
@@ -342,5 +348,6 @@ export function useKeyboardShortcuts({
     editorScale,
     navigateBack,
     navigateForward,
+    toggleNoteContext,
   ]);
 }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -25,6 +25,7 @@ type SessionState = {
   isSidebarCollapsed: boolean;
   isNotesExpanded: boolean;
   isSkillsExpanded: boolean;
+  isNoteContextOpen: boolean;
   selectedNoteCollectionPath: string | null;
   lastNotePathByCollection: Record<string, string>;
   noteOrderByCollection: Record<string, string[]>;
@@ -47,6 +48,7 @@ type SessionState = {
   setSidebarCollapsed: (value: boolean) => void;
   setNotesExpanded: (value: boolean) => void;
   setSkillsExpanded: (value: boolean) => void;
+  setNoteContextOpen: (value: boolean) => void;
   setSelectedNoteCollectionPath: (value: string | null) => void;
   setLastNotePathForCollection: (collectionPath: string, notePath: string) => void;
   getLastNotePathForCollection: (collectionPath: string | null | undefined) => string | null;
@@ -129,6 +131,7 @@ export const useSessionStore = create<SessionState>()(
       isSidebarCollapsed: false,
       isNotesExpanded: true,
       isSkillsExpanded: false,
+      isNoteContextOpen: false,
       selectedNoteCollectionPath: null,
       lastNotePathByCollection: {},
       noteOrderByCollection: {},
@@ -160,6 +163,9 @@ export const useSessionStore = create<SessionState>()(
       },
       setSkillsExpanded: (isSkillsExpanded) => {
         set({ isSkillsExpanded });
+      },
+      setNoteContextOpen: (isNoteContextOpen) => {
+        set({ isNoteContextOpen });
       },
       setSelectedNoteCollectionPath: (selectedNoteCollectionPath) => {
         set({
@@ -333,6 +339,7 @@ export const useSessionStore = create<SessionState>()(
         isSidebarCollapsed: state.isSidebarCollapsed,
         isNotesExpanded: state.isNotesExpanded,
         isSkillsExpanded: state.isSkillsExpanded,
+        isNoteContextOpen: state.isNoteContextOpen,
         selectedNoteCollectionPath: state.selectedNoteCollectionPath,
         lastNotePathByCollection: state.lastNotePathByCollection,
         noteOrderByCollection: state.noteOrderByCollection,

--- a/apps/desktop/src/store/workspace.ts
+++ b/apps/desktop/src/store/workspace.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 import { getBaseName, isPathInside, isSamePath, normalizePath } from "@/core/paths";
 
-import type { DirectoryNode, FileDocument, NoteTab, TabMovePosition } from "@/core/workspace";
+import type { DirectoryNode, FileDocument, NoteTab, TabMovePosition, NoteKnowledgeIndexSnapshot } from "@/core/workspace";
 
 export type NavigationEntry =
   | { kind: "note"; path: string }
@@ -105,6 +105,7 @@ type WorkspaceState = {
   isSaving: boolean;
   lastSavedAt: number | null;
   error: string | null;
+  knowledgeIndex: NoteKnowledgeIndexSnapshot | null;
   navigationHistory: NavigationEntry[];
   navigationIndex: number;
   setWorkspace: (payload: {
@@ -113,6 +114,7 @@ type WorkspaceState = {
     activeFile: FileDocument | null;
   }) => void;
   setTree: (tree: DirectoryNode[]) => void;
+  setKnowledgeIndex: (index: NoteKnowledgeIndexSnapshot | null) => void;
   setActiveFile: (file: FileDocument | null) => void;
   attachActiveFile: (file: FileDocument) => void;
   updateActiveFile: (file: FileDocument) => void;
@@ -153,6 +155,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   isSaving: false,
   lastSavedAt: null,
   error: null,
+  knowledgeIndex: null,
   navigationHistory: [],
   navigationIndex: -1,
   setWorkspace: ({ rootPath, tree, activeFile }) =>
@@ -192,6 +195,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       };
     }),
   setTree: (tree) => set({ tree }),
+  setKnowledgeIndex: (knowledgeIndex) => set({ knowledgeIndex }),
   setActiveFile: (activeFile) =>
     set((state) => {
       if (!activeFile) {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -336,13 +336,16 @@ body {
   background: var(--accent);
 }
 
-.tiptap-editor a {
+.tiptap-editor a,
+.tiptap-editor .wiki-link {
   color: var(--editor-link);
+  cursor: pointer;
   text-decoration-thickness: 1.5px;
   text-decoration-color: color-mix(in oklch, var(--editor-link) 46%, transparent);
 }
 
-.tiptap-editor a:hover {
+.tiptap-editor a:hover,
+.tiptap-editor .wiki-link:hover {
   color: color-mix(in oklch, var(--editor-link) 88%, var(--foreground) 12%);
 }
 

--- a/apps/desktop/src/types/settings-panel.ts
+++ b/apps/desktop/src/types/settings-panel.ts
@@ -1,4 +1,4 @@
-import type { AppInfo, AppSettings, ShortcutSetting, ThemeMode } from "@/core/workspace";
+import type { AppInfo, AppSettings, ShortcutSetting } from "@/core/workspace";
 
 export type SettingsPanelProps = {
   isOpen: boolean;
@@ -6,6 +6,5 @@ export type SettingsPanelProps = {
   appInfo: AppInfo | null;
   onClose: () => void;
   onChooseFolder: () => void;
-  onChangeMode: (mode: ThemeMode) => void;
   onChangeShortcuts: (shortcuts: ShortcutSetting[]) => void;
 };

--- a/apps/desktop/src/types/wiki-suggest.ts
+++ b/apps/desktop/src/types/wiki-suggest.ts
@@ -1,0 +1,15 @@
+export type WikiSuggestItem = {
+  id: string;
+  title: string;
+  path: string;
+  icon?: string | null;
+};
+
+export type WikiSuggestListProps = {
+  items: WikiSuggestItem[];
+  onSelect: (item: WikiSuggestItem) => void;
+};
+
+export type WikiSuggestListHandle = {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+};

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -7,6 +7,7 @@ import type {
   AppSettings,
   DialogKind,
   NoteBrowserEntry,
+  NoteKnowledgeIndexSnapshot,
   UpdateState,
   FileDocument,
   FileOpenResult,
@@ -70,6 +71,7 @@ declare global {
         folderName: string,
       ) => Promise<WorkspaceSnapshot["tree"] | null>;
       searchWorkspace: (query: string) => Promise<SearchResult[]>;
+      getKnowledgeIndex: () => Promise<NoteKnowledgeIndexSnapshot>;
       listTasks: () => Promise<TaskIndexSnapshot>;
       refreshTasks: () => Promise<TaskIndexSnapshot>;
       updateTask: (input: TaskUpdateInput) => Promise<TaskMutationResult>;


### PR DESCRIPTION
## Summary
- add main-process knowledge index extraction for notes, headings, tags, links, backlinks, and stats
- expose knowledge index through preload for future AI and graph surfaces
- add command palette heading jumps and frontmatter formatting
- add right note context sidebar with toolbar toggle, persisted open/close state, and resizable shell support
- refine context sidebar into compact editable metadata panel: searchable/createable type + status controls, tooltip icon picker, date/url fields, distinct tag chips, and Tolaria-style grouped note relationships
- simplify metadata UI: remove Add Property flow, use text-only status option colors, remove icon/tag trigger backgrounds, cap suggested tags to 5 high-signal terms
- expand note/folder icon picker to 20 icons and keep icon rendering consistent across folder menus, relationship pickers, and secondary note rows
- make relationship Add open note picker immediately, and make selected relationship notes clickable to open the linked note
- make focus mode hide context UI and auto-exit when primary sidebar or context panel is opened

## Verification
- pnpm typecheck:desktop
- pnpm --filter @glyph/desktop lint (passes; existing warnings remain in editor-toolbar/editor-pane)
- pnpm test:e2e:desktop (40 passed)

## Notes
- Type defaults to None with no seeded Essay/Habit/etc options; user-created types still work via search/create.
- URL values are clickable, relationship note chips open notes when their path is known, and metadata edits write to YAML frontmatter so notes stay portable markdown.